### PR TITLE
Support for x-example (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v1.5.0
+
+**Support for `x-example` Swagger vendor extension property**
+- [#581](https://github.com/apiaryio/dredd/pull/581) Support for x-example (v1.5.0) (@honzajavorek)
+
 ### v1.4.0
 
 **Dredd is now installable also without C++ compiler + several bug fixes**

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -109,7 +109,7 @@ It's very likely that your API description document will not be testable __as is
 
 Both [API Blueprint][] and [Swagger][] allow usage of URI templates (API Blueprint fully implements [RFC6570][], Swagger templates are much simpler). In order to have an API description which is testable, you need to describe all required parameters used in URI (path or query) and provide sample values to make Dredd able to expand URI templates with given sample values. Following rules apply when Dredd interpolates variables in a templated URI, ordered by precedence:
 
-1. Sample value (not available in Swagger).
+1. Sample value (available in Swagger as [`x-example` vendor extension property](how-to-guides.md#example-values-for-request-parameters)).
 2. Value of `default`.
 3. First value from `enum`.
 

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -530,9 +530,33 @@ When sending test reports to Apiary, Dredd inspects the environment where it was
 - hostname (string) - `DREDD_HOSTNAME` or hostname of the OS
 - CI (boolean) - looks for `TRAVIS`, `CIRCLE`, `CI`, `DRONE`, `BUILD_ID`, ...
 
+## Example Values for Request Parameters
+
+While example values are natural part of the API Blueprint format, the Swagger
+specification allows them only for `body` request parameters (`schema.example`).
+
+However, Dredd needs to know what values to use when testing described API, so
+it supports `x-example` [vendor extension property][] to overcome the Swagger limitation:
+
+```yaml
+...
+paths:
+  /cars:
+    get:
+      parameters:
+        - name: limit
+          in: query
+          type: number
+          x-example: 42
+```
+
+The `x-example` property is respected for all kinds of request parameters except
+of `body` parameters, where native `schema.example` should be used.
+
 
 [Apiary]: https://apiary.io/
 [API Blueprint]: http://apiblueprint.org/
 [Swagger]: http://swagger.io/
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/
+[vendor extension property]: http://swagger.io/specification/#vendorExtensions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "HTTP API Testing Framework",
   "main": "lib/dredd.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clone": "^1.0.2",
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
-    "dredd-transactions": "^1.5.1",
+    "dredd-transactions": "^1.6.0",
     "file": "^0.2.2",
     "gavel": "^0.5.3",
     "glob": "^7.0.5",


### PR DESCRIPTION
Dredd now supports `x-example` Swagger vendor extension property.