### PR TITLE
Slimmer NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
-node_modules
-CHANGELOG-Generated.md
+# Distributed code (source code lives in /src)
 /lib
-/src-cov
-/lcov
-cov.info
-cov.html
+
+# Common for .gitignore and .npmignore
+CHANGELOG-Generated.md
+src-cov/
+lcov/
+site/
+cov.*
 .vagrant
-*.DS_Store
-/.idea
-/npm-debug.log
-/site
+*.log
+
+# List specific to .gitignore
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,30 @@
-src/
-.travis.yml
-HISTORY-Dredd.md
-.git*
+# Source code (distributed code lives in /lib)
+/src
+
+# Common for .gitignore and .npmignore
+CHANGELOG-Generated.md
+src-cov/
+lcov/
+site/
+cov.*
 .vagrant
+*.log
+
+# List specific to .npmignore
+.travis.yml
 .npmignore
+docs/
+img/
+test/
+scripts/
+mkdocs.yml
+provisioning.sh
+coffeelint.json
+Vagrantfile
+*.apib
+*.md
+
+# Regardless the rules above, never ignore following
+!LICENSE
+!README.md
+!CHANGELOG.md


### PR DESCRIPTION
The package includes unnecessary stuff. That makes it harder to publish Dredd to npm on less reliable networks.