### PR TITLE
Fixes sequencing bug in junit reporter

### DIFF
--- a/src/reporters/x-unit-reporter.coffee
+++ b/src/reporters/x-unit-reporter.coffee
@@ -36,7 +36,6 @@ class XUnitReporter extends EventEmitter
           }, false)
 
     emitter.on 'end', (callback) =>
-      appendLine @path, '</testsuite>'
       updateSuiteStats @path, @stats, callback
 
     emitter.on 'test pass', (test) =>
@@ -86,7 +85,7 @@ class XUnitReporter extends EventEmitter
             , time: stats.duration / 1000
           }, false
           xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>'
-          fs.writeFile path, xmlHeader + '\n' + newStats + '\n' + restOfFile, (err) ->
+          fs.writeFile path, xmlHeader + '\n' + newStats + '\n' + restOfFile + '</testsuite>', (err) ->
             if err
               logger.error err
             callback()

--- a/test/unit/reporters/x-unit-reporter-test.coffee
+++ b/test/unit/reporters/x-unit-reporter-test.coffee
@@ -72,32 +72,27 @@ describe 'XUnitReporter', () ->
 
     beforeEach () ->
       sinon.stub fsStub, 'appendFile'
+      sinon.stub fsStub, 'readFile'
+      fsStub.readFile.yields null, 'da\nta'
+      sinon.stub fsStub, 'writeFile'
+      fsStub.writeFile.yields null
 
     afterEach () ->
       fsStub.appendFile.restore()
+      fsStub.readFile.restore()
+      fsStub.writeFile.restore()
 
     describe 'when there is one test', () ->
 
-      it 'should write tests to file', (done) ->
+      it 'should write tests to file', () ->
         emitter = new EventEmitter()
         xUnitReporter = new XUnitReporter(emitter, {}, {})
         xUnitReporter.tests = [ test ]
         xUnitReporter.stats.tests = 1
-        emitter.emit 'end', () ->
-          assert.ok fsStub.appendFile.called
-          done()
+        emitter.emit 'test pass', test
+        assert.ok fsStub.appendFile.called
 
       describe 'when the file writes successfully', () ->
-
-        before () ->
-          sinon.stub fsStub, 'readFile'
-          fsStub.readFile.yields null, 'da\nta'
-          sinon.stub fsStub, 'writeFile'
-          fsStub.writeFile.yields null
-
-        after () ->
-          fsStub.readFile.restore()
-          fsStub.writeFile.restore()
 
         it 'should read the file and update the stats', (done) ->
           emitter = new EventEmitter()
@@ -115,7 +110,7 @@ describe 'XUnitReporter', () ->
         emitter = new EventEmitter()
         xUnitReporter = new XUnitReporter(emitter, {}, {})
         emitter.emit 'end', () ->
-          assert.ok fsStub.appendFile.called
+          assert.ok fsStub.writeFile.called
           done()
 
   describe 'when test passes', () ->


### PR DESCRIPTION
The xUnit reporter had a bug in which dredd could exit before the final `</testsuite>` was written (but it's very system dependent, only ever saw this on linux).

This PR fixes that bug.
