### PR TITLE
rewrite print-installation-guidelines in javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dredd": "bin/dredd"
   },
   "scripts": {
-    "postinstall": "coffee scripts/print-installation-guidelines.coffee",
-    "postupdate": "coffee scripts/print-installation-guidelines.coffee",
+    "postinstall": "node scripts/print-installation-guidelines.js",
+    "postupdate": "node scripts/print-installation-guidelines.js",
     "lint": "coffeelint src",
     "docs:build": "mkdocs build",
     "docs:serve": "mkdocs serve",

--- a/scripts/print-installation-guidelines.js
+++ b/scripts/print-installation-guidelines.js
@@ -1,14 +1,11 @@
-'use strict'
+var colors = require('colors');
 
-const colors = require('colors')
-
-const command = colors.bold(colors.yellow('npm install dredd@stable'))
-console.error(colors.cyan(`
-  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  ::                                                                ::
-  ::    Install Dredd using ${command} in case you    ::
-  ::        prefer stability over new features (e.g. in CI)         ::
-  ::                                                                ::
-  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
-`))
+var command = colors.bold(colors.yellow('npm install dredd@stable'));
+console.error(colors.cyan([
+'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::',
+'  ::                                                                ::',
+'  ::    Install Dredd using ' + command + ' in case you    ::',
+'  ::        prefer stability over new features (e.g. in CI)         ::',
+'  ::                                                                ::',
+'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::'
+].join('\n')));

--- a/scripts/print-installation-guidelines.js
+++ b/scripts/print-installation-guidelines.js
@@ -1,13 +1,14 @@
+'use strict'
 
-colors = require('colors')
+const colors = require('colors')
 
-command = colors.bold(colors.yellow('npm install dredd@stable'))
-console.error(colors.cyan("""
+const command = colors.bold(colors.yellow('npm install dredd@stable'))
+console.error(colors.cyan(`
   ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   ::                                                                ::
-  ::    Install Dredd using #{command} in case you    ::
+  ::    Install Dredd using ${command} in case you    ::
   ::        prefer stability over new features (e.g. in CI)         ::
   ::                                                                ::
   ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"""))
+`))


### PR DESCRIPTION
follow up issue #629 

there won't be need to install coffee-script globally in case of installing Dredd.