### PR TITLE
Use Travis CI without sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: "required"
-dist: "trusty"
 language: "node_js"
 node_js:
   - "0.10"
@@ -18,11 +16,12 @@ before_install:
   # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
   - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
   - "npm -g install npm@latest"
-  - "gem install travis"  # needed for 'npm run test:hooks-handlers'
+  #- "gem install travis"  # needed for 'npm run test:hooks-handlers', disabled because of https://github.com/apiaryio/dredd/issues/672
+install: "npm install --no-optional"
 script:
   - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
   - "npm test"
-  # - "npm run test:hooks-handlers" # disabled because of https://github.com/apiaryio/dredd/issues/672
+  #- "npm run test:hooks-handlers" # disabled because of https://github.com/apiaryio/dredd/issues/672
 after_success:
   - "npm run coveralls"
   - "npm run semantic-release || true"


### PR DESCRIPTION
#### :rocket: Why this change?

Travis CI offers two kinds of runtimes. Simplified,

- one is distro-based allows you to use `sudo` and install all kind of stuff on your own,
- second is container-based, has more limitations, but should be newer and faster.

Dredd did need `sudo` previously, because of C++11 compilation of the [drafter](https://github.com/apiaryio/drafter). Since drafter is now also JS-only, Dredd does not need the distro-based architecture anymore. This PR removes `sudo` and all related options from the Travis CI configuration. The PR also adds `--no-optional` to `npm install`, which forces npm to ignore C++11 compilation of drafter and to use the JS version directly. That should improve build time.

I did try to migrate Dredd's test suite to non-sudo builds previously already, but the test suite did not pass and grappled with the new/simpler/different environment. A lot of stuff was failing without obvious reasons. I filed https://github.com/apiaryio/dredd/issues/574 and postponed the works. Now I'm back to find out that Travis CI probably made changes to the new container-based architecture and there are no changes needed in the test suite at all. It passed at first try, no failures. Curious!

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/issues/574
- Possibly related to #422 and/or #204

#### :white_check_mark: What didn't I forget?

- [x] To write docs - there were no docs related to this change
- [x] To write tests - :trollface: 
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
