### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "url": "https://github.com/apiaryio/dredd"
   },
   "dependencies": {
-    "advisable": "^0.2.0",
     "async": "^2.0.0-rc.6",
     "chai": "^3.5.0",
     "clone": "^2.0.0",
@@ -49,14 +48,12 @@
     "request": "^2.74.0",
     "spawn-args": "^0.2.0",
     "sync-exec": "^0.6.2",
-    "uri-template": "^1.0.1",
     "uuid": "^3.0.0",
     "which": "^1.2.12",
     "winston": "^2.2.0"
   },
   "devDependencies": {
     "body-parser": "^1.15.2",
-    "codo": "^2.1.0",
     "coffee-coverage": "^1.0.1",
     "coffeelint": "^1.15.7",
     "conventional-changelog-lint": "^1.1.0",


### PR DESCRIPTION
#### :rocket: Why this change?

It seems these dependencies are not used anywhere in Dredd.

#### :white_check_mark: What didn't I forget?

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
