### PR TITLE
Redirect /usage to /usage-cli

### DIFF
--- a/docs/usage.html
+++ b/docs/usage.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<!--
+    This file exists only to redirect from old URL to new URL.
+    This is more properly done using an HTTP redirect, but unfortunately
+    readthedocs.org's page redirection is broken (see
+    https://github.com/rtfd/readthedocs.org/issues/1826). Once that bug is
+    fixed, the file can be removed.
+-->
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0;url=usage-cli/">
+        <script type="text/javascript">
+            window.location.href = 'usage-cli/' + window.location.hash
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <p>
+            The page for Dredd usage no longer exists. Please follow one
+            of the following links:
+        </p>
+        <ul>
+            <li><a href="usage-cli/">CLI usage</a></li>
+            <li><a href="usage-js/">JavaScript usage</a></li>
+        </ul>
+    </body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,3 +30,11 @@ theme: readthedocs
 markdown_extensions:
   - toc:
       permalink: true
+
+# These extra_templates exists only to redirect from old URLs to new URLs.
+# This is more properly done using an HTTP redirect, but unfortunately
+# readthedocs.org's page redirection is broken (see
+# https://github.com/rtfd/readthedocs.org/issues/1826). Once that bug is fixed,
+# these files can be removed.
+extra_templates:
+  - usage.html


### PR DESCRIPTION
Attempt to address #467 by @borsboom's workaround from https://github.com/rtfd/readthedocs.org/issues/1826#issuecomment-214753550. I think it will work for `/usage.html`, but I don't know how to do the same for `/usage/`.