### PR TITLE
Transaction names only for API Blueprint

### DIFF
--- a/test/fixtures/multiple-responses.yml
+++ b/test/fixtures/multiple-responses.yml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Beehive API
+consumes:
+  - application/json
+produces:
+  - application/xml
+  - application/json
+paths:
+  /honey:
+    get:
+      responses:
+        200:
+          description: pet response
+          headers:
+            X-Test:
+              type: string
+              enum:
+                - Adam
+                - Pavan
+          schema:
+            $ref: '#/definitions/Bee'
+        400:
+          description: user error
+        500:
+          description: server error
+definitions:
+  Bee:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -550,3 +550,61 @@ describe "Dredd class Integration", () ->
 
       it 'should execute hook with fuxed name', () ->
         assert.include stderr, 'Fixed transaction name'
+
+  describe('Transaction Examples', ->
+    getRelevantLines = (lines) ->
+      lines
+        .split(/[\n\r]+/)
+        .filter((line) -> line.match(/^info:/) and line.match(/ \> /))
+
+    describe('when there are no transaction examples in given API Blueprint document', ->
+      before((done) ->
+        execCommand(
+          options:
+            path: './test/fixtures/single-get.apib'
+            names: true
+        , done)
+      )
+
+      it('Dredd identifies some transactions', ->
+        assert.isAbove(getRelevantLines(stdout).length, 0)
+      )
+      it('no transaction names contain string \'Example #\'', ->
+        assert.notMatch(line, /Example \d+$/) for line in getRelevantLines(stdout)
+      )
+    )
+
+    describe('when there are multiple transaction examples in given API Blueprint document', ->
+      before((done) ->
+        execCommand(
+          options:
+            path: './test/fixtures/multiple-examples.apib'
+            names: true
+        , done)
+      )
+
+      it('Dredd identifies some transactions', ->
+        assert.isAbove(getRelevantLines(stdout).length, 0)
+      )
+      it('all transaction names contain string \'Example #\'', ->
+        assert.match(line, /Example \d+$/) for line in getRelevantLines(stdout)
+      )
+    )
+
+    describe('when there are multiple responses in given Swagger document', ->
+      before((done) ->
+        execCommand(
+          options:
+            path: './test/fixtures/multiple-responses.yml'
+            names: true
+        , done)
+      )
+
+      it('Dredd identifies some transactions', ->
+        assert.isAbove(getRelevantLines(stdout).length, 0)
+      )
+      it('no transaction names contain string \'Example #\'', ->
+        assert.notMatch(line, /Example \d+$/) for line in getRelevantLines(stdout)
+      )
+    )
+  )


### PR DESCRIPTION
Tests ensuring that transaction examples won't appear in transaction names if Swagger is used.