### PR TITLE
Regression tests for #354

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node-uuid": "~1.4.2",
     "optimist": "~0.6.1",
     "pitboss-ng": "^0.3.1",
-    "protagonist": "1.2.6",
+    "protagonist": "1.3.0-pre.0",
     "proxyquire": "~1.7.x",
     "request": "^2.53.0",
     "setimmediate": "^1.0.2",

--- a/test/fixtures/regression-319-354.apib
+++ b/test/fixtures/regression-319-354.apib
@@ -10,8 +10,7 @@ FORMAT: 1A
     + id
     + name (string, required)
     + colors: red, brown (array)
-    + dimensions (array)
-        + 20, 30, 40 (array[number])
+    + Include DimensionsMixin
 
 ### Get Particular Brick Type [GET]
 
@@ -40,16 +39,16 @@ Attributes defined as data structure are referenced from payload.
 
 + Request (application/json)
 + Response 200 (application/json; charset=utf-8)
-    + Attributes (array[User])
+    + Attributes (array[Customer])
 
 ### Add New Customer [POST]
 
 Attributes defined as data structure are referenced from action.
 
-+ Attributes (User)
++ Attributes (Customer)
 + Request (application/json)
 + Response 200 (application/json; charset=utf-8)
-    + Attributes (User)
+    + Attributes (Customer)
 
 ## Data Structures
 
@@ -58,6 +57,18 @@ Attributes defined as data structure are referenced from action.
 + id
 + name (string)
 + shoeSize: 42 (number)
+
+### Customer (User)
+
++ Include AddressMixin
+
+### AddressMixin (object)
+
 + address
     + street
     + city (string, nullable)
+
+### DimensionsMixin (object)
+
++ dimensions (array)
+    + 20, 30, 40 (array[number])

--- a/test/fixtures/regression-319-354.apib
+++ b/test/fixtures/regression-319-354.apib
@@ -11,6 +11,8 @@ FORMAT: 1A
     + name (string, required)
     + colors: red, brown (array)
     + Include DimensionsMixin
+    + producer
+        + Include ProducerMixin
 
 ### Get Particular Brick Type [GET]
 
@@ -67,6 +69,8 @@ Attributes defined as data structure are referenced from action.
 + address
     + street
     + city (string, nullable)
+
+### ProducerMixin (AddressMixin)
 
 ### DimensionsMixin (object)
 

--- a/test/regressions/regression-319-354-test.coffee
+++ b/test/regressions/regression-319-354-test.coffee
@@ -67,7 +67,7 @@ parseOutput = (output) ->
   return results
 
 
-describe 'Regression: Issue #319', ->
+describe 'Regression: Issues #319 and #354', ->
   results = undefined
 
   brickTypePayload =
@@ -135,7 +135,7 @@ describe 'Regression: Issue #319', ->
 
       # Spinning up the Express server, running Dredd, and saving results
       server = app.listen PORT, ->
-        runDredd './test/fixtures/regression-319.apib', (err, result) ->
+        runDredd './test/fixtures/regression-319-354.apib', (err, result) ->
           results = parseOutput result.stdout
           server.close done
 
@@ -219,7 +219,7 @@ describe 'Regression: Issue #319', ->
 
       # Spinning up the Express server, running Dredd, and saving results
       server = app.listen PORT, ->
-        runDredd './test/fixtures/regression-319.apib', (err, result) ->
+        runDredd './test/fixtures/regression-319-354.apib', (err, result) ->
           results = parseOutput result.stdout
           server.close done
 

--- a/test/regressions/regression-319-354-test.coffee
+++ b/test/regressions/regression-319-354-test.coffee
@@ -75,6 +75,10 @@ describe 'Regression: Issues #319 and #354', ->
     name: ''
     colors: ['red', 'brown']
     dimensions: [[20, 30, 40]]
+    producer:
+      address:
+        city: null
+        street: ''
 
   brickTypeSchema =
     $schema: 'http://json-schema.org/draft-04/schema#'
@@ -84,6 +88,14 @@ describe 'Regression: Issues #319 and #354', ->
       name: {type: 'string'}
       colors: {type: 'array'}
       dimensions: {type: 'array'}
+      producer:
+        type: 'object'
+        properties:
+          address:
+            type: 'object'
+            properties:
+              city: {type: ['string', 'null']}
+              street: {type: 'string'}
     required: ['name']
 
   userPayload =
@@ -116,7 +128,7 @@ describe 'Regression: Issues #319 and #354', ->
     type: 'array'
 
   describe 'Tested app is consistent with the API description', ->
-    before (done) ->
+    beforeEach (done) ->
       app = express()
 
       # Attaching endpoint for each testing scenario
@@ -200,7 +212,7 @@ describe 'Regression: Issues #319 and #354', ->
       page: 1
       items: [incorrectUserPayload]
 
-    before (done) ->
+    beforeEach (done) ->
       app = express()
 
       # Attaching endpoint for each testing scenario


### PR DESCRIPTION
This Pull Request introduces tests for #354. Until these tests pass with some version of Protagonist, https://github.com/apiaryio/protagonist/issues/133 can't be considered as resolved.

I created Data Structure, which uses the `Include` statement. I test several combinations of where the Data Structure is defined and from where it is referenced. Following table displays which combinations properly generate JSON and JSON Schema assets when using Protagonist `v1.3.0-pre.0`:

| :open_mouth: | Defined in Resource | Defined as Data Structure |
|---|---|---|
| **Referenced from Payload** | JSON Schema: :heavy_multiplication_x: JSON: :heavy_multiplication_x: | JSON Schema: :heavy_check_mark: JSON: :heavy_check_mark: |
| **Referenced from Action**  | JSON Schema: :heavy_multiplication_x: JSON: :heavy_multiplication_x: | JSON Schema: :heavy_check_mark: JSON: :heavy_check_mark: |

See also https://github.com/apiaryio/dredd/issues/354#issuecomment-188705444 for further details.

-----------

**Update:** Per request in https://github.com/apiaryio/drafter/issues/248#issuecomment-194731665, there is now minimal app reproducing the bug:

### https://github.com/apiaryio/protagonist-include-issue