### PR TITLE
Replace deprecated uuid module

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "inquirer": "^1.1.0",
     "js-yaml": "^3.6.1",
     "markdown-it": "^8.0.1",
-    "node-uuid": "^1.4.7",
     "optimist": "^0.6.1",
     "pitboss-ng": "^0.3.2",
     "proxyquire": "^1.7.10",
@@ -50,6 +49,7 @@
     "spawn-args": "^0.2.0",
     "sync-exec": "^0.6.2",
     "uri-template": "^1.0.1",
+    "uuid": "^3.0.0",
     "which": "^1.2.12",
     "winston": "^2.2.0"
   },

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -2,7 +2,7 @@ net = require 'net'
 {EventEmitter} = require 'events'
 crossSpawn = require('cross-spawn')
 
-generateUuid = require('node-uuid').v4
+generateUuid = require('uuid').v4
 
 # for stubbing in tests
 logger = require('./logger')

--- a/src/reporters/apiary-reporter.coffee
+++ b/src/reporters/apiary-reporter.coffee
@@ -4,7 +4,7 @@ os = require 'os'
 url = require 'url'
 
 clone = require 'clone'
-generateUuid = require('node-uuid').v4
+generateUuid = require('uuid').v4
 
 packageData = require './../../package.json'
 logger = require('./../logger')


### PR DESCRIPTION
Author of node-uuid decided to deprecate for reasons I do not know and
replace it with uuid.