### PR TITLE
Moving readthedocs.org to .io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ immediately during coding.
 The main documentation is written in [Markdown][] using [MkDocs][]. Dredd uses
 [ReadTheDocs][] to build and publish the documentation:
 
-- https://dredd.readthedocs.org/ - preferred long URL
+- https://dredd.readthedocs.io/ - preferred long URL
 - http://dredd.rtfd.org/ - preferred short URL
 
 Source of the documentation can be found in the [docs][] directory. To contribute to Dredd's documentation, you will need to follow the [MkDocs installation instructions](http://www.mkdocs.org/#installation). Once installed, you may use following commands:

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ documentation.
 
 ### Supported Hooks Languages
 
-Dredd supports writing [hooks](http://dredd.readthedocs.io/en/latest/hooks/)
+Dredd supports writing [hooks](https://dredd.readthedocs.io/en/latest/hooks/)
 — a glue code for each test setup and teardown. Following languages are supported:
 
-- [Go](http://dredd.readthedocs.io/en/latest/hooks-go/)
-- [Node.js (JavaScript)](http://dredd.readthedocs.io/en/latest/hooks-nodejs/)
-- [Perl](http://dredd.readthedocs.io/en/latest/hooks-perl/)
-- [PHP](http://dredd.readthedocs.io/en/latest/hooks-php/)
-- [Python](http://dredd.readthedocs.io/en/latest/hooks-python/)
-- [Ruby](http://dredd.readthedocs.io/en/latest/hooks-ruby/)
+- [Go](https://dredd.readthedocs.io/en/latest/hooks-go/)
+- [Node.js (JavaScript)](https://dredd.readthedocs.io/en/latest/hooks-nodejs/)
+- [Perl](https://dredd.readthedocs.io/en/latest/hooks-perl/)
+- [PHP](https://dredd.readthedocs.io/en/latest/hooks-php/)
+- [Python](https://dredd.readthedocs.io/en/latest/hooks-python/)
+- [Ruby](https://dredd.readthedocs.io/en/latest/hooks-ruby/)
 - Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.io/en/latest/hooks-new-language/)_
 
 ### Continuous Integration Support
@@ -69,7 +69,7 @@ $ npm install -g dredd
 [API Blueprint tutorial]: https://apiblueprint.org/documentation/tutorial.html
 [API Blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
 
-[Documentation]: http://dredd.readthedocs.io/en/latest/
+[Documentation]: https://dredd.readthedocs.io/en/latest/
 [Changelog]: CHANGELOG.md
 [Contributor's Guidelines]: CONTRIBUTING.md
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ documentation.
 
 ### Supported Hooks Languages
 
-Dredd supports writing [hooks](http://dredd.readthedocs.org/en/latest/hooks/)
+Dredd supports writing [hooks](http://dredd.readthedocs.io/en/latest/hooks/)
 — a glue code for each test setup and teardown. Following languages are supported:
 
-- [Go](http://dredd.readthedocs.org/en/latest/hooks-go/)
-- [Node.js (JavaScript)](http://dredd.readthedocs.org/en/latest/hooks-nodejs/)
-- [Perl](http://dredd.readthedocs.org/en/latest/hooks-perl/)
-- [PHP](http://dredd.readthedocs.org/en/latest/hooks-php/)
-- [Python](http://dredd.readthedocs.org/en/latest/hooks-python/)
-- [Ruby](http://dredd.readthedocs.org/en/latest/hooks-ruby/)
-- Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.org/en/latest/hooks-new-language/)_
+- [Go](http://dredd.readthedocs.io/en/latest/hooks-go/)
+- [Node.js (JavaScript)](http://dredd.readthedocs.io/en/latest/hooks-nodejs/)
+- [Perl](http://dredd.readthedocs.io/en/latest/hooks-perl/)
+- [PHP](http://dredd.readthedocs.io/en/latest/hooks-php/)
+- [Python](http://dredd.readthedocs.io/en/latest/hooks-python/)
+- [Ruby](http://dredd.readthedocs.io/en/latest/hooks-ruby/)
+- Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.io/en/latest/hooks-new-language/)_
 
 ### Continuous Integration Support
 
@@ -69,7 +69,7 @@ $ npm install -g dredd
 [API Blueprint tutorial]: https://apiblueprint.org/documentation/tutorial.html
 [API Blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
 
-[Documentation]: http://dredd.readthedocs.org/en/latest/
+[Documentation]: http://dredd.readthedocs.io/en/latest/
 [Changelog]: CHANGELOG.md
 [Contributor's Guidelines]: CONTRIBUTING.md
 

--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -8,14 +8,14 @@ $ dredd apiary.apib http://localhost:30000 --hookfiles=./hooks*.js
 
 ## API Reference
 
-- For `before`, `after`, `beforeValidation`, `beforeEach`, `afterEach` and `beforeEachValidation` a [Transaction Object](https://dredd.readthedocs.org/en/latest/hooks/#transaction-object-structure) is passed as the first argument to the hook function.
+- For `before`, `after`, `beforeValidation`, `beforeEach`, `afterEach` and `beforeEachValidation` a [Transaction Object](https://dredd.readthedocs.io/en/latest/hooks/#transaction-object-structure) is passed as the first argument to the hook function.
 - An array of Transaction Objects is passed to `beforeAll` and `afterAll`.
 - The second argument is an optional callback function for async execution.
 - Any modifications on the `transaction` object are propagated to the actual HTTP transactions.
 - You can use `hooks.log` function inside the hook function to print
   yours debug messages and other information.
 
-- [`configuration`](https://dredd.readthedocs.org/en/latest/usage/#configuration-object-for-dredd-class) object is populated on the `hooks` object
+- [`configuration`](https://dredd.readthedocs.io/en/latest/usage/#configuration-object-for-dredd-class) object is populated on the `hooks` object
 
 ### Sync API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,15 +18,15 @@ documentation.
 
 ### Supported Hooks Languages
 
-Dredd supports writing [hooks](http://dredd.readthedocs.io/en/latest/hooks/)
+Dredd supports writing [hooks](https://dredd.readthedocs.io/en/latest/hooks/)
 — a glue code for each test setup and teardown. Following languages are supported:
 
-- [Go](http://dredd.readthedocs.io/en/latest/hooks-go/)
-- [Node.js (JavaScript)](http://dredd.readthedocs.io/en/latest/hooks-nodejs/)
-- [Perl](http://dredd.readthedocs.io/en/latest/hooks-perl/)
-- [PHP](http://dredd.readthedocs.io/en/latest/hooks-php/)
-- [Python](http://dredd.readthedocs.io/en/latest/hooks-python/)
-- [Ruby](http://dredd.readthedocs.io/en/latest/hooks-ruby/)
+- [Go](https://dredd.readthedocs.io/en/latest/hooks-go/)
+- [Node.js (JavaScript)](https://dredd.readthedocs.io/en/latest/hooks-nodejs/)
+- [Perl](https://dredd.readthedocs.io/en/latest/hooks-perl/)
+- [PHP](https://dredd.readthedocs.io/en/latest/hooks-php/)
+- [Python](https://dredd.readthedocs.io/en/latest/hooks-python/)
+- [Ruby](https://dredd.readthedocs.io/en/latest/hooks-ruby/)
 - Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.io/en/latest/hooks-new-language/)_
 
 ### Continuous Integration Support

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,16 +18,16 @@ documentation.
 
 ### Supported Hooks Languages
 
-Dredd supports writing [hooks](http://dredd.readthedocs.org/en/latest/hooks/)
+Dredd supports writing [hooks](http://dredd.readthedocs.io/en/latest/hooks/)
 — a glue code for each test setup and teardown. Following languages are supported:
 
-- [Go](http://dredd.readthedocs.org/en/latest/hooks-go/)
-- [Node.js (JavaScript)](http://dredd.readthedocs.org/en/latest/hooks-nodejs/)
-- [Perl](http://dredd.readthedocs.org/en/latest/hooks-perl/)
-- [PHP](http://dredd.readthedocs.org/en/latest/hooks-php/)
-- [Python](http://dredd.readthedocs.org/en/latest/hooks-python/)
-- [Ruby](http://dredd.readthedocs.org/en/latest/hooks-ruby/)
-- Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.org/en/latest/hooks-new-language/)_
+- [Go](http://dredd.readthedocs.io/en/latest/hooks-go/)
+- [Node.js (JavaScript)](http://dredd.readthedocs.io/en/latest/hooks-nodejs/)
+- [Perl](http://dredd.readthedocs.io/en/latest/hooks-perl/)
+- [PHP](http://dredd.readthedocs.io/en/latest/hooks-php/)
+- [Python](http://dredd.readthedocs.io/en/latest/hooks-python/)
+- [Ruby](http://dredd.readthedocs.io/en/latest/hooks-ruby/)
+- Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.io/en/latest/hooks-new-language/)_
 
 ### Continuous Integration Support
 


### PR DESCRIPTION
Closes #472.