### PR TITLE
Update docs and hooks worker client for go hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cov.*
 
 # List specific to .gitignore
 node_modules
+.idea/

--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -11,7 +11,7 @@ Go hooks are using [Dredd's hooks handler socket interface](hooks-new-language.m
 ```
 $ go get github.com/snikch/goodman
 $ cd $GOPATH/src/github.com/snikch/goodman
-$ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/bin
+$ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
 ```
 
 ## Usage

--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -168,7 +168,7 @@ func main() {
         t.Fail = true
     })
     h.Before("Machines > Machines collection > Post  Machines", func(t *trans.Transaction) {
-        t.Fail = "Post is broken"
+        t.Fail = "POST is broken"
     })
     server.Serve()
     defer server.Listener.Close()

--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -16,7 +16,7 @@ $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
 
 ## Usage
 
-Using Dredd with Go is slightly different to other languages, as a binary needs to be compiled for execution. The --hookfiles flags will be compiled hook binaries.  See below for an example hooks.go file to get an idea of what this would look like.
+Using Dredd with Go is slightly different to other languages, as a binary needs to be compiled for execution. The --hookfiles flags should point to compiled hook binaries.  See below for an example hooks.go file to get an idea of what the source file behind the go binary would look like.
 
 ```
 $ dredd apiary.apib http://localhost:3000 --server ./go-lang-web-server-to-test --language go --hookfiles ./hook-file-binary

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -139,7 +139,7 @@ class HooksWorkerClient
       unless which.which @handlerCommand
         msg = '''\
           Go hooks handler server command not found in $GOPATH/bin
-          Install go hooks handler by running: 
+          Install go hooks handler by running:
           $ go get github.com/snikch/goodman
           $ cd $GOPATH/src/github.com/snikch/goodman
           $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/bin

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -133,6 +133,20 @@ class HooksWorkerClient
       '''
       return callback(new Error(msg))
 
+    else if @language == 'go'
+      gopath = process.env.GOPATH
+      @handlerCommand = "#{gopath}/bin/goodman"
+      unless which.which @handlerCommand
+        msg = '''\
+          Go hooks handler server command not found in $GOPATH/bin
+          Install go hooks handler by running: 
+          $ go get github.com/snikch/goodman
+          $ cd $GOPATH/src/github.com/snikch/goodman
+          $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/bin
+        '''
+        return callback(new Error(msg))
+      else
+        callback()
     else
       @handlerCommand = @language
       unless which.which @handlerCommand

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -142,8 +142,9 @@ class HooksWorkerClient
           Install go hooks handler by running:
           $ go get github.com/snikch/goodman
           $ cd $GOPATH/src/github.com/snikch/goodman
-          $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/bin
+          $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
         '''
+
         return callback(new Error(msg))
       else
         callback()


### PR DESCRIPTION
This PR depends on [this](https://github.com/snikch/goodman/pull/5).  Once that is merged, the go hooks should be considered compliant with the hooks for other languages: php, ruby, python, perl, etc.

I tested the changes with this [repo](https://github.com/ddelnano/dredd-hooks-go-example).  I could not install dredd from a github repo since npm does not run prepublish and the necessary commands to do so I made these commits on my fork and made sure the examples worked.

<img width="782" alt="screen shot 2016-05-31 at 10 58 52 pm" src="https://cloud.githubusercontent.com/assets/5855593/15696950/6532fa62-2783-11e6-975c-5d6b43214794.png">
