### PR TITLE
Making sure transaction.request.body is used only if really present

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -514,7 +514,7 @@ class TransactionRunner
         @configuration.emitter.emit 'test error', error, test, () ->
         return callback()
 
-      req.write transaction.request['body'] if transaction.request['body'] != ''
+      req.write(transaction.request.body) if transaction.request.body
       req.end()
     catch error
       test.title = transaction.id


### PR DESCRIPTION
Making this change per @ddelnano's findings in https://github.com/snikch/goodman/pull/5#issuecomment-222054192.