### PR TITLE
Fix broken changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ npm install -g dredd
 [Swagger]: http://swagger.io/
 
 [Documentation]: https://dredd.readthedocs.io/en/latest/
-[Changelog]: CHANGELOG.md
+[Changelog]: https://github.com/apiaryio/dredd/releases
 [Contributor's Guidelines]: https://dredd.readthedocs.io/en/latest/contributing/
 
 [Travis CI]: https://travis-ci.org/


### PR DESCRIPTION
The CHANGELOG.md file isn't present in the repo anymore and GitHub releases are used instead. Similar link was fixed in docs' index.md, but not in README.md. 