### PR TITLE
Dumb implementation for support --port and --host for hooks server

### DIFF
--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -163,10 +163,10 @@ class HooksWorkerClient
         callback()
 
   spawnHandler: (callback) ->
-    pathGlobs = [].concat ["--port", "#{@handlerPort}", "--host", "#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
+    args = [].concat ["--port", "#{@handlerPort}", "--host", "#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
 
-    logger.info("Spawning `#{@language}` hooks handler process with command `#{@handlerCommand} #{pathGlobs.join ","}`.")
-    @handler = crossSpawn.spawn @handlerCommand, pathGlobs
+    logger.info("Spawning `#{@language}` hooks handler process with command `#{@handlerCommand} #{args.join ","}`.")
+    @handler = crossSpawn.spawn @handlerCommand, args
 
     @handler.stdout.on 'data', (data) ->
       logger.info("Hooks handler stdout:", data.toString())

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -164,7 +164,6 @@ class HooksWorkerClient
 
   spawnHandler: (callback) ->
     pathGlobs = [].concat ["--port", "#{@handlerPort}", "--host", "#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
-    console.info pathGlobs
 
     logger.info("Spawning `#{@language}` hooks handler process with command `#{@handlerCommand} #{pathGlobs.join ","}`.")
     @handler = crossSpawn.spawn @handlerCommand, pathGlobs

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -163,7 +163,7 @@ class HooksWorkerClient
         callback()
 
   spawnHandler: (callback) ->
-    args = [].concat ["--port", "#{@handlerPort}", "--host", "#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
+    args = [].concat ["--port=#{@handlerPort}","--host=#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
 
     logger.info("Spawning `#{@language}` hooks handler process with command `#{@handlerCommand} #{args.join ","}`.")
     @handler = crossSpawn.spawn @handlerCommand, args

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -163,9 +163,10 @@ class HooksWorkerClient
         callback()
 
   spawnHandler: (callback) ->
-    pathGlobs = [].concat @runner.hooks?.configuration?.options?.hookfiles
+    pathGlobs = [].concat ["--port", "#{@handlerPort}", "--host", "#{@handlerHost}"], @runner.hooks?.configuration?.options?.hookfiles
+    console.info pathGlobs
 
-    logger.info("Spawning `#{@language}` hooks handler process.")
+    logger.info("Spawning `#{@language}` hooks handler process with command `#{@handlerCommand} #{pathGlobs.join ","}`.")
     @handler = crossSpawn.spawn @handlerCommand, pathGlobs
 
     @handler.stdout.on 'data', (data) ->

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -183,7 +183,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.rb'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.rb'
             done()
 
     describe 'when --language ruby option is given and the worker is not installed', ->
@@ -247,7 +247,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
             done()
 
     describe 'when --language python option is given and the worker is not installed', ->
@@ -310,7 +310,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
             done()
 
     describe 'when --language go option is given and the worker is not installed', ->
@@ -373,7 +373,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'gobinary'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'gobinary'
             done()
 
     describe 'when --language php option is given and the worker is not installed', ->
@@ -436,7 +436,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
             done()
 
     describe 'when --language perl option is given and the worker is not installed', ->
@@ -499,7 +499,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'someotherfile'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'someotherfile'
             done()
 
     describe "after loading", ->

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -183,7 +183,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.rb'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'somefile.rb'
             done()
 
     describe 'when --language ruby option is given and the worker is not installed', ->
@@ -247,7 +247,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'somefile.py'
             done()
 
     describe 'when --language python option is given and the worker is not installed', ->
@@ -310,7 +310,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'somefile.py'
             done()
 
     describe 'when --language go option is given and the worker is not installed', ->
@@ -373,7 +373,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'gobinary'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'gobinary'
             done()
 
     describe 'when --language php option is given and the worker is not installed', ->
@@ -436,7 +436,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'somefile.py'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'somefile.py'
             done()
 
     describe 'when --language perl option is given and the worker is not installed', ->
@@ -499,7 +499,7 @@ describe 'Hooks worker client', ->
 
           hooksWorkerClient.stop (err) ->
             assert.isUndefined err
-            assert.equal crossSpawnStub.spawn.getCall(0).args[1][4], 'someotherfile'
+            assert.equal crossSpawnStub.spawn.getCall(0).args[1][2], 'someotherfile'
             done()
 
     describe "after loading", ->


### PR DESCRIPTION
#### :rocket: Why this change?

To allow compliant hooks servers to listen on different ports and ip addresses

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd-hooks-template/issues/11
https://github.com/apiaryio/dredd-hooks-template/pull/17

#### :white_check_mark: What didn't I forget?

Still very much WIP since I believe there will need to be a discussion on what flags the hooks servers should look for (php already uses `--port` and `--host` but this can be up for discussion), how to stage these changes amongst the projects, etc.  I just wanted to get the simplest thing done so that I could run the dredd-hooks-php cucumber tests with [this](https://github.com/apiaryio/dredd-hooks-template/pull/17) new test to validate it works properly.