### PR TITLE
Use pitboss-ng npm instead of pitboss fork-git-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "markdown-it": "^4.0.1",
     "node-uuid": "~1.4.2",
     "optimist": "~0.6.1",
-    "pitboss": "git://github.com/apiaryio/pitboss",
+    "pitboss-ng": "^0.2.1",
     "protagonist": "^0.17.2",
     "proxyquire": "^1.3.1",
     "request": "^2.53.0",

--- a/src/sandbox-hooks-code.coffee
+++ b/src/sandbox-hooks-code.coffee
@@ -1,4 +1,4 @@
-{Pitboss} = require 'pitboss'
+{Pitboss} = require 'pitboss-ng'
 Hooks = require './hooks'
 
 sandboxHooksCode = (hooksCode, callback) ->

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -6,7 +6,7 @@ os = require 'os'
 chai = require 'chai'
 gavel = require 'gavel'
 async = require 'async'
-{Pitboss} = require 'pitboss'
+{Pitboss} = require 'pitboss-ng'
 
 flattenHeaders = require './flatten-headers'
 addHooks = require './add-hooks'


### PR DESCRIPTION
- brings in `pitboss-ng` with support for `nodejs 0.12` / `0.10` / `iojs`