### PR TITLE
--config option

### DIFF
--- a/docs/usage-cli.md
+++ b/docs/usage-cli.md
@@ -80,6 +80,10 @@ Remember you can always list all available arguments by `dredd --help`.
 Determines whether console output should include colors.  
 **Default value:** `true`
 
+### --config
+Path to dredd.yml config file.  
+**Default value:** `"./dredd.yml"`
+
 ### --custom, -j
 Pass custom key-value configuration data delimited by a colon. E.g. -j 'a:b'  
 **Default value:** `[]`

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -181,10 +181,11 @@ class DreddCommand
       console.log version
       return @_processExit(0)
 
-  loadDreddFile: () ->
-    if fs.existsSync './dredd.yml'
-      logger.info 'Configuration dredd.yml found, ignoring other arguments.'
-      @argv = configUtils.load()
+  loadDreddFile: ->
+    configPath = @argv.config
+    if configPath and fs.existsSync configPath
+      logger.info("Configuration '#{configPath}' found, ignoring other arguments.")
+      @argv = configUtils.load(configPath)
 
     # overwrite saved config with cli arguments
     for key, value of @cliArgv

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -163,4 +163,8 @@ options =
     description: 'Port of the hook worker.'
     default: 61321
 
+  config:
+    description: 'Path to dredd.yml config file.'
+    default: './dredd.yml'
+
 module.exports = options

--- a/test/unit/config-utils-test.coffee
+++ b/test/unit/config-utils-test.coffee
@@ -225,10 +225,3 @@ describe 'configUtils', () ->
       assert.property output, 'customOpt2'
       assert.equal output['customOpt'], 'itsValue:can:contain:delimiters'
       assert.equal output['customOpt2'], 'itsValue'
-
-
-
-
-
-
-


### PR DESCRIPTION
Implemented #339. Needed for https://github.com/apiaryio/dredd-example/ so it is able to pick both API Blueprint and Swagger during one build.


------

**Please ignore AppVeyor, it's not properly set up and actively used yet.**