### PR TITLE
Dredd exited without an interesting error message

### DIFF
--- a/bin/dredd
+++ b/bin/dredd
@@ -56,6 +56,7 @@ process.on( 'SIGINT', function() {
 
 dredd.run(function(error, stats){
   if (error) {
+   console.error(error.message);
    console.error(error.stack);
    process.exit(1);
   }


### PR DESCRIPTION
because we were using '\r' in our blueprint file. This now prints: 

```
info: Beginning Dredd testing...
the use of carriage return(s) '\r' in source data isn't currently supported, please contact makers
undefined
```

the `undefined` is because this error doesn't have a stack.
