### PR TITLE
Add supported php versions to the php hook docs

### DIFF
--- a/docs/hooks-php.md
+++ b/docs/hooks-php.md
@@ -8,6 +8,11 @@ PHP hooks are using [Dredd's hooks handler socket interface](hooks-new-language.
 
 ## Installation
 
+### Requirements
+ - php version >= 5.4
+
+Installing dredd-hooks-php can be easily installed through the package manager, composer.
+
 ```
 $ composer require ddelnano/dredd-hooks-php:~1.0.0 --dev 
 ```


### PR DESCRIPTION
Just to make it explicit what versions are supported, as per [this](https://github.com/ddelnano/dredd-hooks-php/pull/8#issuecomment-168834122).