### PR TITLE
Quick fix for the reporters issue #263

### DIFF
--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -174,11 +174,11 @@ class DreddCommand
         @_processExit(2)
 
       # Ensure server is not running when dredd exits prematurely somewhere
-      process.on 'beforeExit', () ->
+      process.on 'beforeExit', () =>
         @serverProcess.kill('SIGKILL') if @serverProcess?
 
       # Ensure server is not running when dredd exits prematurely somewhere
-      process.on 'exit', () ->
+      process.on 'exit', () =>
         @serverProcess.kill('SIGKILL') if @serverProcess?
 
       waitSecs = parseInt(@argv['server-wait'], 10)

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -60,8 +60,8 @@ handler.stderr.on 'data', (data) ->
   console.log "Hook handler stderr:", data.toString()
 
 handler.on 'close', (status) ->
-  console.log "Hook handler exited with status: #{status}"
-  if status != 0
+  console.log "Hook handler closed with status: #{status}"
+  if status? and status != 0
     hooks.processExit 2
 
 handler.on 'error', (error) ->


### PR DESCRIPTION
This really is more of a workaround rather than proper fix. Dredd needs
to refactor and rework of the language hooks handling, especially
graceful stopping as `SIGKILL` is definitely not the way to go.