### PR TITLE
docs: Fix typo in hooks-ruby code snippet

### DIFF
--- a/docs/hooks-ruby.md
+++ b/docs/hooks-ruby.md
@@ -48,7 +48,7 @@ end
 
 before_each do |transaction|
   puts 'before each'
-ends
+end
 
 before "Machines > Machines collection > Get Machines" do |transaction|
   puts 'before'


### PR DESCRIPTION
#### :rocket: Why this change?
Improve documentation.
