### PR TITLE
docs: Add link to more examples in python hooks repo

### DIFF
--- a/docs/hooks-python.md
+++ b/docs/hooks-python.md
@@ -79,6 +79,9 @@ def my_after_all_hook(transactions):
 
 ## Examples
 
+More complex examples are to be found in the Github repository
+[under the examples directory](https://github.com/apiaryio/dredd-hooks-python/tree/master/examples). If you want to share your own, don't hesitate and sumbit a PR.
+
 ### How to Skip Tests
 
 Any test step can be skipped by setting `skip` property of the `transaction` object to `true`.


### PR DESCRIPTION
#### :rocket: Why this change?

Improving the documentation

#### :memo: Related issues and Pull Requests
None
#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`

