### PR TITLE
Drop support for Node 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 env:
@@ -20,7 +18,7 @@ before_install:
   #- "gem install travis"  # needed for 'npm run test:hooks-handlers', disabled because of https://github.com/apiaryio/dredd/issues/672
 install: "npm install --no-optional"
 script:
-  - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
+  - "npm run lint"
   - "npm test"
   #- "npm run test:hooks-handlers" # disabled because of https://github.com/apiaryio/dredd/issues/672
 after_success:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dredd": "bin/dredd"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "scripts": {
     "lint": "conventional-changelog-lint --from=master && coffeelint src",
@@ -34,9 +34,9 @@
     "coffee-script": "^1.10.0",
     "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
-    "dredd-transactions": "^3.0.1",
+    "dredd-transactions": "^4.0.0",
     "file": "^0.2.2",
-    "gavel": "^0.5.3",
+    "gavel": "^1.0.0",
     "glob": "^7.0.5",
     "html": "^1.0.0",
     "htmlencode": "0.0.4",
@@ -69,7 +69,7 @@
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.0.0",
     "mocha-lcov-reporter": "^1.2.0",
-    "nock": "^8.0.0",
+    "nock": "^9.0.4",
     "semantic-release": "^6.3.2",
     "sinon": "^1.17.4"
   },

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt-get install -y mc curl git-core build-essential
 sudo su vagrant -c 'curl -L https://raw.github.com/creationix/nvm/master/install.sh | sh'
-sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh; nvm install v0.10.21'
-sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm use v0.10.21'
-sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm alias default v0.10.21'
+sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh; nvm install v6'
+sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm use v6'
+sudo su vagrant -c '. ~vagrant/.nvm/nvm.sh;nvm alias default v6'


### PR DESCRIPTION
#### :rocket: Why this change?

Node 0.10 and 0.12 are not supported anymore, so we're removing them from CI and we're removing any related workarounds.

- See https://github.com/apiaryio/dredd/issues/660 for the list of workarounds which this PR fixes.
- See https://github.com/nodejs/LTS#lts-schedule for details on why Node.js 0.10 and 0.12 can be both considered as officially dead since 2016-12-31.
- This is a breaking change, since we're dropping support of certain runtimes. Merging this PR should release **Dredd 3.0.0**.

#### :memo: Related issues and Pull Requests

Waits for https://github.com/apiaryio/dredd-transactions/pull/69 and https://github.com/apiaryio/gavel.js/pull/86, closes https://github.com/apiaryio/dredd/issues/660.

#### :white_check_mark: What didn't I forget?

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
