### PR TITLE
Passing custom parameters to Reporters via JS API, logic from bin script to CoffeeScript

### DIFF
--- a/bin/dredd
+++ b/bin/dredd
@@ -1,87 +1,12 @@
 #!/usr/bin/env node
-var optimist = require('optimist');
-var parsePackageJson = require('../lib/parse-package-json');
-var path = require('path');
-var Dredd = require('../lib/dredd');
+var DreddCommand = require('../lib/command');
 
-var version = parsePackageJson(path.join(__dirname, '../package.json'));
-
-var argv = optimist
-    .usage("Usage: \n  dredd <path or URL to blueprint> <api_endpoint> [OPTIONS]" +
-    "\n\nExample: \n  " + "dredd ./apiary.md http://localhost:3000 --dry-run")
-    .options(Dredd.options)
-    .wrap(80)
-    .argv;
-
-var argError = false;
-
-if (argv.help === true) {
-  optimist.showHelp(fn=console.error);
-  process.exit(0);
-}
-
-if (argv.version === true) {
-  console.log(version);
-  process.exit(0);
-}
-
-if (argv._[0] === undefined) {
-  console.error("Error: Must specify path to blueprint file.");
-  argError = true;
-}
-if (argv._[1] === undefined) {
-  console.error("Error: Must specify api endpoint.");
-  argError = true;
-}
-
-if (argError) {
-  console.error("\n");
-  optimist.showHelp(fn=console.error);
-  process.exit(1);
-}
-
-// transform path and p argument to array if it's not
-if(!Array.isArray(argv['path'])){
-  argv['path'] = argv['p'] = [argv['path']];
-}
-
-// some shells are automatically expanding globs and concating result as arguments
-// so I'm taking last argument as API endpoint server URL and removing it forom optimist's args
-var server = argv._[argv._.length - 1];
-argv._.splice(argv._.length -1, 1);
-
-// and rest of arguments concating to 'path' and 'p' opts, duplicates are filtered out later
-argv['p'] = argv['path'] = argv['path'].concat(argv._)
-
-configuration = {
-  'server': server,
-  'options': argv
-};
-
-configuration.options.path.push(argv._[0]);
-
-dredd = new Dredd(configuration);
-
-process.on( 'SIGINT', function() {
-  console.log( "\nShutting down from SIGINT (Ctrl-C)" );
-  dredd.transactionsComplete(function() {
-    process.exit(0);
-  });
+var dreddCli = new DreddCommand({
+  custom: {
+    cwd: process.cwd(),
+    argv: process.argv.slice(2)
+  },
+  exit: process.exit
 });
 
-dredd.run(function(error, stats){
-  if (error) {
-    if (error.message) {
-      console.error(error.message);
-    }
-    if (error.stack) {
-      console.error(error.stack);
-    }
-    process.exit(1);
-  }
-  if (stats.failures + stats.errors > 0) {
-    process.exit(1);
-  } else {
-    process.exit(0);
-  }
-});
+dreddCli.warmUp().takeoff();

--- a/scripts/cov
+++ b/scripts/cov
@@ -13,6 +13,6 @@ echo "Using Mocha reporter: $REPORTER" 1>&2
 $COV --exclude node_modules,.git,test --path relative . ./src-cov 1>&2
 cp -r ./test ./src-cov/test
 cp ./package.json ./src-cov
-find ./src-cov/test/unit | grep "\-test" | xargs $MOCHA  --reporter $REPORTER --compilers 'coffee:coffee-script/register'
+find ./src-cov/test/ | grep "\-test" | xargs $MOCHA  --reporter $REPORTER --compilers 'coffee:coffee-script/register'
 
 rm -rf ./src-cov

--- a/src/add-hooks.coffee
+++ b/src/add-hooks.coffee
@@ -3,12 +3,10 @@ path = require 'path'
 require 'coffee-script/register'
 proxyquire = require('proxyquire').noCallThru()
 glob = require 'glob'
-async = require 'async'
-
 hooks = require './hooks'
 logger = require './logger'
 
-addHooks = (runner, transactions, emitter) ->
+addHooks = (runner, transactions, emitter, customConfig) ->
 
   for transaction in transactions
     hooks.transactions[transaction.name] = transaction
@@ -22,7 +20,7 @@ addHooks = (runner, transactions, emitter) ->
 
     try
       for file in files
-        proxyquire path.resolve(process.cwd(), file), {
+        proxyquire path.resolve((customConfig?.cwd or process.cwd()), file), {
           'hooks': hooks
         }
     catch error

--- a/src/apply-configuration.coffee
+++ b/src/apply-configuration.coffee
@@ -1,4 +1,5 @@
 {EventEmitter} = require 'events'
+clone = require 'clone'
 
 logger = require './logger'
 
@@ -18,6 +19,10 @@ applyConfiguration = (config) ->
     blueprintPath: null
     server: null
     emitter: new EventEmitter
+    custom: { # used for custom settings of various APIs or reporters
+      # Keep commented-out, so these values are actually set by DreddCommand
+      # cwd: process.cwd()
+    }
     options:
       'dry-run': false
       silent: false
@@ -37,9 +42,15 @@ applyConfiguration = (config) ->
       names: false
       hookfiles: null
 
-  #normalize options and config
+  # normalize options and config
   for own key, value of config
-    configuration[key] = value
+    # copy anything except "custom" hash
+    if key isnt 'custom'
+      configuration[key] = value
+    else
+      configuration['custom'] ?= {}
+      for own customKey, customVal of config['custom'] or {}
+        configuration['custom'][customKey] = clone customVal, false
 
   #coerce single/multiple options into an array
   configuration.options.reporter = coerceToArray(configuration.options.reporter)

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -1,0 +1,155 @@
+path = require 'path'
+optimist = require 'optimist'
+console = require 'console'
+
+parsePackageJson = require './parse-package-json'
+Dredd = require './dredd'
+
+version = parsePackageJson path.join(__dirname, '../package.json')
+
+class DreddCommand
+  constructor: (options = {}, @cb) ->
+    # support to call both 'new DreddCommand()' and/or 'DreddCommand()'
+    # without the "new" keyword
+    if not (@ instanceof DreddCommand)
+      return new DreddCommand(options, @cb)
+
+    {@exit, @custom} = options
+
+    @custom ?= {}
+
+    if not @custom.cwd or typeof @custom.cwd isnt 'string'
+      @custom.cwd = process.cwd()
+
+    if not @custom.argv or not Array.isArray @custom.argv
+      @custom.argv = []
+
+    @finished = false
+
+  warmUp: ->
+    @finished = false
+
+    @optimist = optimist(@custom['argv'], @custom['cwd'])
+
+    @optimist.usage(
+      """
+      Usage:
+        dredd <path or URL to blueprint> <api_endpoint> [OPTIONS]
+
+      Example:
+        dredd ./apiary.md http://localhost:3000 --dry-run
+      """
+    )
+    .options(Dredd.options)
+    .wrap(80)
+
+    @argv = @optimist.argv
+
+    argError = false
+
+    if not @cb
+      @exit and (@exit is process.exit) and @sigIntEventAdd = true
+      @_processExit = @exit or process.exit
+    else
+      @_processExit = ((code) ->
+        if @finished then return
+        @finished = true
+        if @sigIntEventAdded
+          process.removeEventListener 'SIGINT', @commandSigInt
+        @cb code
+        return @
+      ).bind @
+
+    if @argv.help is true
+      @optimist.showHelp(console.error)
+      return @_processExit(0)
+
+    if @argv.version is true
+      console.log version
+      return @_processExit(0)
+
+    if not @argv._[0]?
+      console.error("\nError: Must specify path to blueprint file.")
+      argError = true
+
+    if not @argv._[1]?
+      console.error("\nError: Must specify api endpoint.")
+      argError = true
+
+    if argError
+      console.error("\n")
+      @optimist.showHelp(console.error)
+      return @_processExit(1)
+
+    # transform path and p argument to array if it's not
+    if !Array.isArray(@argv['path'])
+      @argv['path'] = @argv['p'] = [@argv['path']]
+
+    configurationForDredd = @initConfig()
+    @dreddInstance = @initDredd configurationForDredd
+    return @
+
+  lastArgvIsApiEndpoint: ->
+    # some shells are automatically expanding globs and concating result as arguments
+    # so I'm taking last argument as API endpoint server URL and removing it forom optimist's args
+    @server = @argv._[@argv._.length - 1]
+    @argv._.splice(@argv._.length - 1, 1)
+    return @
+
+  takeRestOfParamsAsPath: ->
+    # and rest of arguments concating to 'path' and 'p' opts, duplicates are filtered out later
+    @argv['p'] = @argv['path'] = @argv['path'].concat(@argv._)
+    return @
+
+  initConfig: ->
+    @
+    .lastArgvIsApiEndpoint()
+    .takeRestOfParamsAsPath()
+
+    configuration =
+      'server': @server
+      'options': @argv
+
+    # push first argument (without some known configuration --key) into paths
+    configuration.options.path ?= []
+    configuration.options.path.push @argv._[0]
+
+    configuration.custom = @custom
+
+    return configuration
+
+  initDredd: (configuration) ->
+    dredd = new Dredd configuration
+    return dredd
+
+  commandSigInt: ->
+    console.log "\nShutting down from SIGINT (Ctrl-C)"
+    @dreddInstance.transactionsComplete => @_processExit(0)
+
+  takeoff: ->
+    if @finished then return
+
+    @runDredd @dreddInstance
+
+  runDredd: (dreddInstance) ->
+    if @sigIntEventAdd
+      # handle SIGINT from user
+      @sigIntEventAdded = !@sigIntEventAdd = false
+      process.on 'SIGINT', @commandSigInt
+
+    dreddInstance.run (error, stats) =>
+      if error
+        if error.message
+          console.error error.message
+        if error.stack
+          console.error error.stack
+        return @_processExit(1)
+      if (stats.failures + stats.errors) > 0
+        @_processExit(1)
+      else
+        @_processExit(0)
+      return
+
+    return @
+
+exports = module.exports = DreddCommand

--- a/src/configure-reporters.coffee
+++ b/src/configure-reporters.coffee
@@ -44,7 +44,7 @@ configureReporters = (config, stats, tests) ->
       when 'markdown'
         mdReporter = new MarkdownReporter(emitter, stats, tests, path, config.options.details)
       when 'apiary'
-        apiaryReporter = new ApiaryReporter(emitter, stats, tests)
+        apiaryReporter = new ApiaryReporter(emitter, stats, tests, config)
       # else
       #   Cannot happen, due to 'intersection' usage
       #   logger.warn "Invalid reporter #{reporter} selected, ignoring."
@@ -60,8 +60,6 @@ configureReporters = (config, stats, tests) ->
     usedFileReportersLength = usedFileReporters.length
     if reporters.indexOf('apiary') > -1
       usedFileReportersLength = usedFileReportersLength - 1
-      if process.env['APIARY_API_KEY'] == undefined or process.env['APIARY_API_NAME'] == undefined
-        logger.warn "Apiary reporter environment variable APIARY_API_KEY or APIARY_API_NAME not defined."
 
     if usedFileReportersLength > outputs.length
       logger.warn """

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -202,7 +202,7 @@ class TransactionRunner
     configuration.emitter.emit 'test start', test
 
     if transaction.skip
-      # manually set to skip a test in hooks
+      # manually set to skip a test (can be done in hooks too)
       configuration.emitter.emit 'test skip', test
       return callback()
     else if transaction.fail
@@ -225,10 +225,6 @@ class TransactionRunner
     else if configuration.options.only.length > 0 and not (transaction.name in configuration.options.only)
       configuration.emitter.emit 'test skip', test
       transaction.skip = true
-      return callback()
-    else if transaction.skip
-      # manually set to skip a test
-      configuration.emitter.emit 'test skip', test
       return callback()
     else
       buffer = ""

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -28,7 +28,7 @@ class TransactionRunner
     async.mapSeries transactions, @configureTransaction, (err, results) ->
       transactions = results
 
-    hooks = addHooks @, transactions, @configuration.emitter
+    hooks = addHooks @, transactions, @configuration.emitter, @configuration.custom
     @executeAllTransactions(transactions, hooks, callback)
 
   runHooksForTransaction: (hooksForTransaction, transaction, callback) ->

--- a/test/integration/command-test.coffee
+++ b/test/integration/command-test.coffee
@@ -1,0 +1,143 @@
+{assert} = require 'chai'
+sinon = require 'sinon'
+express = require 'express'
+clone = require 'clone'
+fs = require 'fs'
+bodyParser = require 'body-parser'
+
+proxyquire = require('proxyquire').noCallThru()
+
+packageJson = require '../../package.json'
+loggerStub = require '../../src/logger'
+
+PORT = 9876
+
+exitStatus = null
+
+stderr = ''
+stdout = ''
+
+addHooksStub = proxyquire '../../src/add-hooks', {
+  './logger': loggerStub
+}
+transactionRunner = proxyquire '../../src/transaction-runner', {
+  './add-hooks': addHooksStub
+  './logger': loggerStub
+}
+dreddStub = proxyquire '../../src/dredd', {
+  './transaction-runner': transactionRunner
+  './logger': loggerStub
+}
+DreddCommand = proxyquire '../../src/command', {
+  './dredd': dreddStub
+  'console': loggerStub
+}
+
+execCommand = (custom = {}, cb) ->
+  stdout = ''
+  stderr = ''
+  exitStatus = null
+  finished = false
+  dreddCommand = new DreddCommand({
+    custom: custom
+  }, (code) ->
+    if not finished
+      finished = true
+      exitStatus = (code ? 0)
+      cb null, stdout, stderr, (code ? 0)
+  ).warmUp().takeoff()
+  return
+
+describe "DreddCommand class Integration", () ->
+  dreddCommand = null
+  custom = {}
+
+  before ->
+    for method in ['warn', 'error'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+    return
+
+  after ->
+    for method in ['warn', 'error']
+      loggerStub[method].restore()
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual']
+      loggerStub[method].restore()
+    return
+
+
+  describe "to test various Errors - When blueprint file should be loaded from 'http(s)://...' url", ->
+    server = null
+
+    errorCmd = argv: [
+      "http://localhost:#{PORT+1}/connection-error.apib"
+      "http://localhost:#{PORT+1}"
+    ]
+    wrongCmd = argv: [
+      "http://localhost:#{PORT}/not-found.apib"
+      "http://localhost:#{PORT}"
+    ]
+    goodCmd = argv: [
+      "http://localhost:#{PORT}/file.apib"
+      "http://localhost:#{PORT}"
+    ]
+
+    before (done) ->
+      app = express()
+
+      app.get '/', (req, res) -> res.sendStatus 404
+
+      app.get '/file.apib', (req, res) ->
+        stream = fs.createReadStream('./test/fixtures/single-get.apib')
+        stream.pipe res.type('text')
+
+      app.get '/machines', (req, res) ->
+        res.type('json').status(200).send [type: 'bulldozer', name: 'willy']
+
+      app.get '/not-found.apib', (req, res) ->
+        res.status(404).end()
+
+      server = app.listen PORT, ->
+        done()
+
+    after (done) ->
+      server.close ->
+        app = null
+        server = null
+        done()
+
+    describe 'and I try to load a file from bad hostname at all', ->
+      before (done) ->
+        execCommand errorCmd, ->
+          done()
+
+      it 'should exit with status 1', ->
+        assert.equal exitStatus, 1
+
+      it 'should print error message to stderr', ->
+        assert.include stderr, 'Error when loading file from URL'
+        assert.include stderr, 'Is the provided URL correct?'
+        assert.include stderr, 'connection-error.apib'
+
+    describe 'and I try to load a file that does not exist from an existing server', ->
+      before (done) ->
+        execCommand wrongCmd, ->
+          done()
+
+      it 'should exit with status 1', ->
+        assert.equal exitStatus, 1
+
+      it 'should print error message to stderr', ->
+        assert.include stderr, 'Unable to load file from URL'
+        assert.include stderr, 'responded with status code 404'
+        assert.include stderr, 'not-found.apib'
+
+    describe 'and I try to load a file that actually is there', ->
+      before (done) ->
+        execCommand goodCmd, ->
+          done()
+
+      it 'should exit with status 0', ->
+        assert.equal exitStatus, 0
+

--- a/test/integration/command-test.coffee
+++ b/test/integration/command-test.coffee
@@ -1,0 +1,382 @@
+{assert} = require 'chai'
+sinon = require 'sinon'
+express = require 'express'
+clone = require 'clone'
+fs = require 'fs'
+bodyParser = require 'body-parser'
+
+proxyquire = require('proxyquire').noCallThru()
+
+packageJson = require '../../package.json'
+loggerStub = require '../../src/logger'
+
+PORT = 9876
+
+exitStatus = null
+
+stderr = ''
+stdout = ''
+
+addHooksStub = proxyquire '../../src/add-hooks', {
+  './logger': loggerStub
+}
+transactionRunner = proxyquire '../../src/transaction-runner', {
+  './add-hooks': addHooksStub
+  './logger': loggerStub
+}
+dreddStub = proxyquire '../../src/dredd', {
+  './transaction-runner': transactionRunner
+  './logger': loggerStub
+}
+DreddCommand = proxyquire '../../src/command', {
+  './dredd': dreddStub
+  'console': loggerStub
+}
+
+execCommand = (custom = {}, cb) ->
+  stdout = ''
+  stderr = ''
+  exitStatus = null
+  finished = false
+  dreddCommand = new DreddCommand({
+    custom: custom
+  }, (code) ->
+    if not finished
+      finished = true
+      exitStatus = (code ? 0)
+      cb null, stdout, stderr, (code ? 0)
+  ).warmUp().takeoff()
+  return
+
+describe "DreddCommand class Integration", () ->
+  dreddCommand = null
+  custom = {}
+
+  before ->
+    for method in ['warn', 'error'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+    return
+
+  after ->
+    for method in ['warn', 'error']
+      loggerStub[method].restore()
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual']
+      loggerStub[method].restore()
+    return
+
+
+  describe "when creating DreddCommand instance with existing blueprint and responding server", () ->
+    describe "when the server is responding as specified in the blueprint", () ->
+
+      before (done) ->
+        custom =
+          argv: [
+            "./test/fixtures/single-get.apib"
+            "http://localhost:#{PORT}"
+          ]
+
+        app = express()
+
+        app.get '/machines', (req, res) ->
+          res.type('json').status(200).send [type: 'bulldozer', name: 'willy']
+
+        server = app.listen PORT, () ->
+          execCommand custom, ->
+            server.close()
+
+        server.on 'close', done
+
+      it 'exit status should be 0', () ->
+        assert.equal exitStatus, 0
+
+    describe "when the server is sending different response", () ->
+      before (done) ->
+        custom =
+          argv: [
+            "./test/fixtures/single-get.apib"
+            "http://localhost:#{PORT}"
+          ]
+
+        app = express()
+
+        app.get '/machines', (req, res) ->
+          res.type('json').status(201).send [kind: 'bulldozer', imatriculation: 'willy']
+
+        server = app.listen PORT, () ->
+          execCommand custom, () ->
+            server.close()
+
+        server.on 'close', done
+
+      it 'exit status should be 1', () ->
+        assert.equal exitStatus, 1
+
+
+  describe "when using reporter -r apiary in DREDD_REST_DEBUG mode", () ->
+    server = null
+    server2 = null
+    receivedRequest = null
+    exitStatus = null
+
+    before (done) ->
+      custom =
+        argv: [
+          "./test/fixtures/single-get.apib"
+          "http://localhost:#{PORT}"
+          "--reporter=apiary"
+        ]
+        apiaryApiUrl: "http://127.0.0.1:#{PORT+1}"
+        dreddRestDebug: '1'
+
+      apiary = express()
+      app = express()
+
+      apiary.use bodyParser.json(size:'5mb')
+
+      apiary.post '/apis/*', (req, res) ->
+        if req.body and req.url.indexOf('/tests/steps') > -1
+          receivedRequest ?= clone(req.body)
+        res.type('json')
+        res.status(201).send
+          _id: '1234_id'
+          testRunId: '6789_testRunId'
+          reportUrl: 'http://url.me/test/run/1234_id'
+
+      apiary.all '*', (req, res) ->
+        res.type 'json'
+        res.send {}
+
+      app.get '/machines', (req, res) ->
+        res.type('json').status(200).send [type: 'bulldozer', name: 'willy']
+
+      server = app.listen PORT, () ->
+        server2 = apiary.listen (PORT+1), ->
+          execCommand custom, () ->
+            server2.close ->
+              server.close ->
+
+      server.on 'close', done
+
+    it 'should print warning about missing APIARY_API_KEY and APIARY_API_NAME', () ->
+      assert.include stderr, 'Apiary reporter environment variable APIARY_API_KEY or APIARY_API_NAME not defined.'
+
+    it 'should print using the new reporter', () ->
+      assert.include stdout, 'http://url.me/test/run/1234_id'
+
+    it 'should send results from gavel', ()->
+      assert.isObject receivedRequest
+      assert.deepProperty receivedRequest, 'resultData.request'
+      assert.deepProperty receivedRequest, 'resultData.realResponse'
+      assert.deepProperty receivedRequest, 'resultData.expectedResponse'
+      assert.deepProperty receivedRequest, 'resultData.result.body.validator'
+      assert.deepProperty receivedRequest, 'resultData.result.headers.validator'
+      assert.deepProperty receivedRequest, 'resultData.result.statusCode.validator'
+
+
+      it 'prints out an error message', ->
+        assert.notEqual exitStatus, 0
+
+
+  describe "when called with arguments", () ->
+
+    describe '--path argument is a string', ->
+      before (done) ->
+        custom =
+          argv: [
+            "./test/fixtures/single-get.apib"
+            '--path', './test/fixtures/single-get.apib'
+            "http://localhost:#{PORT}"
+          ]
+
+        app = express()
+
+        app.get '/machines', (req, res) ->
+          response = [type: 'bulldozer', name: 'willy']
+          res.type('json').status(200).send response
+
+        server = app.listen PORT, () ->
+          execCommand custom, (error, stdOut, stdErr, code) ->
+            err = stdErr
+            out = stdOut
+            exitCode = code
+            server.close()
+
+        server.on 'close', done
+
+      it 'prints out ok', ->
+        assert.equal exitStatus, 0
+
+    describe "when using reporter -r apiary", () ->
+      server = null
+      server2 = null
+      receivedRequest = null
+      exitStatus = null
+
+      before (done) ->
+        custom =
+          argv: [
+            "./test/fixtures/single-get.apib"
+            "http://localhost:#{PORT}"
+            "--reporter=apiary"
+          ]
+          apiaryReporterEnv:
+            APIARY_API_URL: "http://127.0.0.1:#{PORT+1}"
+            DREDD_REST_DEBUG: '1'
+
+        apiary = express()
+        app = express()
+
+        apiary.use bodyParser.json(size:'5mb')
+
+        apiary.post '/apis/*', (req, res) ->
+          if req.body and req.url.indexOf('/tests/steps') > -1
+            receivedRequest ?= clone(req.body)
+          res.type('json')
+          res.status(201).send
+            _id: '1234_id'
+            testRunId: '6789_testRunId'
+            reportUrl: 'http://url.me/test/run/1234_id'
+
+        apiary.all '*', (req, res) ->
+          res.type 'json'
+          res.send {}
+
+        app.get '/machines', (req, res) ->
+          res.type('json').status(200).send [type: 'bulldozer', name: 'willy']
+
+        server = app.listen PORT, () ->
+          server2 = apiary.listen (PORT+1), ->
+            execCommand custom, () ->
+              server2.close ->
+                server.close ->
+
+        server.on 'close', done
+
+      it 'should print warning about missing APIARY_API_KEY and APIARY_API_NAME', () ->
+        assert.include stderr, 'Apiary reporter environment variable APIARY_API_KEY or APIARY_API_NAME not defined.'
+
+      it 'should print using the new reporter', () ->
+        assert.include stdout, 'http://url.me/test/run/1234_id'
+
+      it 'should send results from gavel', ()->
+        assert.isObject receivedRequest
+        assert.deepProperty receivedRequest, 'resultData.request'
+        assert.deepProperty receivedRequest, 'resultData.realResponse'
+        assert.deepProperty receivedRequest, 'resultData.expectedResponse'
+        assert.deepProperty receivedRequest, 'resultData.result.body.validator'
+        assert.deepProperty receivedRequest, 'resultData.result.headers.validator'
+        assert.deepProperty receivedRequest, 'resultData.result.statusCode.validator'
+
+
+  describe "when blueprint file should be loaded from 'http(s)://...' url", ->
+    server = null
+    loadedFromServer = null
+    connectedToServer = null
+    notFound = null
+    fileFound = null
+
+    errorCmd = argv: [
+      "http://localhost:#{PORT+1}/connection-error.apib"
+      "http://localhost:#{PORT+1}"
+    ]
+    wrongCmd = argv: [
+      "http://localhost:#{PORT}/not-found.apib"
+      "http://localhost:#{PORT}"
+    ]
+    goodCmd = argv: [
+      "http://localhost:#{PORT}/file.apib"
+      "http://localhost:#{PORT}"
+    ]
+
+    afterEach ->
+      connectedToServer = null
+
+    before (done) ->
+      app = express()
+
+      app.use (req, res, next) ->
+        connectedToServer = true
+        next()
+
+      app.get '/', (req, res) ->
+        res.sendStatus 404
+
+      app.get '/file.apib', (req, res) ->
+        fileFound = true
+        res.type('text')
+        stream = fs.createReadStream './test/fixtures/single-get.apib'
+        stream.pipe res
+
+      app.get '/machines', (req, res) ->
+        res.type('json').status(200).send [type: 'bulldozer', name: 'willy']
+
+      app.get '/not-found.apib', (req, res) ->
+        notFound = true
+        res.status(404).end()
+
+      server = app.listen PORT, ->
+        done()
+
+    after (done) ->
+      server.close ->
+        app = null
+        server = null
+        done()
+
+    describe 'and I try to load a file from bad hostname at all', ->
+      before (done) ->
+        execCommand errorCmd, ->
+          done()
+
+      after ->
+        connectedToServer = null
+
+      it 'should not send a GET to the server', ->
+        assert.isNull connectedToServer
+
+      it 'should exit with status 1', ->
+        assert.equal exitStatus, 1
+
+      it 'should print error message to stderr', ->
+        assert.include stderr, 'Error when loading file from URL'
+        assert.include stderr, 'Is the provided URL correct?'
+        assert.include stderr, 'connection-error.apib'
+
+    describe 'and I try to load a file that does not exist from an existing server', ->
+      before (done) ->
+        execCommand wrongCmd, ->
+          done()
+
+      after ->
+        connectedToServer = null
+
+      it 'should connect to the right server', ->
+        assert.isTrue connectedToServer
+
+      it 'should send a GET to server at wrong URL', ->
+        assert.isTrue notFound
+
+      it 'should exit with status 1', ->
+        assert.equal exitStatus, 1
+
+      it 'should print error message to stderr', ->
+        assert.include stderr, 'Unable to load file from URL'
+        assert.include stderr, 'responded with status code 404'
+        assert.include stderr, 'not-found.apib'
+
+    describe 'and I try to load a file that actually is there', ->
+      before (done) ->
+        execCommand goodCmd, ->
+          done()
+
+      it 'should send a GET to the right server', ->
+        assert.isTrue connectedToServer
+
+      it 'should send a GET to server at good URL', ->
+        assert.isTrue fileFound
+
+      it 'should exit with status 0', ->
+        assert.equal exitStatus, 0
+

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -48,7 +48,7 @@ execCommand = (custom = {}, cb) ->
   ).warmUp().takeoff()
   return
 
-describe "DreddCommand class Integration", () ->
+describe "Dredd class Integration", () ->
   dreddCommand = null
   custom = {}
 

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -22,9 +22,19 @@ describe 'addHooks(runner, transaction)', () ->
   server = null
 
   before () ->
+    # TODO/FIXME: use new Hooks instance for every addHooks call
+    # until then, clean all hooks
+    hooksStub.beforeAllHooks = []
+    hooksStub.afterAllHooks = []
+    hooksStub.beforeHooks = {}
+    hooksStub.afterHooks = {}
     loggerStub.transports.console.silent = true
 
   after () ->
+    hooksStub.beforeAllHooks = []
+    hooksStub.afterAllHooks = []
+    hooksStub.beforeHooks = {}
+    hooksStub.afterHooks = {}
     loggerStub.transports.console.silent = false
 
   describe 'with no pattern', () ->

--- a/test/unit/command-test.coffee
+++ b/test/unit/command-test.coffee
@@ -1,0 +1,222 @@
+{assert} = require 'chai'
+sinon = require 'sinon'
+
+proxyquire = require('proxyquire').noCallThru()
+
+packageJson = require '../../package.json'
+loggerStub = require '../../src/logger'
+options = require '../../src/options'
+
+PORT = 9876
+
+exitStatus = null
+
+stderr = ''
+stdout = ''
+
+addHooksStub = proxyquire '../../src/add-hooks', {
+  './logger': loggerStub
+}
+transactionRunner = proxyquire '../../src/transaction-runner', {
+  './add-hooks': addHooksStub
+  './logger': loggerStub
+}
+dreddStub = proxyquire '../../src/dredd', {
+  './transaction-runner': transactionRunner
+  './logger': loggerStub
+}
+DreddCommand = proxyquire '../../src/command', {
+  './dredd': dreddStub
+  'console': loggerStub
+}
+
+execCommand = (custom = {}, cb) ->
+  stdout = ''
+  stderr = ''
+  exitStatus = null
+  finished = false
+  dreddCommand = new DreddCommand({
+    custom: custom
+  }, (code) ->
+    if not finished
+      finished = true
+      exitStatus = (code ? 0)
+      cb null, stdout, stderr, (code ? 0)
+  ).warmUp().takeoff()
+  return
+
+describe "DreddCommand class", () ->
+  dreddCommand = null
+  env = {}
+
+  before ->
+    for method in ['warn', 'error'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
+      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+    return
+
+  after ->
+    for method in ['warn', 'error']
+      loggerStub[method].restore()
+    for method in ['log', 'info', 'silly', 'verbose', 'test', 'diff', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual']
+      loggerStub[method].restore()
+    return
+
+
+  describe 'when initialized without "new" keyword', ->
+    dc = null
+    before ->
+      dc = DreddCommand()
+
+    it 'sets finished to false', ->
+      assert.isFalse dc.finished
+
+    it 'sets custom to an Object with "argv" and "cwd" keys', ->
+      assert.isObject dc.custom
+      assert.lengthOf Object.keys(dc.custom), 2
+      assert.property dc.custom, 'cwd'
+      assert.property dc.custom, 'argv'
+
+    it 'sets custom argv to an Array with process.argv', ->
+      assert.isArray dc.custom?.argv
+      assert.equal dc.custom?.argv.length, 0
+
+    it 'returns an instanceof DreddCommand', ->
+      assert.instanceOf dc, DreddCommand
+
+
+  describe 'when initialized with options containing exit callback', ->
+    dc = null
+    hasCalledExit = null
+
+    before () ->
+      dc = DreddCommand({exit: (code) ->
+        hasCalledExit = true
+      })
+      dc.warmUp()?.takeoff?()
+
+    it 'has argv property set to object with properties from optimist', ->
+      assert.isObject dc.argv
+      assert.property dc.argv, '_'
+      assert.isArray dc.argv['_']
+
+    it 'does not set finished to true (keeps false)', ->
+      assert.isFalse dc.finished
+
+    it 'ends with an error message about missing blueprint-file', ->
+      assert.include stderr, 'Must specify path to blueprint file.'
+
+    it 'ends with an error message about missing api endpoint.', ->
+      assert.include stderr, 'Must specify api endpoint.'
+
+    it 'calls exit callback', ->
+      assert.isNotNull hasCalledExit
+
+
+  describe 'warmUp', ->
+    dc = null
+    initDreddStub = null
+    initConfigSpy = null
+    lastArgvIsApiEndpointSpy = null
+    takeRestOfParamsAsPathSpy = null
+
+    before ->
+      dc = new DreddCommand({
+        exit: ->
+        custom:
+          argv: ['./file.apib', 'http://localhost:3000']
+          env: {'NO_KEY': 'NO_VAL'}
+      })
+      initDreddStub = sinon.stub dc, 'initDredd', ->
+        return 'myDreddInstance'
+      initConfigSpy = sinon.spy dc, 'initConfig'
+      lastArgvIsApiEndpointSpy = sinon.spy dc, 'lastArgvIsApiEndpoint'
+      takeRestOfParamsAsPathSpy = sinon.spy dc, 'takeRestOfParamsAsPath'
+
+    after ->
+      dc.initDredd.restore()
+      dc.initConfig.restore()
+      dc.lastArgvIsApiEndpoint.restore()
+      dc.takeRestOfParamsAsPath.restore()
+
+    describe 'with mocked initDredd', ->
+      before ->
+        dc.warmUp()
+
+      it 'should call initConfig', ->
+        assert.equal initConfigSpy.called, 1
+
+      it 'should call susequent helpers as part of initConfig', ->
+        assert.equal lastArgvIsApiEndpointSpy.called, 1
+        assert.equal takeRestOfParamsAsPathSpy.called, 1
+
+      it 'should call initDredd with configuration object', ->
+        assert.equal dc.initDredd.called, 1
+        assert.isArray dc.initDredd.firstCall.args
+        assert.lengthOf dc.initDredd.firstCall.args, 1
+        assert.property dc.initDredd.firstCall.args[0], 'server'
+        assert.property dc.initDredd.firstCall.args[0], 'options'
+        assert.property dc.initDredd.firstCall.args[0], 'custom'
+        assert.equal dc.dreddInstance, 'myDreddInstance'
+
+
+  describe 'takeoff', ->
+    dc = null
+    runDreddStub = null
+    beforeEach ->
+      dc = new DreddCommand({
+        exit: ->
+      })
+      dc.dreddInstance = 'dreddInstance'
+      runDreddStub = sinon.stub dc, 'runDredd', ->
+
+    afterEach ->
+      dc.runDredd.restore()
+
+    describe 'with finished set to false', ->
+      it 'does call runDredd just once with dreddInstance as first argument', ->
+        runDreddStub.reset()
+        dc.takeoff()
+        assert.equal dc.runDredd.called, 1
+        assert.isArray dc.runDredd.firstCall.args
+        assert.lengthOf dc.runDredd.firstCall.args, 1
+        assert.deepEqual dc.runDredd.firstCall.args, ['dreddInstance']
+
+    describe 'with finished set to true', ->
+      it 'does not call runDredd at all', ->
+        runDreddStub.reset()
+        dc.finished = true
+        dc.takeoff()
+        assert.equal dc.runDredd.called, 0
+
+
+  describe "when called w/ OR wo/ special arguments", () ->
+    describe '--help', ->
+      before (done) ->
+        execCommand argv: ['--help'], ->
+          done()
+
+      it 'prints out some really nice help text with all options descriptions', ->
+        assert.include stderr, 'Usage:'
+        assert.include stderr, 'Example:'
+        assert.include stderr, '[OPTIONS]'
+        for optionKey in Object.keys options then do (optionKey) ->
+          assert.include stderr, optionKey
+
+    describe '--version', ->
+      before (done) ->
+        execCommand argv: ['--version'], ->
+          done()
+
+      it 'prints out version', ->
+        assert.include stdout, "#{packageJson.name} v#{packageJson.version}"
+
+    describe 'without argv', ->
+      before (done) ->
+        execCommand argv: [], ->
+          done()
+
+      it 'prints out an error message', ->
+        assert.include stderr, 'Error: Must specify'
+

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -40,9 +40,19 @@ describe 'TransactionRunner', ()->
   runner = {}
 
   before () ->
+    # TODO/FIXME: use new Hooks instance for every addHooks call
+    # until then, clean all hooks
+    hooksStub.beforeAllHooks = []
+    hooksStub.afterAllHooks = []
+    hooksStub.beforeHooks = {}
+    hooksStub.afterHooks = {}
     loggerStub.transports.console.silent = true
 
   after () ->
+    hooksStub.beforeAllHooks = []
+    hooksStub.afterAllHooks = []
+    hooksStub.beforeHooks = {}
+    hooksStub.afterHooks = {}
     loggerStub.transports.console.silent = false
 
   describe 'constructor', () ->


### PR DESCRIPTION
Because `clone` cannot clone `process.stdout`, custom configuration is passed to `Dredd` class as a second argument