### PR TITLE
Transactions sorting by the original order too

### DIFF
--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -98,6 +98,9 @@ class Dredd
   # By sorting the transactions by their methods, it is possible to ensure that
   # objects are created before they are read, updated, or deleted.
   sortTransactions = (arr) ->
+    arr.map (a, i) ->
+      a['_index'] = i
+
     arr.sort (a, b) ->
       sortedMethods = [
         "CONNECT", "OPTIONS",
@@ -106,10 +109,16 @@ class Dredd
       ]
       methodIndexA = sortedMethods.indexOf(a['request']['method'])
       methodIndexB = sortedMethods.indexOf(b['request']['method'])
+
       return switch
         when methodIndexA < methodIndexB then -1
         when methodIndexA > methodIndexB then 1
-        else 0
+        when methodIndexA == methodIndexB
+          a['_index'] - b['_index']
+
+    arr.map (a) ->
+      delete a['_index']
+
     arr
 
 module.exports = Dredd


### PR DESCRIPTION
This simple change is sorting the transactions by the order they were written in the file. So if you have sth like:

```
## Retreive all Machines [GET]
+ Response 200 (application/json)

## Delete Machine [DELETE]
+ Response 204
....
## Retreive all Posts [GET]
+ Response 200 (application/json)

## Delete Post [DELETE]
+ Response 204
```

Transactions will run in the order: GET all Machines, GET all Posts, DELETE Machine, DELETE Post.
