### PR TITLE
Fix "strings" of Boolean values in blueprint files

### DIFF
--- a/ApiaryReportingApi.apib
+++ b/ApiaryReportingApi.apib
@@ -110,7 +110,7 @@ HOST: http://api.apiary.io/
                   "annotations": []
                 }
               ],
-              "public": "true",
+              "public": true,
               "agent": "Dredd/0.1.7 (Linux 3.2.0-23-generic; x64)",
               "agentRunUuid": "03b3de07-d354-4ba6-aa2e-28789b03c619",
               "hostname": "machine.fqdn.tld",
@@ -151,7 +151,7 @@ HOST: http://api.apiary.io/
                   }
                 ],
                 "logs": [],
-                "public": "true",
+                "public": true,
                 "agent": "Dredd/0.1.7 (Linux 3.2.0-23-generic; x64)",
                 "agentRunUuid": "03b3de07-d354-4ba6-aa2e-28789b03c619",
                 "hostname": "machine.fqdn.tld",
@@ -217,7 +217,7 @@ HOST: http://api.apiary.io/
                 "timestamp": 1381924294,
                 "content": "Log message from hooks"
               }],
-              "public": "true",
+              "public": true,
               "agent": "Dredd/0.1.7 (Linux 3.2.0-23-generic; x64)",
               "agentRunUuid": "03b3de07-d354-4ba6-aa2e-28789b03c619",
               "hostname": "machine.fqdn.tld",

--- a/ApiaryReportingApiAnonymous.apib
+++ b/ApiaryReportingApiAnonymous.apib
@@ -106,7 +106,7 @@ HOST: http://api.apiary.io/
                   "annotations": []
                 }
               ],
-              "public": "true",
+              "public": true,
               "agent": "Dredd/0.1.7 (Linux 3.2.0-23-generic; x64)",
               "agentRunUuid": "03b3de07-d354-4ba6-aa2e-28789b03c619",
               "hostname": "machine.fqdn.tld",
@@ -167,7 +167,7 @@ HOST: http://api.apiary.io/
                 "timestamp": 1381924294,
                 "content": "Log message from hooks"
               }],
-              "public": "true",
+              "public": true,
               "agent": "Dredd/0.1.7 (Linux 3.2.0-23-generic; x64)",
               "agentRunUuid": "03b3de07-d354-4ba6-aa2e-28789b03c619",
               "hostname": "machine.fqdn.tld",


### PR DESCRIPTION
Just a small typos-fix

Should not break anything, since Dredd was using `Attributes`-generated JSON-Schema for validating the bodies.