### PR TITLE
Added '-L' parameter to curl command

### DIFF
--- a/provisioning.sh
+++ b/provisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt-get install -y mc curl git-core build-essential
-sudo su vagrant -c 'curl https://raw.github.com/creationix/nvm/master/install.sh | sh'
+sudo su vagrant -c 'curl -L https://raw.github.com/creationix/nvm/master/install.sh | sh'
 sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh; nvm install v0.10.21'
 sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm use v0.10.21'
 sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm alias default v0.10.21'


### PR DESCRIPTION
I was having some `nvm` issues with `vagrant up`-ing the box, and narrowed it down to curl not following a few redirects. Adding the `-L` flag has curl follow them, and `vagrant provision` finishes successfully. Not sure if anyone else was having the problem, but this seems to have fixed it up for me. 
