### PR TITLE
Transaction runner fills all properties for test(step)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "body-parser": "^1.10.2",
     "chai": "^1.10.0",
+    "clone": "",
     "codo": "2.0.9",
     "coffee-coverage": "~0.4.4",
     "coffee-errors": "~0.8.6",


### PR DESCRIPTION
- fill all keys when `transaction` is executed
- fill `results` with results from Gavel.validate