### PR TITLE
Add more hook languages into dredd init

### DIFF
--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -123,6 +123,8 @@ class DreddCommand
           console.log "  $ pip install dredd_hooks"
         else if config['language'] == 'php'
           console.log "  $ composer require ddelnano/dredd-hooks-php:~1.0.0 --dev"
+        else if config['language'] == 'perl'
+          console.log "  $ cpanm Dredd::Hooks"
         else if config['language'] == 'go'
           console.log "  $ go get github.com/snikch/goodman"
 

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -121,6 +121,10 @@ class DreddCommand
           console.log "  $ gem install dredd_hooks"
         else if config['language'] == 'python'
           console.log "  $ pip install dredd_hooks"
+        else if config['language'] == 'php'
+          console.log "  $ composer require ddelnano/dredd-hooks-php:~1.0.0 --dev"
+        else if config['language'] == 'go'
+          console.log "  $ go get github.com/snikch/goodman"
 
         console.log "  $ dredd"
         console.log ""

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -37,6 +37,14 @@ else if language == 'python'
     console.log "$ pip install dredd_hooks"
     hooks.processExit 1
 
+else if language == 'php'
+  handlerCommand = 'dredd-hooks-php'
+  unless which.which handlerCommand
+    console.log "PHP hooks handler server command not found: #{handlerCommand}"
+    console.log "Install php hooks handler by running:"
+    console.log "$ composer require ddelnano/dredd-hooks-php:~1.0.0 --dev"
+    hooks.processExit 1
+
 else if language == 'nodejs'
   throw new Error 'Hooks handler should not be used for nodejs. Use Dredds\' native node hooks instead'
 else

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -45,6 +45,14 @@ else if language == 'php'
     console.log "$ composer require ddelnano/dredd-hooks-php:~1.0.0 --dev"
     hooks.processExit 1
 
+else if language == 'perl'
+  handlerCommand = 'dredd-hooks-perl'
+  unless which.which handlerCommand
+    console.log "Perl hooks handler server command not found: #{handlerCommand}"
+    console.log "Install perl hooks handler by running:"
+    console.log "$ cpanm Dredd::Hooks"
+    hooks.processExit 1
+
 else if language == 'nodejs'
   throw new Error 'Hooks handler should not be used for nodejs. Use Dredds\' native node hooks instead'
 else

--- a/src/interactive-config.coffee
+++ b/src/interactive-config.coffee
@@ -36,6 +36,8 @@ interactiveConfig.prompt = (config = {}, callback) ->
       "ruby"
       "python"
       "nodejs"
+      "php"
+      "go"
     ]
   }
 

--- a/src/interactive-config.coffee
+++ b/src/interactive-config.coffee
@@ -37,6 +37,7 @@ interactiveConfig.prompt = (config = {}, callback) ->
       "python"
       "nodejs"
       "php"
+      "perl"
       "go"
     ]
   }

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -11,7 +11,7 @@ options =
 
   language:
     alias: "a"
-    description: "Language of hookfiles. Possible options are: nodejs, ruby, python, php, go"
+    description: "Language of hookfiles. Possible options are: nodejs, ruby, python, php, perl, go"
     default: "nodejs"
 
   sandbox:

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -11,7 +11,7 @@ options =
 
   language:
     alias: "a"
-    description: "Language of hookfiles. Possible options are: nodejs, ruby, python"
+    description: "Language of hookfiles. Possible options are: nodejs, ruby, python, php, go"
     default: "nodejs"
 
   sandbox:

--- a/test/unit/dredd-command-test.coffee
+++ b/test/unit/dredd-command-test.coffee
@@ -254,7 +254,7 @@ describe "DreddCommand class", () ->
       it 'prints out version', ->
         assert.include stdout, "#{packageJson.name} v#{packageJson.version}"
 
-    describe '"init"', ->
+    describe '"init" (nodejs)', ->
       before (done) ->
         sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
           cb({language: 'nodejs'})
@@ -272,7 +272,7 @@ describe "DreddCommand class", () ->
       it 'should save configuration', ->
         assert.isTrue configUtilsStub.save.called
 
-    describe '"init"', ->
+    describe '"init" (python)', ->
       before (done) ->
         sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
           cb({language: 'python'})
@@ -291,7 +291,7 @@ describe "DreddCommand class", () ->
         assert.isTrue configUtilsStub.save.called
 
 
-    describe '"init"', ->
+    describe '"init" (php)', ->
       before (done) ->
         sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
           cb({language: 'php'})
@@ -309,7 +309,7 @@ describe "DreddCommand class", () ->
       it 'should save configuration', ->
         assert.isTrue configUtilsStub.save.called
 
-    describe '"init"', ->
+    describe '"init" (perl)', ->
       before (done) ->
         sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
           cb({language: 'perl'})

--- a/test/unit/dredd-command-test.coffee
+++ b/test/unit/dredd-command-test.coffee
@@ -309,6 +309,24 @@ describe "DreddCommand class", () ->
       it 'should save configuration', ->
         assert.isTrue configUtilsStub.save.called
 
+    describe '"init"', ->
+      before (done) ->
+        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+          cb({language: 'perl'})
+        sinon.stub configUtilsStub, 'save'
+        execCommand argv: ['init'], ->
+          done()
+
+      after () ->
+        interactiveConfigStub.run.restore()
+        configUtilsStub.save.restore()
+
+      it 'should run interactive config', ->
+        assert.isTrue interactiveConfigStub.run.called
+
+      it 'should save configuration', ->
+        assert.isTrue configUtilsStub.save.called
+
     describe 'without argv', ->
       before (done) ->
         execCommand argv: [], ->

--- a/test/unit/dredd-command-test.coffee
+++ b/test/unit/dredd-command-test.coffee
@@ -272,6 +272,43 @@ describe "DreddCommand class", () ->
       it 'should save configuration', ->
         assert.isTrue configUtilsStub.save.called
 
+    describe '"init"', ->
+      before (done) ->
+        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+          cb({language: 'python'})
+        sinon.stub configUtilsStub, 'save'
+        execCommand argv: ['init'], ->
+          done()
+
+      after () ->
+        interactiveConfigStub.run.restore()
+        configUtilsStub.save.restore()
+
+      it 'should run interactive config', ->
+        assert.isTrue interactiveConfigStub.run.called
+
+      it 'should save configuration', ->
+        assert.isTrue configUtilsStub.save.called
+
+
+    describe '"init"', ->
+      before (done) ->
+        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+          cb({language: 'php'})
+        sinon.stub configUtilsStub, 'save'
+        execCommand argv: ['init'], ->
+          done()
+
+      after () ->
+        interactiveConfigStub.run.restore()
+        configUtilsStub.save.restore()
+
+      it 'should run interactive config', ->
+        assert.isTrue interactiveConfigStub.run.called
+
+      it 'should save configuration', ->
+        assert.isTrue configUtilsStub.save.called
+
     describe 'without argv', ->
       before (done) ->
         execCommand argv: [], ->


### PR DESCRIPTION
By http://dredd.readthedocs.org/en/latest/ are PHP, Go available in Dredd but missing in `dredd init`