### PR TITLE
Do not lowercase header values.

### DIFF
--- a/src/flatten-headers.coffee
+++ b/src/flatten-headers.coffee
@@ -2,7 +2,7 @@ flattenHeaders = (blueprintHeaders) ->
   flatHeaders = {}
   # flatten headers object from blueprint structure
   for name, values of blueprintHeaders
-    flatHeaders[name] = values['value'].toLowerCase()
+    flatHeaders[name] = values['value']
   return flatHeaders
 
 module.exports = flattenHeaders


### PR DESCRIPTION
Important information (e.g. case sensitive authentication data) is lost.

RFC2616 specifies that while field names are case insensitive, field values are not.

The initial test suite was not green at the time of my fork. This change did not change the test suite status and this behavior appears untested.
