### PR TITLE
Do not rely on Travis CI default value for 'sudo' flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: "node_js"
 node_js:
   - "0.10"


### PR DESCRIPTION
#### ⚠️ Warning!

Please ignore AppVeyor builds. AppVeyor is present only to test the [`honzajavorek/appveyor`](https://github.com/apiaryio/dredd/tree/honzajavorek/appveyor) branch (in progress) and is expected to fail everywhere else.

#### :rocket: Why this change?

In https://github.com/apiaryio/dredd/pull/689 I thought I ensured Dredd's test suite runs on Travis CI without `sudo`. That was wrong assumption, because I've removed `sudo` flag altogether. However, the flag's default value depends on when the repository was first connected to Travis CI. See [docs](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments).

For that reason, I'm explicitly stating in the `.travis.yml` file that architecture without `sudo` should be used.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/689 (previous attempt)
- Closes https://github.com/apiaryio/dredd/issues/574 (now for real)
- Possibly related to #422 and/or #204

#### :white_check_mark: What didn't I forget?

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
