### PR TITLE
Update all local occurences of `localhost` in docs

### DIFF
--- a/docs/hooks-new-language.md
+++ b/docs/hooks-new-language.md
@@ -4,7 +4,7 @@
 
 Dredd comes with concept of hooks language abstraction bridge via simple TCP socket.
 
-When you run Dredd with `--language` argument, it runs the command in argument and tries to connect to localhost port `61321`. If connection to the hook handling server wasn't successful, it exits with exit code `3`.
+When you run Dredd with `--language` argument, it runs the command in argument and tries to connect to `http://localhost:61321`. If connection to the hook handling server wasn't successful, it exits with exit code `3`.
 
 Dredd internally registers a function for each [type of hooks](hooks.md#types-of-hooks) and when this function is executed it assigns execution `uuid` to that event, serializes received function parameters (a [Transaction object](hooks.md#transaction-object-structure) or an Array of it), sends it to the TCP socket to be handled (executed) in other language and waits until message with same `uuid` is received. After data reception it assigns received `data` back to the transaction, so other language can interact with transactions same way like [native Node.js hooks](hooks-nodejs.md).
 
@@ -34,7 +34,7 @@ If you want to write a hook handler for your language you will have to implement
     - it exposes API similar to those in [Ruby](hooks-ruby.md), [Python](hooks-python.md) and [Node.js](hooks-nodejs.md) to each loaded file
     - it registers functions declared in files for later execution
 
-  - starts a TCP socket server and starts listening on localhost port `61321`.
+  - starts a TCP socket server and starts listening on `http://localhost:61321`.
 
 - When any data is received by the server
   - Adds every received character to a buffer

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -87,7 +87,7 @@ In this case, you will have to write a `before` hook for adding a database fixtu
 First, retrieve the transaction names.
 
 ```
-dredd blueprint.md localhost:3000 --names
+dredd blueprint.md http://localhost:3000 --names
 info: Categories > Create a category
 info: Category > Delete a category
 info: Category Items > Create an item
@@ -164,7 +164,7 @@ FORMAT: 1A
 Retrieve transactions names with:
 
 ```
-$ dredd blueprint.md localhost:3000 --names
+$ dredd blueprint.md http://localhost:3000 --names
 info: /login > POST
 info: /cars > GET
 info: /cars/{id} > PATCH
@@ -329,7 +329,7 @@ If you need to use different URI address for each example, you can [modify trans
 Dredd will compile following transaction names:
 
 ```
-$ dredd blueprint.md localhost --names
+$ dredd blueprint.md http://localhost --names
 info: Beginning Dredd testing...
 info: Resource > Update resource > Example 1
 info: Resource > Update resource > Example 2


### PR DESCRIPTION
Fixes #425

Just a quick fix for `docs`. My method of action was to `grep` through the `docs` dir, and look for all instances of `localhost`. I did a quick replace to prepend `http://` to anywhere that localhost was used, but didn't have `http://`. I read this issue as only being relevant to the `docs` dir, so I left the `src` dir alone--though there are some instances of just `localhost` in there as well.  I ran `mkdocs serve` and things looked good. Let me know if this is what you were looking for. Thanks! Apiary rocks. :metal: 