### PR TITLE
Add helpful error message if dredd hooks fail to modify transaction

### DIFF
--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -299,7 +299,9 @@ class HooksWorkerClient
       # https://github.com/apiaryio/dredd-hooks-template/blob/master/features/execution_order.feature
       if process.env['TEST_DREDD_HOOKS_HANDLER_ORDER'] == "true"
         console.error 'FOR TESTING ONLY'
-        for mod, index in transactions[0]['hooks_modifications']
+        unless mods = transactions[0]?.hooks_modifications?
+          throw new Error "Hooks must modify transaction.hooks_modifications"
+        for mod, index in mods
           console.error "#{index} #{mod}"
         console.error 'FOR TESTING ONLY'
 


### PR DESCRIPTION
This PR is to address when developing a hooks server from [dredd-hooks-template](https://github.com/apiaryio/dredd-hooks-template/blob/master/features/execution_order.feature#L78-L93).  If the hooks fail to modify the transaction sent back to dredd, it will crash dredd.  This is to present a more helpful error to the hook developer.  I just went through this for the second time (PHP and Go) and it took me a little digging before I realized I wrote the hookfile wrong.

I tried to add a test but it would have been difficult to be able to stub everything to the point where I could trigger the error.  I didn't get to spend enough time wrapping my head around some of the really long tests.