### PR TITLE
Solution for #615 and #558 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clone": "^1.0.2",
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
-    "dredd-transactions": "^2.0.0",
+    "dredd-transactions": "^3.0.0",
     "file": "^0.2.2",
     "gavel": "^0.5.3",
     "glob": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clone": "^1.0.2",
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
-    "dredd-transactions": "^1.6.0",
+    "dredd-transactions": "^2.0.0",
     "file": "^0.2.2",
     "gavel": "^0.5.3",
     "glob": "^7.0.5",

--- a/test/fixtures/regression-615.apib
+++ b/test/fixtures/regression-615.apib
@@ -1,0 +1,22 @@
+FORMAT: 1A
+
+# Beehive API
+
+## Honey [/honey]
+
+### Retrieve [GET]
+
++ Request (application/json)
++ Request (application/xml)
++ Response 200
++ Response 500
+
+### Remove [DELETE]
+
++ Request (application/json)
++ Response 200
++ Response 403
++ Response 500
+
++ Request (text/plain)
++ Response 200

--- a/test/fixtures/swagger-multiple-responses.js
+++ b/test/fixtures/swagger-multiple-responses.js
@@ -2,9 +2,7 @@
 var hooks = require('hooks');
 
 
-hooks.before('/honey > GET', function (transaction, done) {
-  if (transaction.expected.statusCode[0] == '5') {
-    transaction.skip = false;
-  }
+hooks.before('/honey > GET > 500 > application/json', function (transaction, done) {
+  transaction.skip = false;
   done();
 });

--- a/test/fixtures/swagger-transaction-names.js
+++ b/test/fixtures/swagger-transaction-names.js
@@ -1,0 +1,13 @@
+
+var hooks = require('hooks');
+
+
+function logTransactionName(transaction, done) {
+  hooks.log(transaction.name);
+  done();
+}
+
+
+hooks.before('/honey > GET > 400 > application/json', logTransactionName);
+hooks.before('/honey > GET > 500 > application/json', logTransactionName);
+hooks.before('/honey > GET > 200 > application/json', logTransactionName);

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -627,9 +627,9 @@ describe 'Dredd class Integration', ->
 
     it('transaction names contain status code and content type', ->
       assert.deepEqual(matches, [
+        '/honey > GET > 200 > application/json'
         '/honey > GET > 400 > application/json'
         '/honey > GET > 500 > application/json'
-        '/honey > GET > 200 > application/json'
       ])
     )
   )

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -608,3 +608,28 @@ describe 'Dredd class Integration', ->
       assert.notEqual(matches[2][1], 'skip')
     )
   )
+
+  describe('when using Swagger document with hooks', ->
+    reTransactionName = /hook: (.+)/g
+    matches = undefined
+
+    beforeEach((done) ->
+      execCommand(
+        options:
+          path: './test/fixtures/multiple-responses.yaml'
+          hookfiles: './test/fixtures/swagger-transaction-names.js'
+      , (err) ->
+        matches = []
+        matches.push(groups[1]) while groups = reTransactionName.exec(stdout)
+        done(err)
+      )
+    )
+
+    it('transaction names contain status code and content type', ->
+      assert.deepEqual(matches, [
+        '/honey > GET > 400 > application/json'
+        '/honey > GET > 500 > application/json'
+        '/honey > GET > 200 > application/json'
+      ])
+    )
+  )

--- a/test/regressions/regression-319-354-test.coffee
+++ b/test/regressions/regression-319-354-test.coffee
@@ -30,6 +30,7 @@ parseJSON = (body) ->
     body
 
 
+# This can be removed once https://github.com/apiaryio/dredd/issues/341 is done
 parseOutput = (output) ->
   # Parse individual entries (deals also with multi-line entries)
   entries = []

--- a/test/regressions/regression-615-test.coffee
+++ b/test/regressions/regression-615-test.coffee
@@ -1,0 +1,93 @@
+{assert} = require 'chai'
+{exec} = require 'child_process'
+express = require 'express'
+clone = require 'clone'
+
+
+PORT = 3333
+DREDD_BIN = require.resolve '../../bin/dredd'
+
+
+runDredd = (descriptionFile, cb) ->
+  result = {}
+  cmd = "#{DREDD_BIN} #{descriptionFile} http://localhost:#{PORT} -ed --no-color"
+
+  cli = exec cmd, (err, stdout, stderr) ->
+    result.exitStatus = err?.code or null
+    result.stdout = '' + stdout
+    result.stderr = '' + stderr
+
+  cli.on 'close', (code) ->
+    result.exitStatus ?= code if code
+    cb null, result
+
+
+parseJSON = (body) ->
+  return undefined unless body
+  try
+    JSON.parse body
+  catch
+    body
+
+
+# This can be removed once https://github.com/apiaryio/dredd/issues/341 is done
+parseOutput = (output) ->
+  # Parse individual entries (deals also with multi-line entries)
+  entries = []
+  entry = undefined
+  for line in output.split /\r?\n/
+    match = line.match /^(\w+): (.+)?$/
+    if match
+      if entry
+        entry.body = entry.body.trim()
+        entries.push entry
+      entry = {label: match[1], body: match[2] or ''}
+    else
+      entry.body += "\n#{line.trim()}"
+
+  # Correction of following situation:
+  #
+  # fail: POST /customers duration: 13ms
+  # fail: body: At '/name' Invalid type: null (expected string)
+  # body: At '/shoeSize' Invalid type: string (expected number)
+  entries = entries.filter (entry, i) ->
+    previousEntry = entries[i - 1]
+    if entry.label is 'body' and previousEntry.label is 'fail'
+      previousEntry.body += '\n' + entry.body
+      return false
+    return true
+
+  # Re-arrange data from entries
+  results = {summary: '', failures: []}
+  for entry in entries
+    switch entry.label
+      when 'complete' then results.summary = entry.body
+      when 'fail' then results.failures.push entry.body
+  return results
+
+
+describe 'Regression: Issue #615', ->
+  requests = []
+  results = undefined
+
+  beforeEach (done) ->
+    app = express()
+
+    # Attaching endpoint for each testing scenario
+    app.all '/honey', (req, res) ->
+      res.status(200).send ''
+
+    # Spinning up the Express server, running Dredd, and saving results
+    server = app.listen PORT, ->
+      runDredd './test/fixtures/regression-615.apib', (err, result) ->
+        results = parseOutput result.stdout
+        server.close done
+
+  it 'outputs no failures', ->
+    # Intentionally not testing just '.length' as this approach will output the difference
+    assert.deepEqual results.failures, []
+  it 'results in exactly three tests', ->
+    assert.include results.summary, '3 total'
+  it 'results in three passing tests', ->
+    # Ensures just the 200 responses were selected, because the server returns only 200s
+    assert.include results.summary, '3 passing'


### PR DESCRIPTION
**BREAKING CHANGE**

This change closes https://github.com/apiaryio/dredd/issues/615 and also closes https://github.com/apiaryio/dredd/issues/558. 

##  Dredd is not using just the 1st req-res pair within APIB transaction examples - #615

Added a regression test, which fails on current Dredd and is expected to pass when https://github.com/apiaryio/dredd-transactions/pull/61 gets merged and released. The change is breaking for some API Blueprint users and will bump Dredd's major version.

## Transaction Names from Swagger are not unique - #558 

Added a test, which fails on current Dredd and is expected to pass when https://github.com/apiaryio/dredd-transactions/pull/63 gets merged and released. Updated all related documentation. The change is breaking for all Swagger users and will bump Dredd's major version.