### PR TITLE
Make spawning server command and 'which' Windows-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clone": "^2.0.0",
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
+    "cross-spawn": "^5.0.1",
     "dredd-transactions": "^3.0.1",
     "file": "^0.2.2",
     "gavel": "^0.5.3",
@@ -47,9 +48,9 @@
     "proxyquire": "^1.7.10",
     "request": "^2.74.0",
     "spawn-args": "^0.2.0",
-    "spawn-sync": "^1.0.15",
     "sync-exec": "^0.6.2",
     "uri-template": "^1.0.1",
+    "which": "^1.2.12",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -4,7 +4,7 @@ console = require 'console'
 fs = require 'fs'
 os = require 'os'
 spawnArgs = require 'spawn-args'
-{spawn} = require('child_process')
+{spawn} = require('cross-spawn')
 execSync = require('sync-exec')
 
 Dredd = require './dredd'

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -1,12 +1,12 @@
 net = require 'net'
 {EventEmitter} = require 'events'
-child_process = require 'child_process'
+crossSpawn = require('cross-spawn')
 
 generateUuid = require('node-uuid').v4
 
 # for stubbing in tests
 logger = require('./logger')
-which = require './which'
+which = require('./which')
 
 
 class HooksWorkerClient
@@ -168,7 +168,7 @@ class HooksWorkerClient
     pathGlobs = [].concat @runner.hooks?.configuration?.options?.hookfiles
 
     logger.info("Spawning `#{@language}` hooks handler process.")
-    @handler = child_process.spawn @handlerCommand, pathGlobs
+    @handler = crossSpawn.spawn @handlerCommand, pathGlobs
 
     @handler.stdout.on 'data', (data) ->
       logger.info("Hooks handler stdout:", data.toString())

--- a/src/which.coffee
+++ b/src/which.coffee
@@ -1,5 +1,10 @@
-spawnSync = require 'spawn-sync'
+which = require('which')
+
 
 module.exports =
   which: (command) ->
-    spawnSync("which", [command]).status == 0
+    try
+      which.sync(command)
+      return true
+    catch e
+      return false

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -5,9 +5,9 @@ net = require 'net'
 {assert} = require 'chai'
 clone = require 'clone'
 
-childProcessStub = require 'child_process'
-loggerStub = require '../../src/logger'
-whichStub =  require '../../src/which'
+crossSpawnStub = require('cross-spawn')
+whichStub = require('../../src/which')
+loggerStub = require('../../src/logger')
 
 Hooks = require '../../src/hooks'
 commandLineOptions = require '../../src/options'
@@ -18,11 +18,10 @@ runner = null
 logs = null
 logLevels = ['error', 'log', 'info', 'warn']
 
-HooksWorkerClient = proxyquire '../../src/hooks-worker-client', {
-  'child_process': childProcessStub
-  './logger': loggerStub
+HooksWorkerClient = proxyquire '../../src/hooks-worker-client',
+  'cross-spawn': crossSpawnStub
   './which': whichStub
-}
+  './logger': loggerStub
 
 TransactionRunner = require '../../src/transaction-runner'
 
@@ -130,9 +129,21 @@ describe 'Hooks worker client', ->
             done()
         , 100
 
+    describe 'when --language nodejs option is given', ->
+      beforeEach ->
+        runner.hooks['configuration'] =
+          options:
+            language: 'nodejs'
+
+      it 'should write a hint that native hooks should be used', (done) ->
+        loadWorkerClient (err) ->
+          assert.isDefined err
+          assert.include err.message, 'native Node.js hooks instead'
+          done()
+
     describe 'when --language ruby option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -149,7 +160,7 @@ describe 'Hooks worker client', ->
           callback()
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -162,8 +173,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], 'dredd-hooks-ruby'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-ruby'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -172,20 +183,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'somefile.rb'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.rb'
             done()
-
-    describe 'when --language nodejs option is given', ->
-      beforeEach ->
-        runner.hooks['configuration'] =
-          options:
-            language: 'nodejs'
-
-      it 'should write a hint that native hooks should be used', (done) ->
-        loadWorkerClient (err) ->
-          assert.isDefined err
-          assert.include err.message, 'native Node.js hooks instead'
-          done()
 
     describe 'when --language ruby option is given and the worker is not installed', ->
       beforeEach ->
@@ -208,7 +207,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language python option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -225,7 +224,7 @@ describe 'Hooks worker client', ->
           callback()
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -238,8 +237,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], 'dredd-hooks-python'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-python'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -248,7 +247,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
     describe 'when --language python option is given and the worker is not installed', ->
@@ -271,7 +270,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language php option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -288,7 +287,7 @@ describe 'Hooks worker client', ->
           callback()
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -301,8 +300,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], 'dredd-hooks-php'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-php'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -311,7 +310,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
     describe 'when --language go option is given and the worker is not installed', ->
@@ -335,7 +334,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language go option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -352,7 +351,7 @@ describe 'Hooks worker client', ->
           callback()
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -366,8 +365,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], 'gopath/bin/goodman'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], 'gopath/bin/goodman'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -376,7 +375,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'gobinary'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'gobinary'
             done()
 
     describe 'when --language php option is given and the worker is not installed', ->
@@ -399,7 +398,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language perl option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -416,7 +415,7 @@ describe 'Hooks worker client', ->
           callback()
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -429,8 +428,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], 'dredd-hooks-perl'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-perl'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -439,7 +438,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
     describe 'when --language perl option is given and the worker is not installed', ->
@@ -462,7 +461,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language ./any/other-command is given', ->
       beforeEach ->
-        sinon.stub childProcessStub, 'spawn', ->
+        sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
@@ -479,7 +478,7 @@ describe 'Hooks worker client', ->
         sinon.stub whichStub, 'which', -> true
 
       afterEach ->
-        childProcessStub.spawn.restore()
+        crossSpawnStub.spawn.restore()
 
         runner.hooks['configuration'] = undefined
 
@@ -492,8 +491,8 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.isTrue childProcessStub.spawn.called
-            assert.equal childProcessStub.spawn.getCall(0).args[0], './my-fancy-command'
+            assert.isTrue crossSpawnStub.spawn.called
+            assert.equal crossSpawnStub.spawn.getCall(0).args[0], './my-fancy-command'
             done()
 
       it 'should pass --hookfiles option as an array of arguments', (done) ->
@@ -502,7 +501,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal childProcessStub.spawn.getCall(0).args[1][0], 'someotherfile'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'someotherfile'
             done()
 
     describe "after loading", ->


### PR DESCRIPTION
#### :rocket: Why this change?

I want to add an experimental AppVeyor (Windows-based) CI builds to [dredd-example](https://github.com/apiaryio/dredd-example/). This PR is a small step towards better Windows support.

- **The `--server` option should now work also on Windows.** I manually verified that this change is an improvement and enables running the server command on Windows.
- **Removed direct subprocess call to `which` command, which isn't present on Windows.** This is an obvious blocker for non-JS hooks being supported on Windows and I just wanted to have it out of our way. I didn't verify if it actually enables anything right away.

#### :memo: Related issues and Pull Requests

- #204 
