### PR TITLE
Use conventional changelog linter

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,6 @@
-Filing a bug report? :bug:
+If you want to share an idea :bulb:, feel free to delete all this and just write what you want. If you are reporting a bug :bug:, remove this paragraph and fill following:
+
+#### Describe your problem
 
 #### What command line options do you use?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 
 - [ ] To write docs
 - [ ] To write tests
-- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits
+- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ before_install:
   - "npm -g install npm@latest"
   - "gem install travis"
   - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
-before_script:
-  - "npm run lint"
 script:
+  - "npm run lint"
   - "npm test"
   - "npm run test:hooks-handlers"
 after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - "gem install travis"  # needed for 'npm run test:hooks-handlers'
   - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
 script:
-  - "npm run lint"
+  - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
   - "npm test"
   - "npm run test:hooks-handlers"
 after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ cache:
   directories:
     - "node_modules"
 before_install:
+  # Travis CI has only shallow clone of the repository. We need to get the 'master' branch
+  # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
+  - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
   - "npm -g install npm@latest"
-  - "gem install travis"
+  - "gem install travis"  # needed for 'npm run test:hooks-handlers'
   - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
 script:
   - "npm run lint"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,15 +23,19 @@
 2. Create a feature branch.
 3. Write tests.
 4. Write code.
-5. Send a Pull Request.
-6. Make sure [test coverage][] didn't drop and all CI builds are passing.
+5. Lint what you created: `npm run lint`
+6. Send a Pull Request.
+7. Make sure [test coverage][] didn't drop and all CI builds are passing.
 
 <a name="sem-rel">
 #### Semantic Release and Conventional Changelog
 
-To make [Semantic Release][] and [Conventional Changelog][] work, all commit messages
-in the project should follow the Conventional Changelog format. If you're new to the
-concept, just make sure your commit messages look like this:
+Releasing of new Dredd versions to npm is automatically managed by [Semantic Release][].
+Semantic Release makes sure correct version numbers get bumped according to the **meaning**
+of your changes once your PR gets merged to `master`.
+
+To make it work, it's necessary to follow [Conventional Changelog][]. That basically
+means all commit messages in the project should follow a particular format:
 
 ```
 <type>: <subject>
@@ -47,14 +51,14 @@ Where `<type>` is:
 - `refactor` - Changes in code, but no changes in behavior
 - `test` - Tests added/removed/improved/...
 
-See [existing commits][] as a reference. The [Commitizen CLI][] can also help you.
-
-Semantic Release will make sure correct version numbers get bumped according
-to the **meaning** of your changes once your PR gets merged to `master`.
-Semantic Release then also automatically releases new Dredd to npm.
-
 In the rare cases when your changes break backwards compatibility, the message
-must include words `BREAKING CHANGE`. That will result in bumping the major version.
+must include string `BREAKING CHANGE:`. That will result in bumping the major version.
+
+Seems hard?
+
+- See [existing commits][] as a reference
+- [Commitizen CLI][] can help you to create correct commit messages
+- `npm run lint` validates format of your messages
 
 ## Handbook for Contributors and Maintainers
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "node scripts/print-installation-guidelines.js",
     "postupdate": "node scripts/print-installation-guidelines.js",
-    "lint": "conventional-changelog-lint --from=HEAD~1 && coffeelint src",
+    "lint": "conventional-changelog-lint --from=master && coffeelint src",
     "docs:build": "mkdocs build",
     "docs:serve": "mkdocs serve",
     "build": "coffee -b -c -o lib/ src/ && coffee scripts/generate-cli-docs.coffee",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "node scripts/print-installation-guidelines.js",
     "postupdate": "node scripts/print-installation-guidelines.js",
-    "lint": "coffeelint src",
+    "lint": "conventional-changelog-lint --from=HEAD~1 && coffeelint src",
     "docs:build": "mkdocs build",
     "docs:serve": "mkdocs serve",
     "build": "coffee -b -c -o lib/ src/ && coffee scripts/generate-cli-docs.coffee",
@@ -57,6 +57,7 @@
     "codo": "^2.1.0",
     "coffee-coverage": "^1.0.1",
     "coffeelint": "^1.15.7",
+    "conventional-changelog-lint": "^1.1.0",
     "coveralls": "^2.11.9",
     "cz-conventional-changelog": "^1.1.6",
     "drafter": "^1.0.0",


### PR DESCRIPTION
#### :rocket: Why this change?

Dredd uses Conventional Changelog to automate releasing and changelog generating. It's crutial not to make mistakes in formatting of the commits. Of course, there are [contributing docs](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) on this topic, but prevention is always better - humans make mistakes :)

#### :memo: Related issues and Pull Requests

- #438 
