### PR TITLE
Tests of hooks handlers now report under PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: "trusty"
 language: "node_js"
 env:
   global:
-    - secure: "STxhfQh/AHeyRJgErinjZrjnJDChHKLctjqAUDwiIWcZZonopfB8DNp6DgcCHj6FPCTfcHeWdjQjvOiC6ZZugMcMUwzhi+PdDR4kDVP3GoeaMcKC2ckkdjapcA+mnmJDLF35FjhK6PvR1zpRbwlwiYpIayKHEjdgEzna3RmfRH8="
+    - secure: "io+3qwINOL+43e0qNPOr0oOEoMYUXDJroSGMwVXC4jgPW3YUe10lPRMCr39iEHg9iIOUj30xtqN8nqDdrljVIT1nM4pcrnrCcMegKXZ5dzQYFW0CW3DN06lLHt7K1Kdcah+3fXCSWPwIahns0R/SC/QRedZcOgDhD3KG7gBeoag="
   matrix:
     - "DRAFTER=JS"
     - "DRAFTER=CPP"
@@ -20,6 +20,6 @@ before_script:
 script:
   - "if [[ $DRAFTER = JS ]]; then find ./node_modules -name protagonist -type d -exec rm -rf {} +; fi"
   - "npm test"
-  - "if [[ $DRAFTER = JS && $TRAVIS_PULL_REQUEST = false ]]; then npm run test:hooks-handlers; fi"
+  - "if [[ $DRAFTER = JS ]]; then npm run test:hooks-handlers; fi"
 after_success:
   - "npm run coveralls"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,17 @@ It's default options are in the `test/mocha.opts` file.
 If you experience a flaky test, you can use `npm run test:stress` in combination
 with `describe.only` to try to replicate the flaky behavior.
 
+### Integration Tests of Hooks Handlers
+
+Every Pull Request spawns dependent integration builds of hook handlers. Thanks
+to this author of the PR can be sure they did not break hook handler
+implementations by the changes.
+
+The script `scripts/test-hooks-handlers.coffee` is automatically ran by
+Travis CI in one of the jobs in the build matrix every time the tested commit
+is part of a PR. Head to the [script code][scripts/test-hooks-handlers.coffee]
+to understand how it works. It's thoroughly documented.
+
 ### Linting
 
 Dredd uses [coffeelint][] to lint the CoffeeScript codebase. There is a plan

--- a/scripts/test-hooks-handlers.coffee
+++ b/scripts/test-hooks-handlers.coffee
@@ -1,67 +1,60 @@
-# Spawns dependent integration builds of hook handlers with current Dredd,
-# where 'current Dredd' means whatever is currently in its repository under
-# the last commit on currently active branch.
+# Spawns dependent integration builds of hook handlers for every PR on Dredd
 #
 # Purpose:
-#   Thanks to this we can be sure we did not break hook handler implementations
-#   with a new version of Dredd or with a major refactoring.
+#   Thanks to this we can be sure we did not break hook handler implementations.
 #
 # Usage:
-#   The script is automatically ran by Travis CI in one of the builds in
-#   the build matrix every time the tested commit is tagged:
-#
-#       $ npm version
-#       $ git push origin ... --tags
-#
-#   When testing commits without tag, you can magically trigger these
-#   integration tests by writing 'tests hook handlers' into the commit message:
-#
-#       $ git commit -m 'Fixes everything, closes #123, tests hook handlers.'
-#       $ git push origin ...
+#   The script is automatically ran by Travis CI in one of the jobs in
+#   the build matrix every time the tested commit is part of a PR.
 #
 # How it works:
-#   1. Every time commit is pushed to GitHub, Travis CI automatically starts
-#      a new build.
-#   2. The build is defined by contents of `.travis.yml`. It runs regular tests
+#   1. Every time commit is pushed to GitHub as part of a PR, Travis CI
+#      automatically starts a new 'PR build' (as well as 'push build').
+#   2. The job follows contents of `.travis.yml`. It runs regular tests
 #      and then runs this script, `npm run test:hook-handlers`.
 #   3. This script...
-#       1. makes sure it is ran for just one build job within the build matrix.
-#       2. checks whether hook handler integration tests were triggered or not.
-#          **If the tested commit has tag or its commit message contains words
-#          "tests hook handlers", it continues.** Otherwise it skips the tests
-#          (ends immediately with 0 exit status code).
-#       3. creates special dependent integration branches for each hook handler
+#       1. Makes sure it is ran for just one job within the build matrix.
+#       2. Checks whether hook handler integration tests should be triggered
+#          or not. **If the tested commit is part of PR, it continues.**
+#          Otherwise it skips the tests (ends immediately with 0 exit code).
+#       3. Creates special dependent integration branches for each hook handler
 #          implementation. In these branches, it takes whatever is in master
 #          branch of the hook handler repository with the only difference that
 #          instead of `npm i -g dredd` it links the Dredd from currently tested
 #          commit.
-#       4. pushes these dependent branches to GitHub, which triggers dependent
-#          Travis CI builds.
-#       5. polls for results of the dependent Travis CI builds.
-#       6. evaluates results of dependent builds and if any of them didn't pass,
-#          the script exits with non-zero code.
-#       7. makes sure it deletes the dependent git branches from GitHub before
-#          exiting.
+#       4. Pushes these dependent branches to GitHub, which triggers dependent
+#          Travis CI builds. If dependent build would run in a build matrix,
+#          selects only one language version (with the highest number).
+#       5. Every dependent build informs the PR about the result and if it
+#          passes with success, it deletes its special branch.
 #
 # Known issues:
-#   * If `master` branch of hook handler repository becomes red, this whole
-#     build will fail and we won't be able to release new version of Dredd
-#     (not with green status). Instead, we should integrate with commit
+#   * If the `master` branch of hook handler repository becomes red, this whole
+#     build will fail. Instead, we should integrate with commit
 #     corresponding to the latest release of the hook handler implementation.
-#   * If the main Travis CI build where the script is being ran gets canceled,
-#     the script won't cleanup the dependent branches on GitHub.
+#   * If repository of the hook handler project has something in the `master`
+#     branch which would print the GITHUB_TOKEN environment variable during
+#     the Travis CI build, the token gets disclosed in the corresponding
+#     dependent build output. Preventing this is impossible if we want
+#     to work with GitHub in the dependent build, so as of now we rely
+#     on carefulness and honesty of maintainers of the hook handler repos.
 
-fs = require('fs')
-execSync = require('sync-exec')
-{exec} = require('child_process')
+
 async = require('async')
+execSync = require('sync-exec')
+request = require('request')
 yaml = require('js-yaml')
+
+{exec} = require('child_process')
+fs = require('fs')
 
 
 unless process.env.CI
   console.error('''\
-    This script is meant to be ran on Travis CI. It is not optimized (yet) for
-    local usage. It could mess up your Git repository.
+    Aborting!
+
+    This script is meant to be ran on Travis CI. It is not optimized for local
+    usage. It could mess up your Git repository.
   ''')
   process.exit(1)
 
@@ -73,21 +66,26 @@ unless process.env.CI
 JOBS = [
     name: 'ruby-hooks-handler'
     repo: 'https://github.com/apiaryio/dredd-hooks-ruby.git'
+    matrixName: 'rvm'
   ,
     name: 'python-hooks-handler'
     repo: 'https://github.com/apiaryio/dredd-hooks-python.git'
+    matrixName: 'python'
   ,
     name: 'php-hooks-handler'
     repo: 'https://github.com/ddelnano/dredd-hooks-php.git'
+    matrixName: 'php'
   ,
     name: 'perl-hooks-handler'
     repo: 'https://github.com/ungrim97/Dredd-Hooks.git'
+    matrixName: 'perl'
   ,
     name: 'go-hooks-handler'
     repo: 'https://github.com/snikch/goodman.git'
+    matrixName: 'go'
 ]
 
-TRIGGER_KEYWORD = 'tests hook handlers' # inspired by https://help.github.com/articles/closing-issues-via-commit-messages/
+TRAVIS_CONFIG_FILE = '.travis.yml'
 LINKED_DREDD_DIR = './__dredd__'
 RE_DREDD_INSTALL_CMD = /npm ([ \-=\w]+ )?i(nstall)? ([ \-=\w]+ )?dredd/
 DREDD_LINK_CMD = "npm link --python=python2 #{LINKED_DREDD_DIR}"
@@ -129,46 +127,13 @@ buildFindExcludes = (excludedPaths) ->
 
 # Replaces given pattern with replacement in given file. Returns boolean whether
 # any changes were made.
-replaceInFile = (file, pattern, replacement) ->
-  contents = fs.readFileSync(file, 'utf-8')
-  unless contents.match(pattern)
+replaceDreddInstallation = ->
+  contents = fs.readFileSync(TRAVIS_CONFIG_FILE, 'utf-8')
+  unless contents.match(RE_DREDD_INSTALL_CMD)
     return false
-  contents = contents.replace(pattern, replacement)
-  fs.writeFileSync(file, contents, 'utf-8')
+  contents = contents.replace(RE_DREDD_INSTALL_CMD, DREDD_LINK_CMD)
+  fs.writeFileSync(TRAVIS_CONFIG_FILE, contents, 'utf-8')
   return true
-
-
-# Waits until the latest Travis CI build finishes on given Dredd's Git branch.
-# Provides status in the callback (should be either 'errored' or 'passed', but
-# who knows).
-pollForBuildResult = (branch, callback) ->
-  command = """travis history \
-    --repo apiaryio/dredd \
-    --branch #{branch} \
-    --limit 1 \
-    --no-interactive
-  """
-
-  process.stdout.write('.') # poor man's progress bar
-  exec(command, (err, stdout) ->
-    return callback(err) if err
-
-    status = parseBuildStatus(stdout)
-    if status not in ['created', 'started']
-      return callback(null, status)
-
-    setTimeout( ->
-      pollForBuildResult(branch, callback)
-    , 120000)
-  )
-
-
-# Takes output of 'travis history' command (see
-# https://github.com/travis-ci/travis.rb#history) and parses out build status.
-parseBuildStatus = (stdout) ->
-  stdout = stdout.toString() if Buffer.isBuffer(stdout)
-  match = stdout.match(/^#\d+ (\w+):/)
-  match[1]
 
 
 # Exits the script in case Travis CI CLI isn't installed.
@@ -179,21 +144,21 @@ requireTravisCli = ->
 
 
 # If Git author is empty, sets the commiter of the last commit as an author.
-ensureGitAuthor = ->
-  name = getTrimmedStdout(execSync('git show --format="%cN" -s'))
-  console.log("Setting Git user name to '#{name}'.")
+ensureGitAuthor = (testedCommit) ->
+  name = getTrimmedStdout(execSync('git show --format="%cN" -s ' + testedCommit))
+  console.log("Setting Git user name to '#{name}'")
   execSync("git config user.name '#{name}'")
 
-  email = getTrimmedStdout(execSync('git show --format="%cE" -s'))
-  console.log("Setting Git e-mail to '#{email}'.")
+  email = getTrimmedStdout(execSync('git show --format="%cE" -s ' + testedCommit))
+  console.log("Setting Git e-mail to '#{email}'")
   execSync("git config user.email '#{email}'")
 
 
-# Adds remote origin URL with GitHub token so the script is able to could push
-# to the Dredd repository. GitHub token is encrypted in Dredd's .travis.yml.
+# Adds remote origin URL with GitHub token so the script could push to the Dredd
+# repository. GitHub token is encrypted in Dredd's .travis.yml.
 ensureGitOrigin = ->
   if process.env.GITHUB_TOKEN
-    console.log('Applying GitHub token.')
+    console.log('Applying GitHub token')
     repo = "https://#{process.env.GITHUB_TOKEN}@github.com/apiaryio/dredd.git"
     execSync("git remote set-url origin #{repo} #{DROP_OUTPUT}")
 
@@ -204,19 +169,107 @@ cleanGit = (branch) ->
   execSync('git reset HEAD --hard')
 
 
-# Deletes given branches both locally and remotely on GitHub.
-deleteGitBranches = (branches) ->
-  for branch in branches
-    console.log("Deleting #{branch} from GitHub...")
-    execSync('git branch -D ' + branch)
-    execSync("git push origin -f --delete #{branch} #{DROP_OUTPUT}")
-
-
-# Lists Node versions defined in the .travis.yml config file.
-listTestedNodeVersions = ->
-  contents = fs.readFileSync('.travis.yml')
+# Returns the latest tested Node.js version defined in the .travis.yml
+# config file.
+getLatestTestedNodeVersion = ->
+  contents = fs.readFileSync(TRAVIS_CONFIG_FILE)
   config = yaml.safeLoad(contents)
-  return config.node_js
+
+  versions = config.node_js
+  versions.sort((v1, v2) -> v2 - v1)
+  return versions[0]
+
+
+# Takes Travis config property and prepends its existing value with given value.
+# Takes care of various cases, such as the existing property being already an
+# array, being single value, etc.
+prependToTravisConfigProperty = (config, property, value) ->
+  currentValue = config[property]
+  if currentValue
+    currentValue = [currentValue] unless Array.isArray(currentValue)
+    config[property] = [value].concat(currentValue)
+  else
+    config[property] = [value]
+
+
+# Adjusts dependent build configuration
+#
+# *  Takes language version matrix in the .travis.yml config file and reduces
+#    it to just one language version. It chooses the one which represents
+#    the highest floating point number. If there is no version like that, it
+#    selects the first specified version.
+# *  Removes 'deploy'
+# *  Adds status reporting
+adjustTravisBuildConfig = (pullRequestId, testedCommit, jobName, matrixName) ->
+  if pullRequestId
+    # We will want to report under the Pull Request, so we will need GitHub
+    # token present in the configuration.
+    execSync("""\
+      travis encrypt GITHUB_TOKEN=#{process.env.GITHUB_TOKEN} \
+        --add --append --no-interactive --repo=apiaryio/dredd #{DROP_OUTPUT}
+    """)
+
+  # Read contents of the '.travis.yml' file
+  contents = fs.readFileSync(TRAVIS_CONFIG_FILE)
+  config = yaml.safeLoad(contents)
+
+  # Reduce number of tested versions to just the latest one
+  reduced = config[matrixName].map((version) -> parseFloat(version))
+  reduced.sort((v1, v2) -> v2 - v1)
+  config[matrixName] = "#{reduced[0] or config[matrixName][0]}"
+
+  # Remove any deploy configuration, just to be sure
+  delete config.deploy
+
+  if pullRequestId
+    # Enhance the build configuration so it reports results back to PR and deletes
+    # the branch afterwards.
+    command = createStatusCommand(testedCommit,
+      state: 'pending'
+      description: 'Dependent build created'
+      context: "continuous-integration/travis-ci/#{jobName}"
+      target_url: "https://travis-ci.org/apiaryio/dredd/builds/$TRAVIS_BUILD_ID"
+    )
+    prependToTravisConfigProperty(config, 'before_install', command)
+
+    command = createStatusCommand(testedCommit,
+      state: 'error'
+      description: 'Dependent build finished'
+      context: "continuous-integration/travis-ci/#{jobName}"
+      target_url: "https://travis-ci.org/apiaryio/dredd/builds/$TRAVIS_BUILD_ID"
+    )
+    prependToTravisConfigProperty(config, 'after_failure', command)
+
+    command = createStatusCommand(testedCommit,
+      state: 'success'
+      description: 'Dependent build finished'
+      context: "continuous-integration/travis-ci/#{jobName}"
+      target_url: "https://travis-ci.org/apiaryio/dredd/builds/$TRAVIS_BUILD_ID"
+    )
+    prependToTravisConfigProperty(config, 'after_success', command)
+
+    config.after_success.push('if [[ $TRAVIS_BRANCH = master ]]; then echo "Deleting aborted (master)" && exit 1; fi')
+    config.after_success.push('git branch -D $TRAVIS_BRANCH')
+    config.after_success.push("git remote set-url origin \"https://$GITHUB_TOKEN@github.com/apiaryio/dredd.git\" #{DROP_OUTPUT}")
+    config.after_success.push("git push origin -f --delete $TRAVIS_BRANCH #{DROP_OUTPUT}")
+
+  # Save all changes
+  fs.writeFileSync(TRAVIS_CONFIG_FILE, yaml.dump(config), 'utf-8')
+
+
+# Creates cURL command which pushes status information to GitHub. Allows
+# interpolation for environment variables in data (just use $ENV_NAME in the
+# data).
+createStatusCommand = (testedCommit, data) ->
+  command = 'curl -X POST'
+  command += ' -H "Content-Type: application/json"'
+  command += ' -H "Authorization: token $GITHUB_TOKEN"'
+
+  escapedJson = JSON.stringify(data).replace(/"/g, '\\"')
+  command += " -d \"#{escapedJson}\""
+
+  command += " 'https://api.github.com/repos/apiaryio/dredd/statuses/#{testedCommit}'"
+  return command
 
 
 # Retrieves full commit message.
@@ -224,43 +277,30 @@ getGitCommitMessage = (commitHash) ->
   getTrimmedStdout(execSync('git log --format=%B -n 1 ' + commitHash))
 
 
-# Returns tag name if given commit is tagged. TRAVIS_TAG environment variable
-# is present only in special builds Travis CI starts separately for new tags.
-getGitCommitTag = (commitHash) ->
-  return process.env.TRAVIS_TAG if process.env.TRAVIS_TAG
-  latestTag = getTrimmedStdout(execSync('git describe --abbrev=0 --tags'))
-  taggedCommit = getTrimmedStdout(execSync('git rev-list -n 1 ' + latestTag))
-  return latestTag if commitHash is taggedCommit
-
-
 # Aborts this script in case it finds out that conditions to run this script
 # are not satisfied. The script should run only if it was triggered by the
-# tested commit being tagged or by a keyword in the commit message.
-abortIfNotTriggered = ->
+# tested commit being part of a PR.
+abortIfNotTriggered = (testedNodeVersion, testedCommit, pullRequestId) ->
   reason = null
 
   # We do not want to run integration tests of hook handlers for every node
   # version in the matrix. One node version is perfectly enough as
   # the dependent builds will be performed on the default version Travis CI
-  # provides anyway (.travis.yml of dependent repositories usually do not
+  # provides anyway (`.travis.yml` of dependent repositories usually do not
   # specify node version, they care about Ruby, Python, ... versions).
-  nodeVersionTestedAsFirst = listTestedNodeVersions()[0]
-  if process.env.TRAVIS_NODE_VERSION isnt nodeVersionTestedAsFirst
-    reason = "They run only in builds with Node #{nodeVersionTestedAsFirst}."
+  latestTestedNodeVersion = getLatestTestedNodeVersion()
+  if testedNodeVersion isnt latestTestedNodeVersion
+    reason = "They run only in builds with Node #{latestTestedNodeVersion}."
   else
-    # Integration tests are triggered only if the tested commit is tagged or
+    # Integration tests are triggered only if the tested commit is in PR or
     # it's message contains trigger keyword. If this is not the case, abort
     # the script.
-    commitHash = process.env.TRAVIS_COMMIT
-    tag = getGitCommitTag(commitHash)
-    message = getGitCommitMessage(commitHash)
+    message = getGitCommitMessage(testedCommit)
 
-    if tag
-      console.log("Tested commit (#{commitHash}) is tagged as '#{tag}'.")
-    else if message.toLowerCase().indexOf(TRIGGER_KEYWORD) isnt -1
-      console.log("Message of tested commit (#{commitHash}) contains '#{TRIGGER_KEYWORD}'.")
+    if pullRequestId
+      console.log("Tested commit (#{testedCommit}) is part of the '##{pullRequestId}' PR")
     else
-      reason = "Tested commit (#{commitHash}) isn't tagged and its message doesn't contain keyword '#{TRIGGER_KEYWORD}'."
+      reason = "Tested commit (#{testedCommit}) isn't part of PR"
 
   # There is a reason to abort the script, so let's do it.
   if reason
@@ -268,45 +308,32 @@ abortIfNotTriggered = ->
     process.exit(0)
 
 
-# Waits for results from dependent builds. Its callback gets results in form
-# of object where keys are integration branches and values are resulting build
-# statuses.
-waitForResults = (integrationBranches, callback) ->
-  # Waiting 2 minutes at the beginning so Travis CI has time to pick up
-  # dependent builds from GitHub.
-  setTimeout( ->
-    polling = {}
-    integrationBranches.forEach((branch) ->
-      polling[branch] = (next) -> pollForBuildResult(branch, next)
-    )
-    async.parallel(polling, (err, results) ->
-      console.log('\n') # 'pollForBuildResult' prints dots without newline
-      callback(err, results)
-    )
-  , 120000)
-
-
 ################################################################################
 ##                                   MAIN                                     ##
 ################################################################################
 
-abortIfNotTriggered()
+
+integrationBranches = []
+testedNodeVersion = process.env.TRAVIS_NODE_VERSION
+testedBranch = process.env.TRAVIS_BRANCH
+testedCommit = process.env.TRAVIS_COMMIT_RANGE.split('...')[1]
+buildId = process.env.TRAVIS_BUILD_ID
+pullRequestId = if process.env.TRAVIS_PULL_REQUEST isnt 'false' then process.env.TRAVIS_PULL_REQUEST else null
+
+
+abortIfNotTriggered(testedNodeVersion, testedCommit, pullRequestId)
 requireTravisCli()
 
 
-ensureGitAuthor()
+ensureGitAuthor(testedCommit)
 ensureGitOrigin()
 
 
-integrationBranches = []
-testedBranch = process.env.TRAVIS_BRANCH
-buildId = process.env.TRAVIS_BUILD_ID
-
-
-JOBS.forEach(({name, repo}) ->
-  integrationBranch = "dependent-build/#{buildId}/#{name}"
+JOBS.forEach(({name, repo, matrixName}) ->
+  id = if pullRequestId then "pr#{pullRequestId}/#{buildId}" else buildId
+  integrationBranch = "dependent-build/#{id}/#{name}"
   integrationBranches.push(integrationBranch)
-  console.log("Preparing branch #{integrationBranch}...")
+  console.log("Preparing branch #{integrationBranch}")
 
   # Prepare a special integration branch
   cleanGit(testedBranch)
@@ -314,8 +341,18 @@ JOBS.forEach(({name, repo}) ->
 
   # Move contents of the root directory to the directory for linked Dredd and
   # commit this change.
+  execSync('rm -rf ./node_modules')
   moveAllFilesTo(LINKED_DREDD_DIR, ['./.git', './.git/*'])
-  execSync('git add -A && git commit -m "Moving Dredd to directory."')
+
+  # We need to keep this script. Node sometimes fails to run certain operations
+  # (especially modifications to other files or building stack straces) when
+  # executing code which doesn't exist on disk anymore.
+  execSync('mkdir ./scripts')
+  execSync("cp #{LINKED_DREDD_DIR}/scripts/test-hooks-handlers.coffee ./scripts/test-hooks-handlers.coffee")
+
+  # Commit changes so we can perform merge later...
+  execSync('git add -A')
+  execSync('git commit -m "chore: Moving Dredd to directory"')
 
   # Add Git remote with the repository being integrated. Merge its master
   # branch with what's in current branch. After this, we have contents of the
@@ -325,33 +362,21 @@ JOBS.forEach(({name, repo}) ->
 
   # Replace installation of Dredd in .travis.yml with a command which links
   # Dredd from the directory we created. Commit the change.
-  unless replaceInFile('.travis.yml', RE_DREDD_INSTALL_CMD, DREDD_LINK_CMD)
+  unless replaceDreddInstallation()
     console.error('Could not find Dredd installation command in .travis.yml.', contents)
     process.exit(1)
-  execSync('git commit -am "Using linked Dredd."')
+
+  # Adjust build configuration and commit the changes.
+  adjustTravisBuildConfig(pullRequestId, testedCommit, name, matrixName)
+  execSync('git commit -am "chore: Adjust build configuration"')
+
+  # Remove this script.
+  execSync('rm ./scripts/test-hooks-handlers.coffee')
+  execSync('git add -A')
+  execSync('git commit -m "chore: Remove build preparation script"')
 
   # Push the integration branch to GitHub and clean the repository.
-  console.log("Pushing #{integrationBranch} to GitHub...")
+  console.log("Pushing #{integrationBranch} to GitHub")
   execSync("git push origin #{integrationBranch} -f #{DROP_OUTPUT}")
   cleanGit(testedBranch)
-)
-
-
-# Poll for results and evaluate them.
-console.log("Waiting for dependent builds...")
-waitForResults(integrationBranches, (err, results) ->
-  console.log('All dependent builds finished!')
-
-  if err
-    console.error(err.message, err)
-    deleteGitBranches(integrationBranches)
-    process.exit(1)
-
-  failed = false
-  for own integrationBranch, result of results
-    console.log("* #{integrationBranch}: #{result}")
-    failed = true if result isnt 'passed'
-
-  deleteGitBranches(integrationBranches)
-  process.exit(if failed then 1 else 0)
 )


### PR DESCRIPTION
Changed integration tests of hooks handlers so they:

- report under PRs - they create statuses on GitHub now
- do not spawn full matrix of dependent build language versions - now they select just one
- do not time out - closes https://github.com/apiaryio/dredd/issues/374
- run only once! (currently they run twice for every new Dredd version)
- are documented in `CONTRIBUTING.md`
- use @ApiaryBot's GitHub token, not mine

Since the tests now run under every PR, the triggering logic was simplified and string `tests hook handlers` in the commit message won't have any effect anymore.

Basically, the aim is to make the tests more user-friendly and more "throwaway" and omnipresent. This will fix some current issues as well as it should enable us to get closer to Semantic Releasing (#438, #440) with Dredd in the future.