### PR TITLE
Adding pretty JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "advisable": "~0.2.0",
     "async": "^0.9.x",
+    "blueprint-transactions": "^0.0.2",
     "chai": "^2.1.0",
     "clone": "^1.0.0",
     "coffee-script": "^1.9.1",
@@ -34,13 +35,13 @@
     "node-uuid": "~1.4.2",
     "optimist": "~0.6.1",
     "pitboss-ng": "^0.3.1",
+    "prettyjson": "^1.1.3",
     "proxyquire": "~1.4.x",
     "request": "^2.53.0",
     "setimmediate": "^1.0.2",
     "spawn-sync": "^1.0.11",
     "uri-template": "~1.0.0",
-    "winston": "^1.0.0",
-    "blueprint-transactions": "^0.0.2"
+    "winston": "^1.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.12.0",


### PR DESCRIPTION
- addition of [prettyjson](https://github.com/rafeca/prettyjson) to `src/prettyify-response.coffee` so that body and schema objects that are of content type `application/json' are easier to read
- update to how we check content type, since types such as `application/json; charset=utf-8` are valid we should not do an exact match on `application/json` and instead do an indexOf
- allowing `schemaBody` to be passed through prettyjson along with `schema`
