### PR TITLE
Fixes #98 header parsing issue

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -69,8 +69,10 @@ class TransactionRunner
 
     if configuration.options.header.length > 0
       for header in configuration.options.header
-        splitHeader = header.split(':')
-        flatHeaders[splitHeader[0]] = splitHeader[1]
+        splitIndex = header.indexOf(':')
+        headerKey = header.substring(0, splitIndex)
+        headerValue = header.substring(splitIndex + 1)
+        flatHeaders[headerKey] = headerValue
 
     request['headers'] = flatHeaders
 

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -111,6 +111,19 @@ describe 'TransactionRunner', ()->
           assert.equal configuredTransaction.request.headers['Content-Length'], 44
           done()
 
+    describe 'when an additional header has a colon', ()->
+      beforeEach () ->
+        configuration.options.header = ["MyCustomDate:Wed, 10 Sep 2014 12:34:26 GMT"]
+        runner = new Runner(configuration)
+
+      afterEach () ->
+        configuration.options.header = []
+
+      it 'should include the entire value in the header', (done)->
+        runner.configureTransaction transaction, (err, configuredTransaction) ->
+          assert.equal configuredTransaction.request.headers['MyCustomDate'], 'Wed, 10 Sep 2014 12:34:26 GMT'
+          done()
+
     describe 'when configuring a transaction', () ->
 
       it 'should callback with a properly configured transaction', (done) ->


### PR DESCRIPTION
You can pass in headers with spaces by quoting them:

`dredd ./test/fixtures/single-get.apib http://machines.apiary.io -h "MyCustomDate:Wed, 10 Sep 2014 12:34:26 GMT"`

and it also keeps additional colons in the value of the header.
