### PR TITLE
Use cross-spawn instead of exec

### DIFF
--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -71,7 +71,7 @@ describe 'CLI - Server Process', ->
       args = [
         './test/fixtures/single-get.apib'
         "http://localhost:#{PORT}"
-        "--server='coffee ./test/fixtures/scripts/dummy-server.coffee #{PORT}'"
+        "--server=coffee ./test/fixtures/scripts/dummy-server.coffee #{PORT}"
         '--server-wait=1'
       ]
 
@@ -115,7 +115,7 @@ describe 'CLI - Server Process', ->
           args = [
             scenario.apiDescriptionDocument
             "http://localhost:#{PORT}"
-            "--server='#{scenario.server}'"
+            "--server=#{scenario.server}"
             '--server-wait=1'
           ]
 
@@ -142,7 +142,7 @@ describe 'CLI - Server Process', ->
       args = [
         './test/fixtures/single-get.apib'
         "http://localhost:#{PORT}"
-        "--server='coffee ./test/fixtures/scripts/dummy-server-nosigterm.coffee #{PORT}'"
+        "--server=coffee ./test/fixtures/scripts/dummy-server-nosigterm.coffee #{PORT}"
         '--server-wait=1'
       ]
 


### PR DESCRIPTION
#### :rocket: Why this change?

This seems to be the only sane way to spawn subprocess on both Windows and UNIX in Node.js.

#### :memo: Related issues and Pull Requests

- #204 

#### :white_check_mark: What didn't I forget?

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
