### PR TITLE
Computing content-length in executeTransasction, fixing #124

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "winston": "~0.8.0"
   },
   "devDependencies": {
+    "body-parser": "^1.10.1",
     "chai": "~1.9.0",
     "codo": "2.0.9",
     "coffee-coverage": "~0.4.2",

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -112,7 +112,7 @@ class TransactionRunner
       caseInsensitiveMap[key.toLowerCase()] = key
 
     if not caseInsensitiveMap['content-length'] and transaction.request['body'] != ''
-      transaction.request.headers['Content-Length'] = transaction.request['body'].length
+      transaction.request.headers['Content-Length'] = Buffer.byteLength(transaction.request['body'], 'utf8')
 
     requestOptions =
       host: transaction.host

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -59,14 +59,6 @@ class TransactionRunner
         packageConfig['version'] + \
         " ("+ system + ")"
 
-    # Add length of body if no Content-Length present
-    caseInsensitiveMap = {}
-    for key, value of flatHeaders
-      caseInsensitiveMap[key.toLowerCase()] = key
-
-    if not caseInsensitiveMap['content-length'] and request['body'] != ''
-      flatHeaders['Content-Length'] = request['body'].length
-
     if configuration.options.header.length > 0
       for header in configuration.options.header
         splitIndex = header.indexOf(':')
@@ -111,6 +103,16 @@ class TransactionRunner
 
   executeTransaction: (transaction, callback) =>
     configuration = @configuration
+
+    # Add length of body if no Content-Length present
+    # Doing here instead of in configureTransaction, because request body can be edited in before hook
+
+    caseInsensitiveMap = {}
+    for key, value of transaction.request.headers
+      caseInsensitiveMap[key.toLowerCase()] = key
+
+    if not caseInsensitiveMap['content-length'] and transaction.request['body'] != ''
+      transaction.request.headers['Content-Length'] = transaction.request['body'].length
 
     requestOptions =
       host: transaction.host

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -92,25 +92,6 @@ describe 'TransactionRunner', ()->
           assert.ok configuredTransaction.request.headers['User-Agent']
           done()
 
-    describe 'when no Content-Length is present', () ->
-
-      it 'should add a Content-Length header', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.ok configuredTransaction.request.headers['Content-Length']
-          done()
-
-    describe 'when Content-Length header is present', () ->
-
-      beforeEach () ->
-        transaction.headers =
-          "Content-Length":
-              value: 44
-
-      it 'should not add a Content-Length header', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.equal configuredTransaction.request.headers['Content-Length'], 44
-          done()
-
     describe 'when an additional header has a colon', ()->
       beforeEach () ->
         configuration.options.header = ["MyCustomDate:Wed, 10 Sep 2014 12:34:26 GMT"]
@@ -163,6 +144,42 @@ describe 'TransactionRunner', ()->
           exampleName: 'Bogus example name'
         fullPath: '/machines'
         protocol: 'http:'
+
+    describe 'when no Content-Length is present', () ->
+
+      beforeEach () ->
+        delete transaction.request.headers["Content-Length"]
+        server = nock('http://localhost:3000').
+          post('/machines', {"type":"bulldozer","name":"willy"}).
+          reply transaction['expected']['status'],
+            transaction['expected']['body'],
+            {'Content-Type': 'application/json'}
+
+      afterEach () ->
+        nock.cleanAll()
+
+      it 'should add a Content-Length header', (done) ->
+        runner.executeTransaction transaction, () ->
+          assert.ok transaction.request.headers['Content-Length']
+          done()
+
+    describe 'when Content-Length header is present', () ->
+
+      beforeEach () ->
+        transaction.request.headers["Content-Length"] = 44
+        server = nock('http://localhost:3000').
+          post('/machines', {"type":"bulldozer","name":"willy"}).
+          reply transaction['expected']['status'],
+            transaction['expected']['body'],
+            {'Content-Type': 'application/json'}
+
+      afterEach () ->
+        nock.cleanAll()
+
+      it 'should not add a Content-Length header', (done) ->
+        runner.executeTransaction transaction, () ->
+          assert.equal transaction.request.headers['Content-Length'], 44
+          done()
 
 
     describe 'when printing the names', () ->


### PR DESCRIPTION
Related to #124, computing content-length in executeTransaction not in configureTransaction, because transaction body can be modified in some before hook and content-length sensitive backends can hang forever. 