### PR TITLE
Rewrite print installation guidelines in JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dredd": "bin/dredd"
   },
   "scripts": {
-    "postinstall": "coffee scripts/print-installation-guidelines.coffee",
-    "postupdate": "coffee scripts/print-installation-guidelines.coffee",
+    "postinstall": "node scripts/print-installation-guidelines.js",
+    "postupdate": "node scripts/print-installation-guidelines.js",
     "lint": "coffeelint src",
     "docs:build": "mkdocs build",
     "docs:serve": "mkdocs serve",

--- a/scripts/print-installation-guidelines.js
+++ b/scripts/print-installation-guidelines.js
@@ -2,10 +2,10 @@ var colors = require('colors');
 
 var command = colors.bold(colors.yellow('npm install dredd@stable'));
 console.error(colors.cyan([
-'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::',
-'  ::                                                                ::',
-'  ::    Install Dredd using ' + command + ' in case you    ::',
-'  ::        prefer stability over new features (e.g. in CI)         ::',
-'  ::                                                                ::',
-'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::'
+  '::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::',
+  '::                                                                ::',
+  '::    Install Dredd using ' + command + ' in case you    ::',
+  '::        prefer stability over new features (e.g. in CI)         ::',
+  '::                                                                ::',
+  '::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::',
 ].join('\n')));

--- a/scripts/print-installation-guidelines.js
+++ b/scripts/print-installation-guidelines.js
@@ -1,14 +1,11 @@
-'use strict'
+var colors = require('colors');
 
-const colors = require('colors')
-
-const command = colors.bold(colors.yellow('npm install dredd@stable'))
-console.error(colors.cyan(`
-  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  ::                                                                ::
-  ::    Install Dredd using ${command} in case you    ::
-  ::        prefer stability over new features (e.g. in CI)         ::
-  ::                                                                ::
-  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
-`))
+var command = colors.bold(colors.yellow('npm install dredd@stable'));
+console.error(colors.cyan([
+'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::',
+'  ::                                                                ::',
+'  ::    Install Dredd using ' + command + ' in case you    ::',
+'  ::        prefer stability over new features (e.g. in CI)         ::',
+'  ::                                                                ::',
+'  ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::'
+].join('\n')));

--- a/scripts/print-installation-guidelines.js
+++ b/scripts/print-installation-guidelines.js
@@ -1,13 +1,14 @@
+'use strict'
 
-colors = require('colors')
+const colors = require('colors')
 
-command = colors.bold(colors.yellow('npm install dredd@stable'))
-console.error(colors.cyan("""
+const command = colors.bold(colors.yellow('npm install dredd@stable'))
+console.error(colors.cyan(`
   ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   ::                                                                ::
-  ::    Install Dredd using #{command} in case you    ::
+  ::    Install Dredd using ${command} in case you    ::
   ::        prefer stability over new features (e.g. in CI)         ::
   ::                                                                ::
   ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"""))
+`))


### PR DESCRIPTION
For no obvious reason, npm scripts written in CoffeeScript can cause problems. This change avoids any problems all together, since it introduces rewrite of the script, which is being run every time after installation, into a plain ES5 JavaScript.

This fixes https://github.com/apiaryio/dredd/issues/629 and supersedes https://github.com/apiaryio/dredd/pull/630.