### PR TITLE
Note on security - Apiary Reporter

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -178,7 +178,23 @@ codes are marked as _skipped_ and can be activated in [hooks](hooks.md) - see [T
 only `application/json` media type is supported in [`produces`][produces] and [`consumes`][consumes].
 Other media types are skipped.
 
+## Security
 
+Depending on what you test and how, output of Dredd may contain sensitive data.
+
+Mind that if you run Dredd in a CI server provided as a service (such as [CircleCI][], [Travis CI][], etc.), you are disclosing the CLI output of Dredd to third parties.
+
+When using [Apiary Reporter and Apiary Tests](how-to-guides.md#using-apiary-reporter-and-apiary-tests), you are sending your testing data to [Apiary][] (Dredd creators and maintainers). See their [Terms of Service][] and [Privacy Policy][]. Which data exactly is being sent to Apiary?
+
+- **Complete API description under test.** This means your API Blueprint or Swagger files. The API description is stored encrypted in Apiary.
+- **Complete testing results.** Those can contain details of all requests made to the server under test and their responses. Apiary stores this data unencrypted, even if the original communication between Dredd and the API server under test happens to be over HTTPS. See [Apiary Reporter Test Data](data-structures.md#apiary-reporter-test-data) for detailed description of what is sent. You can [sanitize it before it gets sent](how-to-guides.md#removing-sensitive-data-from-test-reports).
+- **Little meta data about your environment.** Contents of environment variables `TRAVIS`, `CIRCLE`, `CI`, `DRONE`, `BUILD_ID`, `DREDD_AGENT`, `USER`, and `DREDD_HOSTNAME` can be sent to Apiary. Your [hostname][], version of your Dredd installation, and [type][os-type], [release][os-release] and [architecture][os-arch] of your OS can be sent as well. Apiary stores this data unencrypted.
+
+See also [guidelines on how to develop Apiary Reporter](contributing.md#hacking-apiary-reporter).
+
+
+
+[Apiary]: https://apiary.io/
 [Semantic Versioning]: http://semver.org/
 [API Blueprint]: http://apiblueprint.org/
 [Swagger]: http://swagger.io/
@@ -188,6 +204,15 @@ Other media types are skipped.
 [JSON Schema]: http://json-schema.org/
 [Swagger Adapter]: https://github.com/apiaryio/fury-adapter-swagger/
 [RFC6570]: https://tools.ietf.org/html/rfc6570
+
+[CircleCI]: https://circleci.com/
+[Travis CI]: http://travis-ci.org/
+[Terms of Service]: https://apiary.io/tos
+[Privacy Policy]: https://www.iubenda.com/privacy-policy/323220
+[hostname]: https://en.wikipedia.org/wiki/Hostname
+[os-type]: https://nodejs.org/api/os.html#os_os_type
+[os-release]: https://nodejs.org/api/os.html#os_os_release
+[os-arch]: https://nodejs.org/api/os.html#os_os_arch
 
 [schema-section]: https://apiblueprint.org/documentation/specification.html#def-schema-section
 [parameters-section]: https://apiblueprint.org/documentation/specification.html#def-uriparameters-section

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -570,16 +570,6 @@ When sending test reports to Apiary, Dredd inspects the environment where it was
 - hostname (string) - `DREDD_HOSTNAME` or hostname of the OS
 - CI (boolean) - looks for `TRAVIS`, `CIRCLE`, `CI`, `DRONE`, `BUILD_ID`, ...
 
-### Security Concerns
-
-When using Apiary Reporter and Apiary Tests, you are sending your testing data to a company called [Apiary][] (Dredd creators and maintainers). See their [Terms of Service][] and [Privacy Policy][]. Which data exactly is being sent to Apiary?
-
-- complete API description under the test
-- complete testing results (see [Apiary Reporter Test Data](data-structures.md#apiary-reporter-test-data); you can [sanitize them before they get sent](#removing-sensitive-data-from-test-reports))
-- little meta data about your environment (CI detection, Dredd version detection, hostname, ...)
-
-See also [guidelines on how to develop Apiary Reporter](contributing.md#hacking-apiary-reporter).
-
 ## Example Values for Request Parameters
 
 While example values are natural part of the API Blueprint format, the Swagger
@@ -607,7 +597,7 @@ of `body` parameters, where native `schema.example` should be used.
 
 Sometimes your API sends back sensitive information you don't want to get disclosed in [Apiary Tests](how-to-guides.md#using-apiary-reporter-and-apiary-tests) or in your CI log. In that case you can use [Hooks](hooks.md) to do sanitation. Before diving into examples below, do not forget to consider following:
 
-- Be sure to read [section about Apiary Reporter security concerns][#security-concerns] first.
+- Be sure to read [section about security][how-it-works.md#security] first.
 - Only the [`transaction.test`](data-structures.md#transaction-test) object will make it to reporters. You don't have to care about sanitation of the rest of the [`transaction`](data-structures.md#transaction) object.
 - The `transaction.test.message` and all the `transaction.test.results.body.results.rawData.*.message` properties contain validation error messages. While they're very useful for learning about what's wrong on command line, they can contain direct mentions of header names, header values, body properties, body structure, body values, etc., thus it's recommended their contents are completely removed to prevent unintended leaks of sensitive information.
 - Without the `transaction.test.results.body.results.rawData` property [Apiary reporter](how-to-guides.md#using-apiary-reporter-and-apiary-tests) won't be able to render green/red difference between payloads.
@@ -702,5 +692,3 @@ If your hooks crash, Dredd will send an error to reporters, alongside with curre
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/
 [vendor extension property]: http://swagger.io/specification/#vendorExtensions
-[Terms of Service]: https://apiary.io/tos
-[Privacy Policy]: https://www.iubenda.com/privacy-policy/323220

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -570,6 +570,16 @@ When sending test reports to Apiary, Dredd inspects the environment where it was
 - hostname (string) - `DREDD_HOSTNAME` or hostname of the OS
 - CI (boolean) - looks for `TRAVIS`, `CIRCLE`, `CI`, `DRONE`, `BUILD_ID`, ...
 
+### Security Concerns
+
+When using Apiary Reporter and Apiary Tests, you are sending your testing data to a company called [Apiary][] (Dredd creators and maintainers). See their [Terms of Service][] and [Privacy Policy][]. Which data exactly is being sent to Apiary?
+
+- complete API description under the test
+- complete testing results (see [Apiary Reporter Test Data](data-structures.md#apiary-reporter-test-data); you can [sanitize them before they get sent](#removing-sensitive-data-from-test-reports))
+- little meta data about your environment (CI detection, Dredd version detection, hostname, ...)
+
+See also [guidelines on how to develop Apiary Reporter](#hacking-apiary-reporter).
+
 ## Example Values for Request Parameters
 
 While example values are natural part of the API Blueprint format, the Swagger
@@ -597,6 +607,7 @@ of `body` parameters, where native `schema.example` should be used.
 
 Sometimes your API sends back sensitive information you don't want to get disclosed in [Apiary Tests](how-to-guides.md#using-apiary-reporter-and-apiary-tests) or in your CI log. In that case you can use [Hooks](hooks.md) to do sanitation. Before diving into examples below, do not forget to consider following:
 
+- Be sure to read [section about Apiary Reporter security concerns][#security-concerns] first.
 - Only the [`transaction.test`](data-structures.md#transaction-test) object will make it to reporters. You don't have to care about sanitation of the rest of the [`transaction`](data-structures.md#transaction) object.
 - The `transaction.test.message` and all the `transaction.test.results.body.results.rawData.*.message` properties contain validation error messages. While they're very useful for learning about what's wrong on command line, they can contain direct mentions of header names, header values, body properties, body structure, body values, etc., thus it's recommended their contents are completely removed to prevent unintended leaks of sensitive information.
 - Without the `transaction.test.results.body.results.rawData` property [Apiary reporter](how-to-guides.md#using-apiary-reporter-and-apiary-tests) won't be able to render green/red difference between payloads.
@@ -691,3 +702,5 @@ If your hooks crash, Dredd will send an error to reporters, alongside with curre
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/
 [vendor extension property]: http://swagger.io/specification/#vendorExtensions
+[Terms of Service]: https://apiary.io/tos
+[Privacy Policy]: https://www.iubenda.com/privacy-policy/323220

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -578,7 +578,7 @@ When using Apiary Reporter and Apiary Tests, you are sending your testing data t
 - complete testing results (see [Apiary Reporter Test Data](data-structures.md#apiary-reporter-test-data); you can [sanitize them before they get sent](#removing-sensitive-data-from-test-reports))
 - little meta data about your environment (CI detection, Dredd version detection, hostname, ...)
 
-See also [guidelines on how to develop Apiary Reporter](#hacking-apiary-reporter).
+See also [guidelines on how to develop Apiary Reporter](contributing.md#hacking-apiary-reporter).
 
 ## Example Values for Request Parameters
 


### PR DESCRIPTION
#### :rocket: Why this change?

We should be transparent about this.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
