### PR TITLE
Better file handling for reporters (fixes #48 and #57)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "API Blueprint testing tool",
   "main": "lib/dredd.js",
   "bin": {
@@ -27,7 +27,8 @@
     "advisable": "~0.2.0",
     "proxyquire": "~0.5.1",
     "coffee-script": "1.6.3",
-    "glob": "~3.2.8"
+    "glob": "~3.2.8",
+    "file": "~0.2.2"
   },
   "devDependencies": {
     "coffee-errors": "~0.8.4",

--- a/src/reporters/html-reporter.coffee
+++ b/src/reporters/html-reporter.coffee
@@ -2,6 +2,7 @@
 fs = require 'fs'
 
 marked = require 'marked'
+file = require 'file'
 
 logger = require './../logger'
 prettifyResponse = require './../prettify-response'
@@ -29,7 +30,7 @@ class HtmlReporter extends EventEmitter
     @configureEmitter emitter
 
   sanitizedPath: (path) =>
-    filePath = if path? then process.cwd() + "/" + path else process.cwd() + "/report.html"
+    filePath = if path? then file.path.abspath(path) else file.path.abspath("./report.html")
     if fs.existsSync(filePath)
       logger.info "File exists at #{filePath}, will be overwritten..."
     filePath

--- a/src/reporters/markdown-reporter.coffee
+++ b/src/reporters/markdown-reporter.coffee
@@ -1,6 +1,8 @@
 {EventEmitter} = require 'events'
 fs = require 'fs'
 
+file = require 'file'
+
 logger = require './../logger'
 prettifyResponse = require './../prettify-response'
 
@@ -17,7 +19,7 @@ class MarkdownReporter extends EventEmitter
     @configureEmitter emitter
 
   sanitizedPath: (path) =>
-    filePath = if path? then process.cwd() + "/" + path else process.cwd() + "/report.md"
+    filePath = if path? then file.path.abspath(path) else file.path.abspath("./report.md")
     if fs.existsSync(filePath)
       logger.info "File exists at #{filePath}, will be overwritten..."
     filePath

--- a/src/reporters/x-unit-reporter.coffee
+++ b/src/reporters/x-unit-reporter.coffee
@@ -2,6 +2,7 @@
 fs = require 'fs'
 
 htmlencode = require 'htmlencode'
+file = require 'file'
 
 logger = require './../logger'
 prettifyResponse = require './../prettify-response'
@@ -17,7 +18,7 @@ class XUnitReporter extends EventEmitter
     @configureEmitter emitter
 
   sanitizedPath: (path) =>
-    filePath = if path? then process.cwd() + "/" +  path else process.cwd() + "/report.xml"
+    filePath = if path? then file.path.abspath(path) else file.path.abspath("./report.xml")
     if fs.existsSync(filePath)
       logger.info "File exists at #{filePath}, will be overwritten..."
     filePath


### PR DESCRIPTION
Two main changes:
- Instead of deleting an existing report file, it's simply overwritten (see #57)
- The [file](https://www.npmjs.org/package/file) module is used to resolve paths, supporting the use of home (~) in reporter paths. (see #48)

**Something weird happened with this and it's picking up some previous commits. Will Fix**
