### PR TITLE
Making sure Travis CI uses the latest npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
   - "4"
   - "5"
 before_install:
+  - "npm -g install npm@latest"
   - "gem install travis"
 before_script:
   - "npm run lint"


### PR DESCRIPTION
This is mainly to get rid of the annoying deprecation warnings in the Travis CI output:

<img width="779" alt="screen shot 2016-02-27 at 13 24 07" src="https://cloud.githubusercontent.com/assets/283441/13372840/7017da2e-dd55-11e5-83d5-fb5e2bbac208.png">
