### PR TITLE
WIP: Use Protagonist instead of Drafter.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "advisable": "~0.2.0",
     "async": "^0.9.x",
+    "blueprint-transactions": "^0.0.2",
     "chai": "^2.1.0",
     "clone": "^1.0.0",
     "coffee-script": "^1.9.1",
-    "drafter": "~0.2.5",
     "file": "~0.2.2",
     "gavel": "0.5.2",
     "glob": "^5.0.3",
@@ -34,13 +34,13 @@
     "node-uuid": "~1.4.2",
     "optimist": "~0.6.1",
     "pitboss-ng": "^0.3.1",
+    "protagonist": "^1.0.0",
     "proxyquire": "~1.4.x",
     "request": "^2.53.0",
     "setimmediate": "^1.0.2",
     "spawn-sync": "^1.0.11",
     "uri-template": "~1.0.0",
-    "winston": "^1.0.0",
-    "blueprint-transactions": "^0.0.2"
+    "winston": "^1.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.12.0",

--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -3,7 +3,7 @@ require 'setimmediate'
 
 glob = require 'glob'
 fs = require 'fs'
-Drafter = require 'drafter'
+protagonist = require 'protagonist'
 async = require 'async'
 request = require 'request'
 url = require 'url'
@@ -170,9 +170,8 @@ class Dredd
   # parse all file blueprints
   parseBlueprints: (callback) ->
     async.each Object.keys(@configuration.data), (file, parseCallback) =>
-      drafter = new Drafter
-      drafter.make @configuration.data[file]['raw'], (drafterError, result) =>
-        return parseCallback drafterError if drafterError
+      protagonist.parse @configuration.data[file]['raw'], (parseError, result) =>
+        return parseCallback parseError if parseError
         @configuration.data[file]['parsed'] = result
         parseCallback()
     , (err) =>

--- a/src/reporters/apiary-reporter.coffee
+++ b/src/reporters/apiary-reporter.coffee
@@ -171,7 +171,7 @@ class ApiaryReporter
     returnedData.filename = blueprintData.filename
 
     returnedData.parsed =
-      # omit parsed.ast, it might change in future (depends heavily on protagonist/drafter versions)
+      # omit parsed.ast, it might change in future (depends heavily on protagonist version)
       _version: blueprintData.parsed._version
       warnings: clone blueprintData.parsed.warnings
       error: blueprintData.parsed.error

--- a/test/unit/blueprint-ast-to-runtime-test.coffee
+++ b/test/unit/blueprint-ast-to-runtime-test.coffee
@@ -1,5 +1,5 @@
 {assert} = require 'chai'
-Drafter = require 'drafter'
+protagonist = require 'protagonist'
 fs = require 'fs'
 
 blueprintAstToRuntime = require '../../src/blueprint-ast-to-runtime'
@@ -193,9 +193,8 @@ describe "blueprintAstToRuntime()", () ->
     before (done) ->
       filename = './test/fixtures/arbitrary-action.md'
       code = fs.readFileSync(filename).toString()
-      drafter = new Drafter
-      drafter.make code, (drafterError, result) ->
-        done(drafterError) if drafterError
+      protagonist.parse code, (parseError, result) ->
+        done(parseError) if parseError
         transactions = blueprintAstToRuntime(result['ast'], filename)['transactions']
         done()
 
@@ -211,5 +210,3 @@ describe "blueprintAstToRuntime()", () ->
 
     it 'second (arbitrary) action should have its method', ->
       assert.equal transactions[1].request.method, 'GET'
-
-

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -5,14 +5,14 @@ bodyParser = require 'body-parser'
 express = require 'express'
 
 fsStub = require 'fs'
-DrafterClassStub = require 'drafter'
+protagonistStub = require 'protagonist'
 requestStub = require 'request'
 loggerStub = require '../../src/logger'
 
 blueprintTransactionsStub = require 'blueprint-transactions'
 
 Dredd = proxyquire '../../src/dredd', {
-  'drafter': DrafterClassStub
+  'protagonist': protagonistStub
   'request': requestStub
   'blueprint-transactions': blueprintTransactionsStub
   'fs': fsStub
@@ -25,11 +25,11 @@ describe 'Dredd class', () ->
   dredd = {}
 
   beforeEach () ->
-    sinon.spy DrafterClassStub::, 'make'
+    sinon.spy protagonistStub, 'parse'
     sinon.spy fsStub, 'readFile'
 
   afterEach () ->
-    DrafterClassStub::make.restore()
+    protagonistStub.parse.restore()
     fsStub.readFile.restore()
 
   describe 'with legacy configuration', () ->
@@ -88,7 +88,7 @@ describe 'Dredd class', () ->
       sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
-        assert.ok DrafterClassStub::make.called
+        assert.ok protagonistStub.parse.called
         dredd.runner.executeTransaction.restore()
         done()
 
@@ -645,5 +645,3 @@ describe 'Dredd class', () ->
           done()
 
         dredd.emitStart callback
-
-

--- a/test/unit/utils-test.coffee
+++ b/test/unit/utils-test.coffee
@@ -1,6 +1,6 @@
 {assert} = require 'chai'
 
-Drafter = require 'drafter'
+protagonist = require 'protagonist'
 blueprintUtils = require '../../src/blueprint-utils'
 
 describe 'blueprintUtils', () ->
@@ -55,8 +55,7 @@ describe 'blueprintUtils', () ->
 
               ok indentation
       """
-      drafter = new Drafter
-      drafter.make blueprint, (err, results) ->
+      protagonist.parse blueprint, (err, results) ->
         return done err if err
         assert.isObject results
         assert.property results, 'warnings'
@@ -122,8 +121,7 @@ describe 'blueprintUtils', () ->
 
                 yup!
         """
-        drafter = new Drafter
-        drafter.make blueprint, (err, results) ->
+        protagonist.parse blueprint, (err, results) ->
           warnings = results.warnings or []
           ranges = (blueprintUtils.warningLocationToRanges(warn.location, blueprint) for warn in warnings)
           done err
@@ -142,4 +140,3 @@ describe 'blueprintUtils', () ->
           generatedLine = blueprintUtils.rangesToLinesText ranges[lineIndex]
           assert.isString expectedLine
           assert.strictEqual generatedLine, expectedLine
-


### PR DESCRIPTION
Drafter.js is now deprecated, and has been replaced by Protagonist.

This commit is just a naive replacement of `new Drafter().make` with `protagonist.parse` for parsing the API Blueprint documents.
A lot of tests are currently failing, so probably the output of the two methods are not compatible.