### PR TITLE
Freeze proxyquire to 1.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node-uuid": "~1.4.2",
     "optimist": "~0.6.1",
     "pitboss-ng": "^0.3.1",
-    "proxyquire": "^1.3.1",
+    "proxyquire": "~1.4.x",
     "request": "^2.53.0",
     "setimmediate": "^1.0.2",
     "uri-template": "~1.0.0",


### PR DESCRIPTION
- because proxyquire 1.5.x uses "fill-keys" package, which breaks add-hooks(-test)

> _a hotfix, real fix probably in next week(s) or month_