### PR TITLE
Enhance apiary reported json

### DIFF
--- a/ApiaryReportingApi.md
+++ b/ApiaryReportingApi.md
@@ -12,6 +12,7 @@ HOST: http://api.apiary.io/
 
 - Attributes
   - _id (string, `507f1f77bcf86cd799439011`) ... Unique object id. DO NOT USE IT WHEN CREATING! Used in post body only for purpose of testing this blueprint.
+  - endpoint (string, required, 'http://localhost:3000') ... protocol with hostname and optional PORT in URL format, root for all transactions in this Test Run
   - reportUrl (string, required, `https://absolutely.fency.url/wich-can-change/some/id`) ... Report UI URL
   - blueprints (array, required) ... Array of blueprints used for the test run
       - filename (string, required) ... file name
@@ -53,6 +54,7 @@ HOST: http://api.apiary.io/
         ```
         {
           "_id": "507f1f77bcf86cd799439011",
+          "endpoint": "http://localhost:3000",
           "blueprints": [
             {
               "raw": "",
@@ -93,6 +95,7 @@ HOST: http://api.apiary.io/
         ```
         {
           "_id": "507f1f77bcf86cd799439011",
+          "endpoint": "http://localhost:3000",
           "reportUrl": "https://absolutely.fency.url/wich-can-change/some/id",
           "blueprints": [
             {
@@ -141,6 +144,7 @@ HOST: http://api.apiary.io/
         [
           {
             "_id": "507f1f77bcf86cd799439011",
+            "endpoint": "http://localhost:3000",
             "reportUrl": "https://absolutely.fency.url/wich-can-change/some/id",
             "blueprints": [
               {
@@ -210,6 +214,7 @@ HOST: http://api.apiary.io/
         ```
         {
           "_id": "507f1f77bcf86cd799439011",
+          "endpoint": "http://localhost:3000",
           "reportUrl": "https://absolutely.fency.url/wich-can-change/some/id",
           "blueprints": [
             {

--- a/ApiaryReportingApi.md
+++ b/ApiaryReportingApi.md
@@ -252,6 +252,7 @@ HOST: http://api.apiary.io/
   - _id (string) ... Unique object id. DO NOT USE IT WHEN CREATING! Used in post body only for purpose of testing this blueprint.
   - testRunId (string) ... Reference to the parent test run identificator
   - origin (object) ... Origin path (position, location) of the step in the blueprint AST
+    - uriTemplate (string) ... URI Template used as source for URL of this step
     - filename (string) .. File name of original blueprint
     - resourceGroupName (string) ... Group name
     - resourceName (string) ... Resource name
@@ -262,7 +263,7 @@ HOST: http://api.apiary.io/
     - Values
       - `passed`
       - `failed`
-  - resultData (obejct) ... Data from step execution
+  - resultData (object) ... Data from step execution
     - request  ... [Real HTTP Request](https://www.relishapp.com/apiary/gavel/v/0-1/docs/data-model#http-request)
     - realResponse ... [Real HTTP response](https://www.relishapp.com/apiary/gavel/v/0-1/docs/data-model#http-response)
     - expected Response ... [Expected HTTP Response](https://www.relishapp.com/apiary/gavel/v/0-1/docs/data-model#expected-http-response)
@@ -294,6 +295,7 @@ HOST: http://api.apiary.io/
         "testRunId": "507f1f77bcf86cd799439011",
         "origin": {
           "filename": "./apiary.apib",
+          "uriTemplate": "/",
           "resourceGroupName": "Machines",
           "resourceName": "Machines collection",
           "actionName": "Create a machine",
@@ -356,6 +358,7 @@ HOST: http://api.apiary.io/
         "testRunId": "507f1f77bcf86cd799439011",
         "origin": {
           "filename": "./apiary.apib",
+          "uriTemplate": "/",
           "resourceGroupName": "Machines",
           "resourceName": "Machines collection",
           "actionName": "Create a machine",
@@ -396,6 +399,7 @@ HOST: http://api.apiary.io/
           "testRunId": "507f1f77bcf86cd799439011",
           "origin": {
             "filename": "./apiary.apib",
+            "uriTemplate": "/",
             "resourceGroupName": "Machines",
             "resourceName": "Machines collection",
             "actionName": "Create a machine",
@@ -442,6 +446,7 @@ HOST: http://api.apiary.io/
         "testRunId": "507f1f77bcf86cd799439011",
         "origin": {
           "filename": "./apiary.apib",
+          "uriTemplate": "/",
           "resourceGroupName": "Machines",
           "resourceName": "Machines collection",
           "actionName": "Create a machine",

--- a/src/blueprint-ast-to-runtime.coffee
+++ b/src/blueprint-ast-to-runtime.coffee
@@ -34,6 +34,8 @@ blueprintAstToRuntime = (blueprintAst, filename) ->
       else
         origin['resourceName'] = resource['uriTemplate']
 
+      origin['uriTemplate'] = "#{resource['uriTemplate']}"
+
       for action in resource['actions']
         if action['name'] != ""
           origin['actionName'] = action['name']

--- a/src/reporters/apiary-reporter.coffee
+++ b/src/reporters/apiary-reporter.coffee
@@ -68,6 +68,7 @@ class ApiaryReporter
 
       data =
         blueprints: blueprints
+        endpoint: @config.server
         agent: @_get('dreddAgent', 'DREDD_AGENT') || @_get('user', 'USER')
         agentRunUuid: @uuid
         hostname: @_get('dreddHostname', 'DREDD_HOSTNAME') || os.hostname()

--- a/test/unit/blueprint-ast-to-runtime-test.coffee
+++ b/test/unit/blueprint-ast-to-runtime-test.coffee
@@ -9,14 +9,14 @@ describe "blueprintAstToRuntime()", () ->
     data = blueprintAstToRuntime blueprintAst, filename
 
   describe 'its return', () ->
-    it 'shuold return an object', () ->
+    it 'should return an object', () ->
       assert.isObject data
 
     ['transactions', 'errors', 'warnings'].forEach (key) ->
       it 'should have key \'' + key + "'", () ->
         assert.include Object.keys(data), key
 
-    describe 'transcactions', () ->
+    describe 'transactions', () ->
       it 'should not be empty', () ->
         assert.notEqual data['transactions'].length, 0
 
@@ -62,6 +62,10 @@ describe "blueprintAstToRuntime()", () ->
           transactions.forEach (transaction, index) ->
             assert.property transaction['origin'], 'apiName', 'Transaction index ' + index
             assert.equal transaction['origin']['apiName'], 'Machines API', 'Transaction index ' + index
+
+        it 'have uriTemplate property', () ->
+          transactions.forEach (transaction, index) ->
+            assert.property transaction['origin'], 'uriTemplate'
 
       describe 'value under request key', () ->
         ['uri','method','headers','body'].forEach (key) ->

--- a/test/unit/reporters/apiary-reporter-test.coffee
+++ b/test/unit/reporters/apiary-reporter-test.coffee
@@ -221,6 +221,14 @@ describe 'ApiaryReporter', () ->
             assert.isObject blueprint.parsed.sourcemap
           done()
 
+      it 'should have various needed keys in test-run payload sent to apiary', (done) ->
+        emitter = new EventEmitter
+        apiaryReporter = new ApiaryReporter emitter, {}, {}, {server: 'http://my.server.co:8080', custom:apiaryReporterEnv:env}
+        emitter.emit 'start', blueprintData, () ->
+          parsedBody = JSON.parse requestBody
+          assert.propertyVal parsedBody, 'endpoint', 'http://my.server.co:8080'
+          done()
+
     describe 'when adding passing test', () ->
       call = null
       runId = '507f1f77bcf86cd799439011'


### PR DESCRIPTION
- add used server endpoint to sent data via apiary-reporter otherwise is unknown (it is not sent in `headers.host`)
- send `uriTemplate` at origin, because expanded URL can be result of various endpoints