### PR TITLE
On Travis CI use iojs-2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
+  - "iojs-v2.5.0"
 
 sudo: false
 


### PR DESCRIPTION
Protagonist has issues building on iojs > 3.0.0 see. https://github.com/apiaryio/protagonist/issues/81