### PR TITLE
Updating dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,10 @@ before_install:
   - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
   - "npm -g install npm@latest"
   - "gem install travis"  # needed for 'npm run test:hooks-handlers'
-  - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
 script:
   - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
   - "npm test"
   - "npm run test:hooks-handlers"
-after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929
+after_success:
   - "npm run coveralls"
-  - "python travis_after_all.py"
-  - "export $(cat .to_export_back)"
   - "npm run semantic-release || true"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mocha": "^3.0.0",
     "mocha-lcov-reporter": "^1.2.0",
     "nock": "^8.0.0",
-    "semantic-release": "^4.3.5",
+    "semantic-release": "^6.3.2",
     "sinon": "^1.17.4"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "dredd": "bin/dredd"
   },
+  "engines": {
+    "node": ">= 0.10"
+  },
   "scripts": {
     "lint": "conventional-changelog-lint --from=master && coffeelint src",
     "docs:build": "mkdocs build",


### PR DESCRIPTION
Usual chore.

- See [this](https://github.com/semantic-release/semantic-release/releases/tag/v6.3.2), `travis_after_all.py` should not be needed anymore.
- I've documented supported engines (so I could change it in the future when https://github.com/apiaryio/dredd/issues/660 will happen)
- I **did not** update `nock`, because it dropped support for 0.10/0.12/4. I'll do it later and I noted it in the https://github.com/apiaryio/dredd/issues/660.

The `continuous-integration/travis-ci/pr` tests are failing because of https://github.com/apiaryio/dredd/issues/672. I can't do much about it at the moment.