### PR TITLE
Fix coverage collection in bin/dredd

### DIFF
--- a/bin/dredd
+++ b/bin/dredd
@@ -2,7 +2,8 @@
 
 var fs = require('fs');
 
-var DreddCommand = require('../lib/dredd-command');
+var dir = process.env.COLLECT_COVERAGE ? 'src' : 'lib';
+var DreddCommand = require('../' + dir + '/dredd-command');
 
 
 var dreddCli = new DreddCommand({


### PR DESCRIPTION
The bf94183d9f introduced environment variable and merged `bin/dredd` and `bin/dredd-coverage`, which is cool, but I forgot to deal with different directories to require code from.

**This fixes collecting of coverage.**

<img width="522" alt="screen shot 2016-03-02 at 15 27 15" src="https://cloud.githubusercontent.com/assets/283441/13463161/4bc0f78a-e08b-11e5-8c4c-46449caed305.png">
