### PR TITLE
Remove supported Node versions from docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,9 +3,6 @@
 - If you don't have [Node.js](https://nodejs.org/) installed, you may want to use [NVM](https://github.com/creationix/nvm)
 - Create an [API blueprint](https://apiblueprint.org/) in `apiary.apib`
 
-**Note:** Dredd works smoothly with node.js ~0.8.15, 0.10.x, 0.12.x
-and iojs v1.x.x. Support for node.js 4.x.x is on the way.
-
 ```
 # GET /message
 + Response 200 (text/plain)


### PR DESCRIPTION
I already removed similar paragraphs from index.md and README.md, this slipped through the net. We support all recent versions of Node and we will always strive to do so. I consider such information redundant and hard to maintain in docs. If somebody wants to know, I'm okay with replying individually and sending them to CI config as a source of truth.