### PR TITLE
docs: update instructions for go best practices

### DIFF
--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -9,9 +9,7 @@ Go hooks are using [Dredd's hooks handler socket interface](hooks-new-language.m
 ## Installation
 
 ```
-$ go get github.com/snikch/goodman
-$ cd $GOPATH/src/github.com/snikch/goodman
-$ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
+$ go get github.com/snikch/goodman/cmd/goodman
 ```
 
 ## Usage

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -173,7 +173,7 @@ class DreddCommand
         else if config['language'] == 'perl'
           console.log "  $ cpanm Dredd::Hooks"
         else if config['language'] == 'go'
-          console.log "  $ go get github.com/snikch/goodman"
+          console.log "  $ go get github.com/snikch/goodman/cmd/goodman"
 
         console.log "  $ dredd"
         console.log ""

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -149,9 +149,7 @@ class HooksWorkerClient
         msg = '''\
           Go hooks handler command not found in $GOPATH/bin
           Install go hooks handler by running:
-          $ go get github.com/snikch/goodman
-          $ cd $GOPATH/src/github.com/snikch/goodman
-          $ go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
+          $ go get github.com/snikch/goodman/cmd/goodman
         '''
         return callback(new Error(msg))
       else

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -327,9 +327,7 @@ describe 'Hooks worker client', ->
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
           assert.isDefined err
-          assert.include err.message, "go get github.com/snikch/goodman"
-          assert.include err.message, "cd $GOPATH/src/github.com/snikch/goodman"
-          assert.include err.message, "go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman"
+          assert.include err.message, "go get github.com/snikch/goodman/cmd/goodman"
           done()
 
     describe 'when --language go option is given and the worker is installed', ->


### PR DESCRIPTION
#### :rocket: Why this change?
Its best practice in go to allow `go get` to install the package's binaries for you.

#### :memo: Related issues and Pull Requests
Please see https://github.com/snikch/goodman/issues/17


#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
