### PR TITLE
Prefer --option=value (GNU-style) format of long options

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -181,6 +181,12 @@ There is also one environment variable you could find useful:
 
 - `APIARY_API_URL='https://api.apiary.io'` - Allows to override host of the Apiary Tests API.
 
+### Misc Tips
+
+- When using long CLI options in tests or documentation, please always use the notation with `=`. For example,
+  use `--path=/dev/null`, not `--path /dev/null`. While both should work, the version with `=` feels
+  more like standard GNU-style long options and it makes arrays of arguments for `spawn` more readable.
+
 
 [Apiary]: https://apiary.io/
 

--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -17,7 +17,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
 Using Dredd with Go is slightly different to other languages, as a binary needs to be compiled for execution. The --hookfiles flags should point to compiled hook binaries.  See below for an example hooks.go file to get an idea of what the source file behind the go binary would look like.
 
 ```
-$ dredd apiary.apib http://localhost:3000 --server ./go-lang-web-server-to-test --language go --hookfiles ./hook-file-binary
+$ dredd apiary.apib http://localhost:3000 --server=./go-lang-web-server-to-test --language=go --hookfiles=./hook-file-binary
 ```
 
 ## API Reference

--- a/docs/hooks-perl.md
+++ b/docs/hooks-perl.md
@@ -15,7 +15,7 @@ $ cpanm Dredd::Hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language dredd-hooks-perl --hookfiles=./hooks*.pl
+$ dredd apiary.apib http://localhost:3000 --language=dredd-hooks-perl --hookfiles=./hooks*.pl
 ```
 
 ## API Reference

--- a/docs/hooks-php.md
+++ b/docs/hooks-php.md
@@ -20,7 +20,7 @@ $ composer require ddelnano/dredd-hooks-php --dev
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language vendor/bin/dredd-hooks-php --hookfiles=./hooks*.php
+$ dredd apiary.apib http://localhost:3000 --language=vendor/bin/dredd-hooks-php --hookfiles=./hooks*.php
 ```
 
 ## API Reference

--- a/docs/hooks-python.md
+++ b/docs/hooks-python.md
@@ -16,7 +16,7 @@ $ pip install dredd_hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language python --hookfiles=./hooks*.py
+$ dredd apiary.apib http://localhost:3000 --language=python --hookfiles=./hooks*.py
 ```
 
 ## API Reference

--- a/docs/hooks-ruby.md
+++ b/docs/hooks-ruby.md
@@ -15,7 +15,7 @@ $ gem install dredd_hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language ruby --hookfiles=./hooks*.rb
+$ dredd apiary.apib http://localhost:3000 --language=ruby --hookfiles=./hooks*.rb
 ```
 
 ## API Reference

--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -123,7 +123,7 @@ describe 'CLI', () ->
         before (done) ->
           languageCmd = "./foo/bar.sh"
           hookfiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language #{languageCmd} --hookfiles #{hookfiles} --server-wait 0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -168,7 +168,7 @@ describe 'CLI', () ->
         before (done) ->
           languageCmd = "./test/fixtures/scripts/exit_3.sh"
           hookfiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language #{languageCmd} --hookfiles #{hookfiles} --server-wait 0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -210,7 +210,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/kill-self.sh"
           hookFiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server #{serverCmd} --language #{languageCmd} --hookfiles #{hookFiles} --server-wait 0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
 
           app = express()
 
@@ -254,7 +254,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           hookFiles = "./test/fixtures/scripts/hooks-kill-after-all.coffee"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server #{serverCmd} --language #{languageCmd} --hookfiles #{hookFiles} --server-wait 0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
 
           killHandlerCmd = 'ps aux | grep "bash" | grep "endless-nosigterm.sh" | grep -v grep | awk \'{print $2}\' | xargs kill -9'
 
@@ -310,7 +310,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           hookFiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server '#{serverCmd}' --language '#{languageCmd}' --hookfiles #{hookFiles} --server-wait 0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server='#{serverCmd}' --language='#{languageCmd}' --hookfiles=#{hookFiles} --server-wait=0"
 
           app = express()
 

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -31,7 +31,7 @@ describe 'CLI - Reporters', ->
     args = [
       './test/fixtures/single-get.apib'
       "http://localhost:#{PORT}"
-      '--reporter nyan'
+      '--reporter=nyan'
     ]
 
     beforeEach (done) ->

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -129,7 +129,7 @@ describe 'Hooks worker client', ->
             done()
         , 100
 
-    describe 'when --language nodejs option is given', ->
+    describe 'when --language=nodejs option is given', ->
       beforeEach ->
         runner.hooks['configuration'] =
           options:
@@ -141,7 +141,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, 'native Node.js hooks instead'
           done()
 
-    describe 'when --language ruby option is given and the worker is installed', ->
+    describe 'when --language=ruby option is given and the worker is installed', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
@@ -186,7 +186,7 @@ describe 'Hooks worker client', ->
             assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.rb'
             done()
 
-    describe 'when --language ruby option is given and the worker is not installed', ->
+    describe 'when --language=ruby option is given and the worker is not installed', ->
       beforeEach ->
         sinon.stub whichStub, 'which', (command) -> false
 
@@ -205,7 +205,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, "gem install dredd_hooks"
           done()
 
-    describe 'when --language python option is given and the worker is installed', ->
+    describe 'when --language=python option is given and the worker is installed', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
@@ -250,7 +250,7 @@ describe 'Hooks worker client', ->
             assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
-    describe 'when --language python option is given and the worker is not installed', ->
+    describe 'when --language=python option is given and the worker is not installed', ->
       beforeEach ->
         sinon.stub whichStub, 'which', (command) -> false
 
@@ -268,7 +268,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, "pip install dredd_hooks"
           done()
 
-    describe 'when --language php option is given and the worker is installed', ->
+    describe 'when --language=php option is given and the worker is installed', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
@@ -313,7 +313,7 @@ describe 'Hooks worker client', ->
             assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
-    describe 'when --language go option is given and the worker is not installed', ->
+    describe 'when --language=go option is given and the worker is not installed', ->
       beforeEach ->
           sinon.stub whichStub, 'which', (command) -> false
 
@@ -330,7 +330,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, "go get github.com/snikch/goodman/cmd/goodman"
           done()
 
-    describe 'when --language go option is given and the worker is installed', ->
+    describe 'when --language=go option is given and the worker is installed', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
@@ -376,7 +376,7 @@ describe 'Hooks worker client', ->
             assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'gobinary'
             done()
 
-    describe 'when --language php option is given and the worker is not installed', ->
+    describe 'when --language=php option is given and the worker is not installed', ->
       beforeEach ->
         sinon.stub whichStub, 'which', (command) -> false
 
@@ -394,7 +394,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, "composer require ddelnano/dredd-hooks-php --dev"
           done()
 
-    describe 'when --language perl option is given and the worker is installed', ->
+    describe 'when --language=perl option is given and the worker is installed', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter
@@ -439,7 +439,7 @@ describe 'Hooks worker client', ->
             assert.equal crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py'
             done()
 
-    describe 'when --language perl option is given and the worker is not installed', ->
+    describe 'when --language=perl option is given and the worker is not installed', ->
       beforeEach ->
         sinon.stub whichStub, 'which', (command) -> false
 
@@ -457,7 +457,7 @@ describe 'Hooks worker client', ->
           assert.include err.message, "cpanm Dredd::Hooks"
           done()
 
-    describe 'when --language ./any/other-command is given', ->
+    describe 'when --language=./any/other-command is given', ->
       beforeEach ->
         sinon.stub crossSpawnStub, 'spawn', ->
           emitter = new EventEmitter


### PR DESCRIPTION
#### :rocket: Why this change?

I prefer to stick to UNIX / GNU conventions. This style of options is also less error-prone when trying to test Dredd on Windows.

#### :memo: Related issues and Pull Requests

- #204 

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
