### PR TITLE
Reintroduces "silent" flag

### DIFF
--- a/src/options.coffee
+++ b/src/options.coffee
@@ -63,6 +63,11 @@ options =
     alias: "t"
     description: "Determines whether console output should include timestamps.\n"
     default: false
+  
+  silent:
+    alias: "q"
+    description: "Silences commandline output.\n"
+    default: false
 
   help:
     description: "Show usage information.\n"


### PR DESCRIPTION
This option is used inside `src/configure-reporters.coffee` to silence commandline output, however, is not present in Dredd's `options`.  Re-adding it so I can wrap Dredd in a nagiosplugin :).
