### PR TITLE
Remove 'setimmediate' shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "protagonist": "1.3.0",
     "proxyquire": "~1.7.x",
     "request": "^2.53.0",
-    "setimmediate": "^1.0.2",
     "spawn-args": "^0.1.0",
     "spawn-sync": "^1.0.11",
     "uri-template": "~1.0.0",

--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -1,6 +1,3 @@
-# faking setImmediate for node < 0.9
-require 'setimmediate'
-
 glob = require 'glob'
 fs = require 'fs'
 protagonist = require 'protagonist'


### PR DESCRIPTION
Node 0.9 isn't supported by Dredd anymore. The shim isn't needed.