### PR TITLE
Support for before validation hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -74,7 +74,7 @@ Dredd supports following types of hooks:
 
 ## Hooks JavaScript API Reference
 
-- For `before`, `after`, `beforeEach`, and `afterEach`, a [Transaction Object](#transaction-object-structure) is passed as the first argument to the hook function.
+- For `before`, `after`, `beforeValidation`, `beforeEach`, `afterEach` and `beforeEachValidation` a [Transaction Object](#transaction-object-structure) is passed as the first argument to the hook function.
 - An array of Transaction Objects is passed to `beforeAll` and `afterAll`.
 - The second argument is an optional callback function for async execution.
 - Any modifications on the `transaction` object is propagated to the actual HTTP transactions.
@@ -93,8 +93,16 @@ hooks.beforeEach(function (transaction) {
   hooks.log('beforeEach');
 });
 
+hooks.beforeEachValidation(function (transaction) {
+  hooks.log('beforeEachValidation');
+});
+
 hooks.before("Machines > Machines collection > Get Machines", function (transaction) {
   hooks.log("before");
+});
+
+hooks.before("Machines > Machines collection > Get Machines", function (transaction) {
+  hooks.log("beforeValidation");
 });
 
 hooks.after("Machines > Machines collection > Get Machines", function (transaction) {
@@ -127,8 +135,18 @@ hooks.beforeEach(function (transaction, done) {
   done();
 });
 
+hooks.beforeEachValidation(function (transaction, done) {
+  hooks.log('beforeEachValidation');
+  done();
+});
+
 hooks.before("Machines > Machines collection > Get Machines", function (transaction, done) {
   hooks.log("before");
+  done();
+});
+
+hooks.beforeValidation("Machines > Machines collection > Get Machines", function (transaction, done) {
+  hooks.log("beforeValidation");
   done();
 });
 
@@ -274,6 +292,8 @@ In each hook file you can use following functions:
 
 `before(transactionName, function)`
 
+`beforeValidation(transactionName, function)`
+
 `after(transactionName, function)`
 
 `beforeAll(function)`
@@ -281,6 +301,8 @@ In each hook file you can use following functions:
 `afterAll(function)`
 
 `beforeEach(function)`
+
+`beforeEachValidation(function)`
 
 `afterEach(function)`
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -66,6 +66,8 @@ Dredd supports following types of hooks:
 - `beforeAll` called at the beginning of the whole test run
 - `beforeEach` called before each HTTP transaction
 - `before` called before some specific HTTP transaction
+- `beforeEachValidation` called before each HTTP transaction is validated
+- `beforeValidation` called before some specific HTTP transaction is validated
 - `after` called after some specific HTTP transaction regardless its result
 - `afterEach` called after each HTTP transaction
 - `afterAll` called after whole test run

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -135,12 +135,6 @@ hooks.beforeEach(function (transaction, done) {
   done();
 });
 
-
-hooks.before("Machines > Machines collection > Get Machines", function (transaction, done) {
-  hooks.log("before");
-  done();
-});
-
 hooks.beforeEachValidation(function (transaction, done) {
   hooks.log('beforeEachValidation');
   done();
@@ -150,6 +144,13 @@ hooks.beforeValidation("Machines > Machines collection > Get Machines", function
   hooks.log("beforeValidation");
   done();
 });
+
+hooks.before("Machines > Machines collection > Get Machines", function (transaction, done) {
+  hooks.log("before");
+  done();
+});
+
+
 
 hooks.after("Machines > Machines collection > Get Machines", function (transaction, done) {
   hooks.log("after");

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -93,15 +93,15 @@ hooks.beforeEach(function (transaction) {
   hooks.log('beforeEach');
 });
 
-hooks.beforeEachValidation(function (transaction) {
-  hooks.log('beforeEachValidation');
-});
-
 hooks.before("Machines > Machines collection > Get Machines", function (transaction) {
   hooks.log("before");
 });
 
-hooks.before("Machines > Machines collection > Get Machines", function (transaction) {
+hooks.beforeEachValidation(function (transaction) {
+  hooks.log('beforeEachValidation');
+});
+
+hooks.beforeValidation("Machines > Machines collection > Get Machines", function (transaction) {
   hooks.log("beforeValidation");
 });
 
@@ -135,13 +135,14 @@ hooks.beforeEach(function (transaction, done) {
   done();
 });
 
-hooks.beforeEachValidation(function (transaction, done) {
-  hooks.log('beforeEachValidation');
-  done();
-});
 
 hooks.before("Machines > Machines collection > Get Machines", function (transaction, done) {
   hooks.log("before");
+  done();
+});
+
+hooks.beforeEachValidation(function (transaction, done) {
+  hooks.log('beforeEachValidation');
   done();
 });
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -257,7 +257,9 @@ This section provides the order in which Dredd executes to give a better underst
         - Run `before` hook
         - Send HTTP request
         - Receive HTTP response
-        - Run [Gavel][] validation
+        - Run `beforeEachValidation` hook
+        - Run `beforeValidation` hook
+        - Perform [Gavel][] validation
         - Run `after` hook
         - Run `afterEach` hook
         - Report `test end` with result for in-progress reporting

--- a/src/hooks.coffee
+++ b/src/hooks.coffee
@@ -9,14 +9,19 @@ class Hooks
     {@logs, @logger} = options
     @transactions = {}
     @beforeHooks = {}
+    @beforeValidationHooks = {}
     @afterHooks = {}
     @beforeAllHooks = []
     @afterAllHooks = []
     @beforeEachHooks = []
+    @beforeEachValidationHooks = []
     @afterEachHooks = []
 
   before: (name, hook) =>
     @addHook(@beforeHooks, name, hook)
+
+  beforeValidation: (name, hook) =>
+    @addHook(@beforeValidationHooks, name, hook)
 
   after: (name, hook) =>
     @addHook(@afterHooks, name, hook)
@@ -29,6 +34,9 @@ class Hooks
 
   beforeEach: (hook) =>
     @beforeEachHooks.push hook
+
+  beforeEachValidation: (hook) =>
+    @beforeEachValidationHooks.push hook
 
   afterEach: (hook) =>
     @afterEachHooks.push hook
@@ -52,10 +60,12 @@ class Hooks
     toReturn = {}
     names = [
       'beforeHooks'
+      'beforeValidationHooks'
       'afterHooks'
       'beforeAllHooks'
       'afterAllHooks'
       'beforeEachHooks'
+      'beforeEachValidationHooks'
       'afterEachHooks'
     ]
 

--- a/src/sandbox-hooks-code.coffee
+++ b/src/sandbox-hooks-code.coffee
@@ -12,6 +12,9 @@ sandboxHooksCode = (hooksCode, callback) ->
   var afterAll = _hooks.afterAll;
   var beforeEach = _hooks.beforeEach;
   var afterEach = _hooks.afterEach;
+  var beforeValidation = _hooks.beforeValidation;
+  var beforeEachValidation = _hooks.beforeEachValidation;
+
   var log = _hooks.log;
 
   #{hooksCode}

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -297,7 +297,7 @@ class TransactionRunner
           @runHooksForData hooks.beforeHooks[transaction.name], transaction, false, () =>
 
             # execute and validate HTTP transaction
-            @executeTransaction transaction, () =>
+            @executeTransaction transaction, hooks, () =>
 
               # run afterEach hooks
               @runHooksForData hooks.afterEachHooks, transaction, false, () =>
@@ -312,7 +312,11 @@ class TransactionRunner
         #runAfterHooks
         @runHooksForData hooks.afterAllHooks, transactions, true, callback
 
-  executeTransaction: (transaction, callback) =>
+  executeTransaction: (transaction, hooks, callback) =>
+    unless callback
+      callback = hooks
+      hooks = null
+
     configuration = @configuration
 
     # Add length of body if no Content-Length present
@@ -371,7 +375,7 @@ class TransactionRunner
     else
       buffer = ""
 
-      handleRequest = (res) ->
+      handleRequest = (res) =>
         res.on 'data', (chunk) ->
           buffer = buffer + chunk
 
@@ -381,7 +385,7 @@ class TransactionRunner
 
           return callback()
 
-        res.once 'end', ->
+        res.once 'end', =>
 
           # The data models as used here must conform to Gavel.js
           # as defined in `http-response.coffee`
@@ -392,45 +396,9 @@ class TransactionRunner
 
           transaction['real'] = real
 
-          gavel.isValid real, transaction.expected, 'response', (isValidError, isValid) ->
-            if isValidError
-              configuration.emitter.emit 'test error', isValidError, test, () ->
-
-            test.start = test.start
-            test.title = transaction.id
-            test.actual = real
-            test.expected = transaction.expected
-            test.request = transaction.request
-
-            if isValid
-              test.status = "pass"
-            else
-              test.status = "fail"
-
-            gavel.validate real, transaction.expected, 'response', (validateError, result) ->
-              if not isValidError and validateError
-                configuration.emitter.emit 'test error', validateError, test, () ->
-
-              message = ''
-
-              for resultKey, data of result
-                if resultKey isnt 'version'
-                  for entityResult in data['results']
-                    message += resultKey + ": " + entityResult['message'] + "\n"
-
-              test.message = message
-              test.results = result
-              test.results['general'] = []
-
-              test.valid = isValid
-
-              # propagate test to after hooks
-              transaction.test = test
-
-              if test.valid == false
-                configuration.emitter.emit 'test fail', test, () ->
-
-              return callback()
+          @runHooksForData hooks?.beforeEachValidationHooks, transaction, false, () =>
+            @runHooksForData hooks?.beforeValidationHooks[transaction.name], transaction, false, () =>
+              @validateTransaction test, transaction, callback
 
       transport = if transaction.protocol is 'https:' then https else http
       if transaction.request['body'] and @isMultipart requestOptions
@@ -447,6 +415,49 @@ class TransactionRunner
         req.end()
       catch error
         configuration.emitter.emit 'test error', error, test, () ->
+        return callback()
+
+  validateTransaction: (test, transaction, callback) ->
+    configuration = @configuration
+
+    gavel.isValid transaction.real, transaction.expected, 'response', (isValidError, isValid) ->
+      if isValidError
+        configuration.emitter.emit 'test error', isValidError, test, () ->
+
+      test.start = test.start
+      test.title = transaction.id
+      test.actual = transaction.real
+      test.expected = transaction.expected
+      test.request = transaction.request
+
+      if isValid
+        test.status = "pass"
+      else
+        test.status = "fail"
+
+      gavel.validate transaction.real, transaction.expected, 'response', (validateError, result) ->
+        if not isValidError and validateError
+          configuration.emitter.emit 'test error', validateError, test, () ->
+
+        message = ''
+
+        for resultKey, data of result
+          if resultKey isnt 'version'
+            for entityResult in data['results']
+              message += resultKey + ": " + entityResult['message'] + "\n"
+
+        test.message = message
+        test.results = result
+        test.results['general'] = []
+
+        test.valid = isValid
+
+        # propagate test to after hooks
+        transaction.test = test
+
+        if test.valid == false
+          configuration.emitter.emit 'test fail', test, () ->
+
         return callback()
 
   isMultipart: (requestOptions) ->

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -296,7 +296,12 @@ class TransactionRunner
           # run before hooks
           @runHooksForData hooks.beforeHooks[transaction.name], transaction, false, () =>
 
-            # execute and validate HTTP transaction
+            # This method:
+            # - executes a request
+            # - recieves a response
+            # - runs beforeValidation hooks
+            # - runs beforeEachValidation hooks
+            # - runs Gavel validation
             @executeTransaction transaction, hooks, () =>
 
               # run afterEach hooks

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -299,8 +299,8 @@ class TransactionRunner
             # This method:
             # - executes a request
             # - recieves a response
-            # - runs beforeValidation hooks
             # - runs beforeEachValidation hooks
+            # - runs beforeValidation hooks
             # - runs Gavel validation
             @executeTransaction transaction, hooks, () =>
 
@@ -453,7 +453,7 @@ class TransactionRunner
 
         test.message = message
         test.results = result
-        test.results['general'] = []
+        test.results['general'] ?= []
 
         test.valid = isValid
 

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -47,7 +47,7 @@ describe 'Dredd class', () ->
 
       fn = () ->
         dredd = new Dredd(configuration)
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
         dredd.run (error) ->
           assert.ok dredd.runner.executeTransaction.called
@@ -75,7 +75,7 @@ describe 'Dredd class', () ->
 
     it 'should load the file on given path', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.ok fsStub.readFile.calledWith configuration.options.path[0]
@@ -84,7 +84,7 @@ describe 'Dredd class', () ->
 
     it 'should parse blueprint to ast', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.ok DrafterClassStub::make.called
@@ -93,7 +93,7 @@ describe 'Dredd class', () ->
 
     it 'should not pass any error to the callback function', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.isNull(error)
@@ -102,7 +102,7 @@ describe 'Dredd class', () ->
 
     it 'should pass the reporter as second argument', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error, reporter) ->
         assert.isDefined reporter
@@ -111,7 +111,7 @@ describe 'Dredd class', () ->
 
     it 'should convert ast to runtime', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.ok blueprintAstToRuntimeStub.called
@@ -128,7 +128,7 @@ describe 'Dredd class', () ->
         dredd = new Dredd(configuration)
 
       beforeEach () ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
 
       afterEach () ->
@@ -178,7 +178,7 @@ describe 'Dredd class', () ->
         dredd = new Dredd(configuration)
 
       beforeEach () ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
 
       afterEach () ->
@@ -216,7 +216,7 @@ describe 'Dredd class', () ->
                       {"a":"b"}'
               """
         dredd = new Dredd(configuration)
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
 
       afterEach () ->
@@ -252,7 +252,7 @@ describe 'Dredd class', () ->
           configuration.options ?= {}
           configuration.options.path = ['./test/fixtures/apiary.apib']
           localdredd = new Dredd(configuration)
-          sinon.stub localdredd.runner, 'executeTransaction', (transaction, callback) ->
+          sinon.stub localdredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
             callback()
 
         afterEach ->
@@ -291,7 +291,7 @@ describe 'Dredd class', () ->
           done err
 
       beforeEach () ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
 
       afterEach () ->
@@ -417,7 +417,7 @@ describe 'Dredd class', () ->
       dredd = new Dredd(configuration)
 
     beforeEach () ->
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
 
     afterEach () ->
@@ -472,7 +472,7 @@ describe 'Dredd class', () ->
           silent: true
           path: ['./balony/path.apib']
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
 
     afterEach () ->
@@ -497,7 +497,7 @@ describe 'Dredd class', () ->
           path: ['./test/fixtures/error-uri-template.apib']
 
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
 
     afterEach () ->
@@ -523,7 +523,7 @@ describe 'Dredd class', () ->
           path: ['./test/fixtures/warning-ambigous.apib']
       sinon.spy loggerStub, 'warn'
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
 
     afterEach () ->
@@ -553,7 +553,7 @@ describe 'Dredd class', () ->
           silent: true
           path: ['./test/fixtures/warning-ambigous.apib']
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, callback) ->
+      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
 
     afterEach () ->
@@ -563,6 +563,3 @@ describe 'Dredd class', () ->
       dredd.run (error) ->
         assert.ok blueprintAstToRuntimeStub.called
         done()
-
-
-

--- a/test/unit/hooks-test.coffee
+++ b/test/unit/hooks-test.coffee
@@ -63,6 +63,17 @@ describe 'Hooks', () ->
     it 'should add to hook collection', () ->
       assert.property hooks.beforeHooks, 'beforeHook'
 
+  describe '#beforeValidation', () ->
+    hooks = null
+
+    before () ->
+      hooks = new Hooks()
+      hooks.beforeValidation 'beforeValidationHook', () ->
+        ""
+
+    it 'should add to hook collection', () ->
+      assert.property hooks.beforeValidationHooks, 'beforeValidationHook'
+
   describe '#after', () ->
     hooks = null
 
@@ -107,6 +118,18 @@ describe 'Hooks', () ->
     it 'should add to hook collection', () ->
       assert.lengthOf hooks.beforeEachHooks, 1
 
+  describe '#beforeEachValidation', () ->
+    hooks = null
+
+    before () ->
+      hooks = new Hooks()
+      hooks.beforeEachValidation () ->
+        ""
+
+    it 'should add to hook collection', () ->
+      assert.lengthOf hooks.beforeEachValidationHooks, 1
+
+
   describe '#afterEach', () ->
     hooks = null
 
@@ -143,6 +166,7 @@ describe 'Hooks', () ->
         'beforeEachHooks'
         'afterEachHooks'
         'afterAllHooks'
+        'beforeEachValidationHooks'
       ]
 
       for property in properties then do (property) ->
@@ -163,6 +187,7 @@ describe 'Hooks', () ->
       properties = [
         'beforeHooks'
         'afterHooks'
+        'beforeValidationHooks'
       ]
 
       for property in properties then do (property) ->

--- a/test/unit/sandbox-hooks-code-test.coffee
+++ b/test/unit/sandbox-hooks-code-test.coffee
@@ -42,6 +42,8 @@ describe 'sandboxHooksCode(hooksCode, callback)', () ->
       'afterAll'
       'beforeEach'
       'afterEach'
+      'beforeEachValidation'
+      'beforeValidation'
     ]
 
     for name in functions then do (name) ->
@@ -70,6 +72,8 @@ describe 'sandboxHooksCode(hooksCode, callback)', () ->
       'afterHooks'
       'afterEachHooks'
       'afterAllHooks'
+      'beforeValidationHooks'
+      'beforeEachValidationHooks'
     ]
 
     for property in properties then do (property) ->
@@ -85,6 +89,8 @@ describe 'sandboxHooksCode(hooksCode, callback)', () ->
         after('Transaction Name', dummyFunc);
         beforeEach(dummyFunc);
         afterEach(dummyFunc);
+        beforeEachValidation(dummyFunc);
+        beforeValidation('Transaction Name', dummyFunc);
         """
 
         sandboxHooksCode hooksCode, (err, result) ->


### PR DESCRIPTION
Making @nevir's work in  #223 even more excellent.

Introducing `beforeValidation` and `beforeEachValidation` hooks in standard and sandboxed mode. These hooks are executed after `Receive HTTP response` and before `Perform Gavel validation` in [Dredd's execution lifecycle](http://dredd.readthedocs.org/en/latest/usage/#dredd-execution-lifecycle)

Closes #221 and #223 

Workaround for #194 