### PR TITLE
Apiary reporter not throwing anymore, only passing error to callback

### DIFF
--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -46,23 +46,22 @@ class Dredd
     @configuration = applyConfiguration(config, @stats)
     @configuration.options ?= {}
 
+    @compiledTransactions = {}
+
     @runner = new Runner @configuration
     configureReporters @configuration, @stats, @tests, @runner
 
   run: (callback) ->
-    config = @configuration
-    stats = @stats
 
-    configDataIsEmpty = true
+    @configDataIsEmpty = true
 
-    config.files ?= []
-    config.data ?= {}
-    runtimes = {}
+    @configuration.files ?= []
+    @configuration.data ?= {}
 
     passedConfigData = {}
 
-    for own key, val of config.data or {}
-      configDataIsEmpty = false
+    for own key, val of @configuration.data or {}
+      @configDataIsEmpty = false
       if (typeof val is 'string')
         passedConfigData[key] = {
           filename: key
@@ -74,157 +73,176 @@ class Dredd
           raw: val.raw
         }
 
-    if not configDataIsEmpty
-      config.data = passedConfigData
+    if not @configDataIsEmpty
+      @configuration.data = passedConfigData
 
     # remove duplicate paths
-    config.options.path = removeDuplicates config.options.path
-
-    # expand all globs
-    expandGlobs = (cb) ->
-      async.each config.options.path, (globToExpand, globCallback) ->
-        if /^http(s)?:\/\//.test globToExpand
-          config.files = config.files.concat globToExpand
-          return globCallback()
-        glob globToExpand, (err, match) ->
-          globCallback err if err
-          config.files = config.files.concat match
-          globCallback()
-
-      , (err) ->
-        return callback(err, stats) if err
-
-        if configDataIsEmpty and config.files.length == 0
-          return callback({message: "Blueprint file or files not found on path: '#{config.options.path}'"}, stats)
-
-        # remove duplicate filenames
-        config.files = removeDuplicates config.files
-        cb()
-
-    # load all files
-    loadFiles = (cb) ->
-      # 6 parallel connections is a standard limit when connecting to one hostname,
-      # use the same limit of parallel connections for reading/downloading files
-      async.eachLimit config.files, 6, (fileUrlOrPath, loadCallback) ->
-        try
-          fileUrl = url.parse fileUrlOrPath
-        catch
-          fileUrl = null
-
-        if fileUrl and fileUrl.protocol in ['http:', 'https:'] and fileUrl.host
-          downloadFile fileUrlOrPath, loadCallback
-        else
-          readLocalFile fileUrlOrPath, loadCallback
-
-      , (err) ->
-        return callback(err, stats) if err
-        cb()
-
-    downloadFile = (fileUrl, downloadCallback) ->
-      request.get
-        url: fileUrl
-        timeout: 5000
-        json: false
-      , (downloadError, res, body) ->
-        if downloadError
-          downloadCallback {
-            message: "Error when loading file from URL '#{fileUrl}'. Is the provided URL correct?"
-          }
-        else if not body or res.statusCode < 200 or res.statusCode >= 300
-          downloadCallback {
-            message: """
-            Unable to load file from URL '#{fileUrl}'. \
-            Server did not send any blueprint back and responded with status code #{res.statusCode}.
-            """
-          }
-        else
-          config.data[fileUrl] = {raw: body, filename: fileUrl}
-          downloadCallback()
-
-    readLocalFile = (filePath, readCallback) ->
-      fs.readFile filePath, 'utf8', (readingError, data) ->
-        return readCallback(readingError) if readingError
-        config.data[filePath] = {raw: data, filename: filePath}
-        readCallback()
-
-    # parse all file blueprints
-    parseBlueprints = (cb) ->
-      async.each Object.keys(config.data), (file, parseCallback) ->
-        drafter = new Drafter
-        drafter.make config.data[file]['raw'], (drafterError, result) ->
-          return parseCallback drafterError if drafterError
-          config.data[file]['parsed'] = result
-          parseCallback()
-      , (err) ->
-        return callback(err, config.reporter) if err
-        # log all parser warnings for each ast
-        for file, data of config.data
-          result = data['parsed']
-          if result['warnings'].length > 0
-            for warning in result['warnings']
-              message = "Parser warning in file '#{file}':"  + ' (' + warning.code + ') ' + warning.message
-              ranges = blueprintUtils.warningLocationToRanges warning['location'], data['raw']
-              if ranges?.length
-                pos = blueprintUtils.rangesToLinesText ranges
-                message = message + ' on ' + pos
-              logger.warn message
-
-
-        runtimes['warnings'] = []
-        runtimes['errors'] = []
-        runtimes['transactions'] = []
-
-        # extract http transactions for each ast
-        for file, data of config.data
-          runtime = blueprintTransactions.compile data['parsed']['ast'], file
-
-          runtimes['warnings'] = runtimes['warnings'].concat(runtime['warnings'])
-          runtimes['errors'] = runtimes['errors'].concat(runtime['errors'])
-          runtimes['transactions'] = runtimes['transactions'].concat(runtime['transactions'])
-
-        runtimeError = handleRuntimeProblems runtimes
-        return callback(runtimeError, stats) if runtimeError
-        cb()
-
-    # start the runner
-    startRunner = =>
-      # dredd can have registered more than one reporter
-      reporterCount = config.emitter.listeners('start').length
-
-      # atomic state shared between reporters
-      reporterErrorOccurred = false
-
-      # when event start is emitted, function in callback is executed for each registered reporter by listeners
-      config.emitter.emit 'start', config.data, (reporterError) =>
-        reporterCount--
-
-        # if any error in one of reporters occurres, callback is called and other reporters are not executed
-        if reporterError and reporterErrorOccurred? and reporterErrorOccurred is false
-          reporterErrorOccurred = true
-          return callback(reporterError)
-
-        # last called reporter callback function starts the runner
-        if reporterCount is 0 and reporterErrorOccurred? and reporterErrorOccurred is false
-          # run all transactions
-          @runner.config(config)
-          @runner.run runtimes['transactions'], =>
-            @transactionsComplete(callback)
+    @configuration.options.path = removeDuplicates @configuration.options.path
 
     # spin that merry-go-round
-    expandGlobs ->
-      loadFiles ->
-        parseBlueprints ->
-          startRunner()
+    @expandGlobs (globsErr) =>
+      return callback(globsErr, @stats) if globsErr
+
+      @loadFiles (loadErr) =>
+        return callback(loadErr, @stats) if loadErr
+
+        @parseBlueprints (parseErr) =>
+          return callback(parseErr, @stats) if parseErr
+
+          @compileTransactions (compileErr) =>
+            return callback(compileErr, @stats) if compileErr
+
+            @emitStart (emitStartErr) =>
+              return callback(emitStartErr, @stats) if emitStartErr
+
+              @startRunner (runnerErr) =>
+                return callback(runnerErr, @stats) if runnerErr
+
+                @transactionsComplete(callback)
+
+  # expand all globs
+  expandGlobs: (callback) ->
+    async.each @configuration.options.path, (globToExpand, globCallback) =>
+      if /^http(s)?:\/\//.test globToExpand
+        @configuration.files = @configuration.files.concat globToExpand
+        return globCallback()
+      glob globToExpand, (err, match) =>
+        globCallback err if err
+        @configuration.files = @configuration.files.concat match
+        globCallback()
+
+    , (err) =>
+      return callback(err, @stats) if err
+
+      if @configDataIsEmpty and @configuration.files.length == 0
+        return callback({message: "Blueprint file or files not found on path: '#{@configuration.options.path}'"}, @stats)
+
+      # remove duplicate filenames
+      @configuration.files = removeDuplicates @configuration.files
+      callback(null, @stats)
+
+  # load all files
+  loadFiles: (callback) ->
+    # 6 parallel connections is a standard limit when connecting to one hostname,
+    # use the same limit of parallel connections for reading/downloading files
+    async.eachLimit @configuration.files, 6, (fileUrlOrPath, loadCallback) =>
+      try
+        fileUrl = url.parse fileUrlOrPath
+      catch
+        fileUrl = null
+
+      if fileUrl and fileUrl.protocol in ['http:', 'https:'] and fileUrl.host
+        @downloadFile fileUrlOrPath, loadCallback
+      else
+        @readLocalFile fileUrlOrPath, loadCallback
+
+    , (err) ->
+      return callback(err, @stats) if err
+      callback()
+
+  downloadFile: (fileUrl, callback) ->
+    request.get
+      url: fileUrl
+      timeout: 5000
+      json: false
+    , (downloadError, res, body) =>
+      if downloadError
+        callback {
+          message: "Error when loading file from URL '#{fileUrl}'. Is the provided URL correct?"
+        }, @stats
+      else if not body or res.statusCode < 200 or res.statusCode >= 300
+        callback {
+          message: """
+          Unable to load file from URL '#{fileUrl}'. \
+          Server did not send any blueprint back and responded with status code #{res.statusCode}.
+          """
+        }, @stats
+      else
+        @configuration.data[fileUrl] = {raw: body, filename: fileUrl}
+        callback(null, @stats)
+
+  readLocalFile: (filePath, callback) ->
+    fs.readFile filePath, 'utf8', (readingError, data) =>
+      return readCallback(readingError) if readingError
+      @configuration.data[filePath] = {raw: data, filename: filePath}
+      callback(null, @stats)
+
+  # parse all file blueprints
+  parseBlueprints: (callback) ->
+    async.each Object.keys(@configuration.data), (file, parseCallback) =>
+      drafter = new Drafter
+      drafter.make @configuration.data[file]['raw'], (drafterError, result) =>
+        return parseCallback drafterError if drafterError
+        @configuration.data[file]['parsed'] = result
+        parseCallback()
+    , (err) =>
+      return callback(err, @stats) if err
+      # log all parser warnings for each ast
+      for file, data of @configuration.data
+        result = data['parsed']
+        if result['warnings'].length > 0
+          for warning in result['warnings']
+            message = "Parser warning in file '#{file}':"  + ' (' + warning.code + ') ' + warning.message
+            ranges = blueprintUtils.warningLocationToRanges warning['location'], data['raw']
+            if ranges?.length
+              pos = blueprintUtils.rangesToLinesText ranges
+              message = message + ' on ' + pos
+            logger.warn message
+
+      callback(null, @stats)
 
 
 
-  transactionsComplete: (callback) =>
-    stats = @stats
+  # compile transcations from asts
+  compileTransactions: (callback) ->
+    @compiledTransactions['warnings'] = []
+    @compiledTransactions['errors'] = []
+    @compiledTransactions['transactions'] = []
+
+    # extract http transactions for each ast
+    for file, data of @configuration.data
+      transactions = blueprintTransactions.compile data['parsed']['ast'], file
+
+      @compiledTransactions['warnings'] = @compiledTransactions['warnings'].concat(transactions['warnings'])
+      @compiledTransactions['errors'] = @compiledTransactions['errors'].concat(transactions['errors'])
+      @compiledTransactions['transactions'] = @compiledTransactions['transactions'].concat(transactions['transactions'])
+
+    runtimeError = handleRuntimeProblems @compiledTransactions
+    return callback(runtimeError, @stats) if runtimeError
+    callback(null, @stats)
+
+  # start the runner
+  emitStart: (callback) ->
+    # dredd can have registered more than one reporter
+    reporterCount = @configuration.emitter.listeners('start').length
+
+    # atomic state shared between reporters
+    reporterErrorOccurred = false
+
+    # when event start is emitted, function in callback is executed for each registered reporter by listeners
+    @configuration.emitter.emit 'start', @configuration.data, (reporterError) =>
+      reporterCount--
+
+      # if any error in one of reporters occurres, callback is called and other reporters are not executed
+      if reporterError and reporterErrorOccurred is false
+        reporterErrorOccurred = true
+        return callback(reporterError, @stats)
+
+      # # last called reporter callback function starts the runner
+      if reporterCount is 0 and reporterErrorOccurred is false
+        callback null, @stats
+
+  startRunner: (callback) ->
+    # run all transactions
+    @runner.config(@configuration)
+    @runner.run @compiledTransactions['transactions'], callback
+
+  transactionsComplete: (callback) ->
     reporterCount = @configuration.emitter.listeners('end').length
-    @configuration.emitter.emit 'end', ->
+    @configuration.emitter.emit 'end', =>
       reporterCount--
       if reporterCount is 0
-        callback(null, stats)
+        callback(null, @stats)
 
 module.exports = Dredd
 module.exports.options = options

--- a/src/reporters/apiary-reporter.coffee
+++ b/src/reporters/apiary-reporter.coffee
@@ -106,19 +106,18 @@ class ApiaryReporter
 
       @_performRequestAsync path, 'POST', data, (error, response, parsedBody) =>
         if error
-          callback(error)
+          return callback(error)
         else
           @remoteId = parsedBody['_id']
           @reportUrl = parsedBody['reportUrl'] if parsedBody['reportUrl']
-
           callback()
 
     _createStep = (test, callback) =>
       return callback() if @serverError == true
       data = @_transformTestToReporter test
       path = '/apis/' + @configuration['apiSuite'] + '/tests/steps?testRunId=' + @remoteId
-      @_performRequest path, 'POST', data, (error, response, parsedBody) ->
-        logger.error error if error
+      @_performRequestAsync path, 'POST', data, (error, response, parsedBody) ->
+        return callback(error) if error
         callback()
 
     emitter.on 'test pass', _createStep
@@ -144,8 +143,8 @@ class ApiaryReporter
         }
 
       path = '/apis/' + @configuration['apiSuite'] + '/tests/steps?testRunId=' + @remoteId
-      @_performRequest path, 'POST', data, (error, response, parsedBody) ->
-        logger.error error if error
+      @_performRequestAsync path, 'POST', data, (error, response, parsedBody) ->
+        return callback(error) if error
         callback()
 
     emitter.on 'end', (callback) =>
@@ -158,8 +157,8 @@ class ApiaryReporter
 
       path = '/apis/' + @configuration['apiSuite'] + '/tests/run/' + @remoteId
 
-      @_performRequest path, 'PATCH', data, (error, response, parsedBody) =>
-        logger.error error if error
+      @_performRequestAsync path, 'PATCH', data, (error, response, parsedBody) =>
+        return callback(error) if error
         reportUrl = @reportUrl || "https://app.apiary.io/#{@configuration.apiSuite}/tests/run/#{@remoteId}"
         logger.complete "See results in Apiary at: #{reportUrl}"
         callback()
@@ -193,93 +192,10 @@ class ApiaryReporter
 
     return data
 
-  # To be deprecated
-  # Will be replaced by _performRequestAsync (now implemented only for start event handler)
-  _performRequest: (path, method, body, callback) =>
-    buffer = ""
-
-    handleRequest = (res) =>
-      res.setEncoding 'utf8'
-
-      res.on 'data', (chunk) =>
-        if @verbose
-          logger.log 'REST Reporter HTTPS Response chunk: ' + chunk
-        buffer = buffer + chunk
-
-      res.on 'error', (error) =>
-        if @verbose
-          logger.log 'REST Reporter HTTPS Response error.'
-        return callback error, req, res
-
-      res.on 'end', =>
-        if @verbose
-          logger.log 'Rest Reporter Response ended'
-
-        try
-          parsedBody = JSON.parse buffer
-        catch e
-          throw new Error("Apiary reporter: Failed to JSON parse Apiary API response body: \n #{buffer}")
-
-
-        if @verbose
-          info =
-            headers: res.headers
-            statusCode: res.statusCode
-            body: parsedBody
-          logger.log 'Rest Reporter Response:', JSON.stringify(info, null, 2)
-
-        return callback(undefined, res, parsedBody)
-
-    parsedUrl = url.parse @configuration['apiUrl']
-    system = os.type() + ' ' + os.release() + '; ' + os.arch()
-
-    options =
-      host: parsedUrl['hostname']
-      port: parsedUrl['port']
-      path: path
-      method: method
-      headers:
-        'User-Agent': "Dredd REST Reporter/" + packageConfig['version'] + " (" + system + ")"
-        'Content-Type': 'application/json'
-
-    unless @configuration['apiToken'] == null
-      options.headers['Authentication'] = 'Token ' + @configuration['apiToken']
-
-    if @verbose
-      info =
-        options: options
-        body: body
-      logger.log 'Rest Reporter Request:', JSON.stringify(info, null, 2)
-
-    handleReqError = (error) =>
-      @serverError = true
-      if CONNECTION_ERRORS.indexOf(error.code) > -1
-        logger.error "Apiary reporter: Error connecting to Apiary test reporting API."
-        callback()
-      else
-        return callback error, req, null
-
-    if @configuration.apiUrl?.indexOf('https') is 0
-      if @verbose
-        logger.log 'Starting REST Reporter HTTPS Request'
-      req = https.request options, handleRequest
-
-      req.on 'error', handleReqError
-
-    else
-      if @verbose
-        logger.log 'Starting REST Reporter HTTP Response'
-      req = http.request options, handleRequest
-
-      req.on 'error', handleReqError
-
-    req.write JSON.stringify body
-    req.end()
-
   _performRequestAsync: (path, method, body, callback) =>
     buffer = ""
 
-    handleRequest = (res) =>
+    handleResponse = (res) =>
       res.setEncoding 'utf8'
 
       res.on 'data', (chunk) =>
@@ -299,7 +215,7 @@ class ApiaryReporter
         try
           parsedBody = JSON.parse buffer
         catch e
-          callback new Error("Apiary reporter: Failed to JSON parse Apiary API response body: \n #{buffer}")
+          return callback new Error("Apiary reporter: Failed to JSON parse Apiary API response body: \n #{buffer}")
 
 
         if @verbose
@@ -314,6 +230,8 @@ class ApiaryReporter
     parsedUrl = url.parse @configuration['apiUrl']
     system = os.type() + ' ' + os.release() + '; ' + os.arch()
 
+    postData = JSON.stringify body
+
     options =
       host: parsedUrl['hostname']
       port: parsedUrl['port']
@@ -322,6 +240,7 @@ class ApiaryReporter
       headers:
         'User-Agent': "Dredd REST Reporter/" + packageConfig['version'] + " (" + system + ")"
         'Content-Type': 'application/json'
+        'Content-Length': Buffer.byteLength(postData, 'utf8')
 
     unless @configuration['apiToken'] == null
       options.headers['Authentication'] = 'Token ' + @configuration['apiToken']
@@ -335,26 +254,25 @@ class ApiaryReporter
     handleReqError = (error) =>
       @serverError = true
       if CONNECTION_ERRORS.indexOf(error.code) > -1
-        logger.error "Apiary reporter: Error connecting to Apiary test reporting API."
-        callback()
+        return callback "Apiary reporter: Error connecting to Apiary test reporting API."
       else
         return callback error, req, null
 
     if @configuration.apiUrl?.indexOf('https') is 0
       if @verbose
         logger.log 'Starting REST Reporter HTTPS Request'
-      req = https.request options, handleRequest
+      req = https.request options, handleResponse
 
       req.on 'error', handleReqError
 
     else
       if @verbose
         logger.log 'Starting REST Reporter HTTP Response'
-      req = http.request options, handleRequest
+      req = http.request options, handleResponse
 
       req.on 'error', handleReqError
 
-    req.write JSON.stringify body
+    req.write postData
     req.end()
 
 module.exports = ApiaryReporter

--- a/test/integration/cli-test.coffee
+++ b/test/integration/cli-test.coffee
@@ -287,7 +287,8 @@ describe "Command line interface", () ->
           server2 = apiary.listen (PORT+1), ->
             env = clone process.env
             env['APIARY_API_URL'] = "http://127.0.0.1:#{PORT+1}"
-            execCommand cmd, {env}, () ->
+            execCommand cmd, {env}, (error, stdout, stderr, exitStatus) ->
+
               server2.close ->
                 server.close ->
 

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -157,11 +157,16 @@ describe "Dredd class Integration", () ->
 
       server = app.listen PORT, () ->
         server2 = apiary.listen (PORT+1), ->
+
+          #Comment out this timeout to enable race condition bug
+          setTimeout () ->
+            undefined
+          , 100
+
           execCommand cmd, () ->
             server2.close ->
-              server.close ->
-
-      server.on 'close', done
+              server.close () ->
+                done()
 
     it 'should not print warning about missing APIARY_API_KEY and APIARY_API_NAME', () ->
       assert.notInclude stderr, 'Apiary reporter environment variable APIARY_API_KEY or APIARY_API_NAME not defined.'
@@ -185,7 +190,6 @@ describe "Dredd class Integration", () ->
       assert.deepProperty receivedRequest, 'resultData.result.body.validator'
       assert.deepProperty receivedRequest, 'resultData.result.headers.validator'
       assert.deepProperty receivedRequest, 'resultData.result.statusCode.validator'
-
 
       it 'prints out an error message', ->
         assert.notEqual exitStatus, 0

--- a/test/unit/reporters/apiary-reporter-test.coffee
+++ b/test/unit/reporters/apiary-reporter-test.coffee
@@ -151,26 +151,6 @@ describe 'ApiaryReporter', () ->
       nock.cleanAll()
       done()
 
-    describe "_performRequest", () ->
-      describe 'when server is not available', () ->
-        beforeEach () ->
-          nock.enableNetConnect()
-          nock.cleanAll()
-
-        it 'should log human readable message', (done) ->
-          emitter = new EventEmitter
-          apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
-          apiaryReporter._performRequest '/', 'POST', '', () ->
-            assert.ok loggerStub.error.calledWith 'Apiary reporter: Error connecting to Apiary test reporting API.'
-            done()
-
-        it 'should set server error to true', (done) ->
-          emitter = new EventEmitter
-          apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
-          apiaryReporter._performRequest '/', 'POST', '', () ->
-            assert.isTrue apiaryReporter.serverError
-            done()
-
     describe "_performRequestAsync", () ->
       describe 'when server is not available', () ->
         beforeEach () ->

--- a/test/unit/reporters/apiary-reporter-test.coffee
+++ b/test/unit/reporters/apiary-reporter-test.coffee
@@ -171,6 +171,26 @@ describe 'ApiaryReporter', () ->
             assert.isTrue apiaryReporter.serverError
             done()
 
+    describe "_performRequestAsync", () ->
+      describe 'when server is not available', () ->
+        beforeEach () ->
+          nock.enableNetConnect()
+          nock.cleanAll()
+
+        it 'should log human readable message', (done) ->
+          emitter = new EventEmitter
+          apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
+          apiaryReporter._performRequestAsync '/', 'POST', '', (error) ->
+            assert.isNotNull error
+            done()
+
+        it 'should set server error to true', (done) ->
+          emitter = new EventEmitter
+          apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
+          apiaryReporter._performRequestAsync '/', 'POST', '', () ->
+            assert.isTrue apiaryReporter.serverError
+            done()
+
 
     describe 'when starting', () ->
       call = null


### PR DESCRIPTION
Introducing _performRequestAsync to return callback filled with an error instead of fatal error in Apiary reporter.

Introduced change is triggered by need of assertion failure just after reporter start.