### PR TITLE
Use home directory

### DIFF
--- a/test/integration/cli/api-description-cli-test.coffee
+++ b/test/integration/cli/api-description-cli-test.coffee
@@ -1,5 +1,6 @@
 
 fs = require 'fs'
+os = require 'os'
 {assert} = require 'chai'
 
 {execDredd, startServer} = require './helpers'
@@ -77,7 +78,7 @@ describe 'CLI - API Description Document', ->
     describe 'When given path exists, but can\'t be read', ->
       dreddCommand = undefined
       args = [
-        './test/fixtures/'
+        os.homedir(),
         "http://localhost:#{PORT}"
       ]
 


### PR DESCRIPTION
#### :rocket: Why this change?

The test checks a situation when Dredd is trying to read an existing path, but the path isn't a file, it is a directory. The test expects an exception will occur.

This change ensures the target is existing directory and that it is on a file system, which is native to the underlying operation system. E.g. when trying to read a directory as a file on NFS on Windows (can happen easily in VirtualBox, for instance), the operation won't throw an exception, but will read an empty string.

#### :memo: Related issues and Pull Requests

- #204 

#### :white_check_mark: What didn't I forget?

- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
