### PR TITLE
Hotfix of setCommandAndCheckForExecutables

### DIFF
--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -92,6 +92,8 @@ class HooksWorkerClient
         """
         error = new Error msg
         return callback(error)
+      else
+        callback()
 
     else if @language == 'python'
       @handlerCommand = 'dredd-hooks-python'
@@ -103,9 +105,11 @@ class HooksWorkerClient
         """
         error = new Error msg
         return callback(error)
+      else
+        callback()
 
     else if @language == 'php'
-      handlerCommand = 'dredd-hooks-php'
+      @handlerCommand = 'dredd-hooks-php'
       unless which.which @handlerCommand
         msg = """ \
           PHP hooks handler server command not found: #{@handlerCommand}
@@ -114,9 +118,11 @@ class HooksWorkerClient
         """
         error = new Error msg
         return callback(error)
+      else
+        callback()
 
     else if @language == 'perl'
-      handlerCommand = 'dredd-hooks-perl'
+      @handlerCommand = 'dredd-hooks-perl'
       unless which.which @handlerCommand
         msg = """ \
           Perl hooks handler server command not found: #{@handlerCommand}
@@ -125,6 +131,8 @@ class HooksWorkerClient
         """
         error = new Error msg
         return callback(error)
+      else
+        callback()
 
     else if @language == 'nodejs'
       msg = ''' \
@@ -140,7 +148,6 @@ class HooksWorkerClient
         msg = "Hooks handler server command not found: #{@handlerCommand}"
         error = new Error msg
         return callback(error)
-
       else
         callback()
 

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -123,9 +123,7 @@ describe 'Hooks worker client', ->
             language: 'ruby'
             hookfiles: "somefile.rb"
 
-        sinon.stub HooksWorkerClient.prototype, 'setCommandAndCheckForExecutables' , (callback) ->
-          @handlerCommand = 'dredd-hooks-ruby'
-          callback()
+        sinon.stub whichStub, 'which', (command) -> true
 
         sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
           callback()
@@ -135,7 +133,7 @@ describe 'Hooks worker client', ->
 
         runner.hooks['configuration'] = undefined
 
-        HooksWorkerClient.prototype.setCommandAndCheckForExecutables.restore()
+        whichStub.which.restore()
         HooksWorkerClient.prototype.terminateHandler.restore()
 
       it 'should spawn the server process with command "dredd-hooks-ruby"', (done) ->
@@ -189,9 +187,7 @@ describe 'Hooks worker client', ->
             language: 'python'
             hookfiles: "somefile.py"
 
-        sinon.stub HooksWorkerClient.prototype, 'setCommandAndCheckForExecutables' , (callback) ->
-          @handlerCommand = 'dredd-hooks-python'
-          callback()
+        sinon.stub whichStub, 'which', (command) -> true
 
         sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
           callback()
@@ -201,7 +197,7 @@ describe 'Hooks worker client', ->
 
         runner.hooks['configuration'] = undefined
 
-        HooksWorkerClient.prototype.setCommandAndCheckForExecutables.restore()
+        whichStub.which.restore()
         HooksWorkerClient.prototype.terminateHandler.restore()
 
       it 'should spawn the server process with command "dredd-hooks-python"', (done) ->
@@ -254,9 +250,7 @@ describe 'Hooks worker client', ->
             language: 'php'
             hookfiles: "somefile.py"
 
-        sinon.stub HooksWorkerClient.prototype, 'setCommandAndCheckForExecutables' , (callback) ->
-          @handlerCommand = 'dredd-hooks-php'
-          callback()
+        sinon.stub whichStub, 'which', (command) -> true
 
         sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
           callback()
@@ -266,7 +260,7 @@ describe 'Hooks worker client', ->
 
         runner.hooks['configuration'] = undefined
 
-        HooksWorkerClient.prototype.setCommandAndCheckForExecutables.restore()
+        whichStub.which.restore()
         HooksWorkerClient.prototype.terminateHandler.restore()
 
       it 'should spawn the server process with command "dredd-hooks-php"', (done) ->
@@ -319,9 +313,7 @@ describe 'Hooks worker client', ->
             language: 'perl'
             hookfiles: "somefile.py"
 
-        sinon.stub HooksWorkerClient.prototype, 'setCommandAndCheckForExecutables' , (callback) ->
-          @handlerCommand = 'dredd-hooks-perl'
-          callback()
+        sinon.stub whichStub, 'which', (command) -> true
 
         sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
           callback()
@@ -331,7 +323,7 @@ describe 'Hooks worker client', ->
 
         runner.hooks['configuration'] = undefined
 
-        HooksWorkerClient.prototype.setCommandAndCheckForExecutables.restore()
+        whichStub.which.restore()
         HooksWorkerClient.prototype.terminateHandler.restore()
 
       it 'should spawn the server process with command "dredd-hooks-perl"', (done) ->
@@ -427,9 +419,7 @@ describe 'Hooks worker client', ->
         sinon.stub HooksWorkerClient.prototype, 'spawnHandler' , (callback) ->
           callback()
 
-        sinon.stub HooksWorkerClient.prototype, 'setCommandAndCheckForExecutables' , (callback) ->
-          @handlerCommand = 'dredd-hooks-ruby'
-          callback()
+        sinon.stub whichStub, 'which', (command) -> true
 
         sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
           callback()
@@ -446,7 +436,7 @@ describe 'Hooks worker client', ->
       afterEach ->
         runner.hooks['configuration'] = undefined
 
-        HooksWorkerClient.prototype.setCommandAndCheckForExecutables.restore()
+        whichStub.which.restore()
         HooksWorkerClient.prototype.terminateHandler.restore()
         HooksWorkerClient.prototype.spawnHandler.restore()
 


### PR DESCRIPTION
Method setCommandAndCheckForExecutables was stubbed in tests and was never executed, although in real world it is executed every time someone uses hooks. Since for different hook languages different parts of the method are summoned, it was easy for many if/else branches to slip through error/trials or tests.

Due to this it was possible that it contained a lot of typos and errors, such as callbacks being never called or missing 'this'.

I believe this fixes #404, fixes #393 and possibly it could be also a solution for #384, but so far I can't be sure yet.