### PR TITLE
Skipping non 2xx responses by default for Swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clone": "^1.0.0",
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
-    "dredd-transactions": "^1.2.0",
+    "dredd-transactions": "^1.3.1",
     "file": "~0.2.2",
     "gavel": "0.5.2",
     "glob": "^6.0.1",

--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -181,6 +181,7 @@ class Dredd
           warning.type = 'warning'
           fileData.annotations.push(warning)
 
+        fileData.mediaType = compilationResult.mediaType
         @transactions = @transactions.concat(compilationResult.transactions)
         next()
       )

--- a/test/fixtures/multiple-responses.yaml
+++ b/test/fixtures/multiple-responses.yaml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Beehive API
+consumes:
+  - application/json
+produces:
+  - application/xml
+  - application/json
+paths:
+  /honey:
+    get:
+      responses:
+        400:
+          description: user error
+        500:
+          description: server error
+        200:
+          description: pet response
+          headers:
+            X-Test:
+              type: string
+              enum:
+                - Adam
+                - Pavan
+          schema:
+            $ref: '#/definitions/Bee'
+definitions:
+  Bee:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/fixtures/swagger-multiple-responses.js
+++ b/test/fixtures/swagger-multiple-responses.js
@@ -1,0 +1,10 @@
+
+var hooks = require('hooks');
+
+
+hooks.before('/honey > GET', function (transaction, done) {
+  if (transaction.expected.statusCode[0] == '5') {
+    transaction.skip = false;
+  }
+  done();
+});


### PR DESCRIPTION
Skipping non-2xx Swagger transactions by default, user can unskip them in hooks. This is because non-2xx responses for still the same request are not useful in most flows when testing a working server. Unlike API Blueprint, Swagger doesn't have an ability to specify specific request-response pairs, which address the problem.