### PR TITLE
Print stacktrace on errors.

### DIFF
--- a/bin/dredd
+++ b/bin/dredd
@@ -35,7 +35,7 @@ cli.main( function (args, options) {
 
   dredd.run(function(error, reporter){
     if(error){
-      cli.fatal(error)
+      cli.fatal(error.stack);
     }
     if(reporter['stats']['failures'] > 0){
       process.exit(1);


### PR DESCRIPTION
Dredd/Gavel are still very young tools, and so when fatal errors occur, this will be helpful for issue reports.
