### PR TITLE
Use 127.0.0.1 instead of localhost

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -15,7 +15,7 @@ Transaction object is passed as a first argument to [hook functions](hooks.md) a
     - resourceName: `Hello, world!` (string)
     - actionName: `Retrieve Message` (string)
     - exampleName: `Example 2` (string)
-- host: `localhost` (string) - server hostname without port number
+- host: `127.0.0.1` (string) - server hostname without port number
 - port: `3000` (number) - server port number
 - protocol: `https:` (enum[string]) - server protocol
     - `https:` (string)

--- a/docs/hooks-go.md
+++ b/docs/hooks-go.md
@@ -17,7 +17,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
 Using Dredd with Go is slightly different to other languages, as a binary needs to be compiled for execution. The --hookfiles flags should point to compiled hook binaries.  See below for an example hooks.go file to get an idea of what the source file behind the go binary would look like.
 
 ```
-$ dredd apiary.apib http://localhost:3000 --server=./go-lang-web-server-to-test --language=go --hookfiles=./hook-file-binary
+$ dredd apiary.apib http://127.0.0.1:3000 --server=./go-lang-web-server-to-test --language=go --hookfiles=./hook-file-binary
 ```
 
 ## API Reference

--- a/docs/hooks-js-sandbox.md
+++ b/docs/hooks-js-sandbox.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --sandbox --hookfiles=./hooks*.js
+$ dredd apiary.apib http://127.0.0.1:3000 --sandbox --hookfiles=./hooks*.js
 ```
 
 ### Dredd JS API Option
@@ -13,7 +13,7 @@ Sandbox mode can be enabled in Dredd JavaScript API
 ```javascript
 var Dredd = require('dredd');
 var configuration = {
-  server: "http://localhost",
+  server: "http://127.0.0.1",
   options: {
     path: "./test/fixtures/single-get.apib",
     sandbox: true,

--- a/docs/hooks-new-language.md
+++ b/docs/hooks-new-language.md
@@ -4,7 +4,7 @@
 
 Dredd comes with concept of hooks language abstraction bridge via simple TCP socket.
 
-When you run Dredd with `--language` argument, it runs the command in argument and tries to connect to `http://localhost:61321`. If connection to the hook handling server wasn't successful, it exits with exit code `3`.
+When you run Dredd with `--language` argument, it runs the command in argument and tries to connect to `http://127.0.0.1:61321`. If connection to the hook handling server wasn't successful, it exits with exit code `3`.
 
 Dredd internally registers a function for each [type of hooks](hooks.md#types-of-hooks) and when this function is executed it assigns execution `uuid` to that event, serializes received function parameters (a [Transaction object](data-structures.md#transaction) or an Array of it), sends it to the TCP socket to be handled (executed) in other language and waits until message with same `uuid` is received. After data reception it assigns received `data` back to the transaction, so other language can interact with transactions same way like [native Node.js hooks](hooks-nodejs.md).
 
@@ -34,7 +34,7 @@ If you want to write a hook handler for your language you will have to implement
     - it exposes API similar to those in [Ruby](hooks-ruby.md), [Python](hooks-python.md) and [Node.js](hooks-nodejs.md) to each loaded file
     - it registers functions declared in files for later execution
 
-  - starts a TCP socket server and starts listening on `http://localhost:61321`.
+  - starts a TCP socket server and starts listening on `http://127.0.0.1:61321`.
 
 - When any data is received by the server
   - Adds every received character to a buffer

--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:30000 --hookfiles=./hooks*.js
+$ dredd apiary.apib http://127.0.0.1:30000 --hookfiles=./hooks*.js
 ```
 
 ## API Reference
@@ -244,5 +244,5 @@ With this workaround you can use [Babel](https://babeljs.io/) for support of all
 ```
 npm install -g babel-cli babel-preset-es2015
 echo '{ "presets": ["es2015"] }' > .babelrc
-babel-node `which dredd` test/fixtures/single-get.apib http://localhost:3000 --hookfiles=./es2015.js
+babel-node `which dredd` test/fixtures/single-get.apib http://127.0.0.1:3000 --hookfiles=./es2015.js
 ```

--- a/docs/hooks-perl.md
+++ b/docs/hooks-perl.md
@@ -15,7 +15,7 @@ $ cpanm Dredd::Hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language=dredd-hooks-perl --hookfiles=./hooks*.pl
+$ dredd apiary.apib http://127.0.0.1:3000 --language=dredd-hooks-perl --hookfiles=./hooks*.pl
 ```
 
 ## API Reference

--- a/docs/hooks-php.md
+++ b/docs/hooks-php.md
@@ -20,7 +20,7 @@ $ composer require ddelnano/dredd-hooks-php --dev
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language=vendor/bin/dredd-hooks-php --hookfiles=./hooks*.php
+$ dredd apiary.apib http://127.0.0.1:3000 --language=vendor/bin/dredd-hooks-php --hookfiles=./hooks*.php
 ```
 
 ## API Reference

--- a/docs/hooks-python.md
+++ b/docs/hooks-python.md
@@ -16,7 +16,7 @@ $ pip install dredd_hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language=python --hookfiles=./hooks*.py
+$ dredd apiary.apib http://127.0.0.1:3000 --language=python --hookfiles=./hooks*.py
 ```
 
 ## API Reference

--- a/docs/hooks-ruby.md
+++ b/docs/hooks-ruby.md
@@ -15,7 +15,7 @@ $ gem install dredd_hooks
 ## Usage
 
 ```
-$ dredd apiary.apib http://localhost:3000 --language=ruby --hookfiles=./hooks*.rb
+$ dredd apiary.apib http://127.0.0.1:3000 --language=ruby --hookfiles=./hooks*.rb
 ```
 
 ## API Reference

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -44,7 +44,7 @@ FORMAT: 1A
 To have an idea where we can hook our arbitrary code, we should first ask Dredd to list all available transaction names:
 
 ```
-$ dredd api-description.apib http://localhost:3000 --names
+$ dredd api-description.apib http://127.0.0.1:3000 --names
 info: Categories > Create a category
 info: Category > Delete a category
 info: Category Items > Create an item
@@ -125,7 +125,7 @@ paths:
 To have an idea where we can hook our arbitrary code, we should first ask Dredd to list all available transaction names:
 
 ```
-$ dredd api-description.yml http://localhost:3000 --names
+$ dredd api-description.yml http://127.0.0.1:3000 --names
 info: /categories > POST > 200 > application/json
 info: /category/{id} > DELETE > 200 > application/json
 info: /category/{id}/items > POST > 200 > application/json
@@ -212,7 +212,7 @@ FORMAT: 1A
 To have an idea where we can hook our arbitrary code, we should first ask Dredd to list all available transaction names:
 
 ```
-$ dredd api-description.apib http://localhost:3000 --names
+$ dredd api-description.apib http://127.0.0.1:3000 --names
 info: /login > POST
 info: /cars > GET
 info: /cars/{id} > PATCH
@@ -339,7 +339,7 @@ paths:
 To have an idea where we can hook our arbitrary code, we should first ask Dredd to list all available transaction names:
 
 ```
-$ dredd api-description.yml http://localhost:3000 --names
+$ dredd api-description.yml http://127.0.0.1:3000 --names
 info: /login > POST > 200 > application/json
 info: /cars > GET > 200 > application/json
 info: /cars/{id} > PATCH > 200 > application/json
@@ -405,7 +405,7 @@ dependencies:
     - npm install -g dredd@x.x.x
 test:
   pre:
-    - dredd apiary.apib http://localhost:3000
+    - dredd apiary.apib http://127.0.0.1:3000
 ```
 
 ### `.travis.yml` Configuration File for [Travis CI][]
@@ -414,7 +414,7 @@ test:
 before_install:
   - npm install -g dredd@x.x.x
 before_script:
-  - dredd apiary.apib http://localhost:3000
+  - dredd apiary.apib http://127.0.0.1:3000
 ```
 
 ## Authenticated APIs
@@ -508,7 +508,7 @@ FORMAT: 1A
 Dredd will detect two HTTP transaction examples and will compile following transaction names:
 
 ```
-$ dredd api-description.apib http://localhost --names
+$ dredd api-description.apib http://127.0.0.1 --names
 info: Beginning Dredd testing...
 info: Resource > Update Resource > Example 1
 info: Resource > Update Resource > Example 2
@@ -534,7 +534,7 @@ hooks.before('/resource > GET > 500 > application/json', function (transaction, 
 Command-line output of complex HTTP responses and expectations can be hard to read. To tackle the problem, you can use Dredd to send test reports to [Apiary][]. Apiary provides a comfortable interface for browsing complex test reports:
 
 ```
-$ dredd apiary.apib http://localhost --reporter=apiary
+$ dredd apiary.apib http://127.0.0.1 --reporter=apiary
 warn: Apiary API Key or API Project Subdomain were not provided. Configure Dredd to be able to save test reports alongside your Apiary API project: http://dredd.readthedocs.io/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
 info: Beginning Dredd testing...
 pass: DELETE /honey duration: 884ms

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,8 +92,8 @@ $ node app.js &
 Finally, let Dredd validate whether your freshly implemented API complies with the description you have:
 
 ```sh
-$ dredd api-description.apib http://localhost:3000  # API Blueprint
-$ dredd api-description.yml http://localhost:3000  # Swagger
+$ dredd api-description.apib http://127.0.0.1:3000  # API Blueprint
+$ dredd api-description.yml http://127.0.0.1:3000  # Swagger
 ```
 
 ## Configure Dredd
@@ -104,7 +104,7 @@ Dredd can be configured by [many CLI options](usage-cli.md). It's recommended to
 $ dredd init
 ? Location of the API description document: api-description.apib
 ? Command to start API backend server e.g. (bundle exec rails server)
-? URL of tested API endpoint: http://localhost:3000
+? URL of tested API endpoint: http://127.0.0.1:3000
 ? Programming language of hooks:
 ❯ nodejs
   python

--- a/docs/usage-cli.md
+++ b/docs/usage-cli.md
@@ -9,7 +9,7 @@ $ dredd '<API Description Document>' '<API Location>' [OPTIONS]
 Example:
 
 ```
-$ dredd ./apiary.md 'http://localhost:3000'
+$ dredd ./apiary.md http://127.0.0.1:3000
 ```
 
 ## Arguments
@@ -21,8 +21,8 @@ URL or path to the API description document (API Blueprint, Swagger).
 
 ### API Location (string)
 
-URL, the root address of your API.  
-**Sample values:** `http://localhost:3000`, `http://api.example.com`
+URL, the root address of your API.
+**Sample values:** `http://127.0.0.1:3000`, `http://api.example.com`
 
 ## Configuration File
 
@@ -67,7 +67,7 @@ timestamp: false
 silent: false
 path: []
 blueprint: api-description.apib
-endpoint: "http://localhost:3000"
+endpoint: "http://127.0.0.1:3000"
 ```
 
 > **Note:** Do not get confused by Dredd using a keyword `blueprint` also for paths to Swagger documents. This is for historical reasons and will be changed in the future.
@@ -118,7 +118,7 @@ Total hook worker connection timeout (includes all retries). [ms]
 
 ### --hooks-worker-handler-host
 Host of the hook worker.  
-**Default value:** `"localhost"`
+**Default value:** `"127.0.0.1"`
 
 ### --hooks-worker-handler-port
 Port of the hook worker.  

--- a/docs/usage-cli.md-template
+++ b/docs/usage-cli.md-template
@@ -9,7 +9,7 @@ $ dredd '<API Description Document>' '<API Location>' [OPTIONS]
 Example:
 
 ```
-$ dredd ./apiary.md 'http://localhost:3000'
+$ dredd ./apiary.md http://127.0.0.1:3000
 ```
 
 ## Arguments
@@ -21,8 +21,8 @@ URL or path to the API description document (API Blueprint, Swagger).
 
 ### API Location (string)
 
-URL, the root address of your API.  
-**Sample values:** `http://localhost:3000`, `http://api.example.com`
+URL, the root address of your API.
+**Sample values:** `http://127.0.0.1:3000`, `http://api.example.com`
 
 ## Configuration File
 
@@ -67,7 +67,7 @@ timestamp: false
 silent: false
 path: []
 blueprint: api-description.apib
-endpoint: "http://localhost:3000"
+endpoint: "http://127.0.0.1:3000"
 ```
 
 > **Note:** Do not get confused by Dredd using a keyword `blueprint` also for paths to Swagger documents. This is for historical reasons and will be changed in the future.

--- a/docs/usage-js.md
+++ b/docs/usage-js.md
@@ -28,7 +28,7 @@ Let's have a look at an example configuration first. (Please also see [options s
 
 ```javascript
 {
-  server: 'http://localhost:3000/api', // your URL to API endpoint the tests will run against
+  server: 'http://127.0.0.1:3000/api', // your URL to API endpoint the tests will run against
   options: {
 
     'path': [],       // Required Array if Strings; filepaths to API description documents, can use glob wildcards

--- a/src/configuration.coffee
+++ b/src/configuration.coffee
@@ -67,7 +67,7 @@ applyConfiguration = (config) ->
       'hooks-worker-after-connect-wait': 100
       'hooks-worker-term-timeout': 5000
       'hooks-worker-term-retry': 500
-      'hooks-worker-handler-host': 'localhost'
+      'hooks-worker-handler-host': '127.0.0.1'
       'hooks-worker-handler-port': 61321
 
   # normalize options and config

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -49,7 +49,7 @@ class DreddCommand
         $ dredd <path or URL to API description document> <URL of tested server> [OPTIONS]
 
       Example:
-        $ dredd ./api-description.apib http://localhost:3000 --dry-run
+        $ dredd ./api-description.apib http://127.0.0.1:3000 --dry-run
     ''')
       .options(Dredd.options)
       .wrap(80)

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -19,7 +19,7 @@ class HooksWorkerClient
     @afterConnectWait = options['hooks-worker-after-connect-wait'] || 100
     @termTimeout = options['hooks-worker-term-timeout'] || 5000
     @termRetry = options['hooks-worker-term-retry'] || 500
-    @handlerHost = options['hooks-worker-handler-host'] || 'localhost'
+    @handlerHost = options['hooks-worker-handler-host'] || '127.0.0.1'
     @handlerPort = options['hooks-worker-handler-port'] || 61321
     @handlerMessageDelimiter = '\n'
     @clientConnected = false

--- a/src/interactive-config.coffee
+++ b/src/interactive-config.coffee
@@ -28,7 +28,7 @@ interactiveConfig.prompt = (config = {}, callback) ->
     type: "input"
     name: "endpoint"
     message: "URL of tested API endpoint"
-    default: config['endpoint'] || "http://localhost:3000"
+    default: config['endpoint'] || "http://127.0.0.1:3000"
   }
 
   questions.push {

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -157,7 +157,7 @@ options =
 
   'hooks-worker-handler-host':
     description: 'Host of the hook worker.'
-    default: 'localhost'
+    default: '127.0.0.1'
 
   'hooks-worker-handler-port':
     description: 'Port of the hook worker.'

--- a/test/integration/cli/api-blueprint-cli-test.coffee
+++ b/test/integration/cli/api-blueprint-cli-test.coffee
@@ -41,7 +41,7 @@ describe 'CLI - API Blueprint Document', ->
 
     describe 'When successfully loaded', ->
       dreddCommand = undefined
-      args = ['./test/fixtures/single-get.apib', "http://localhost:#{PORT}"]
+      args = ['./test/fixtures/single-get.apib', "http://127.0.0.1:#{PORT}"]
 
       beforeEach (done) ->
         execDredd args, (err, commandInfo) ->
@@ -57,7 +57,7 @@ describe 'CLI - API Blueprint Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/error-blueprint.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -74,7 +74,7 @@ describe 'CLI - API Blueprint Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/warning-blueprint.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         '--no-color'
       ]
 

--- a/test/integration/cli/api-description-cli-test.coffee
+++ b/test/integration/cli/api-description-cli-test.coffee
@@ -46,7 +46,7 @@ describe 'CLI - API Description Document', ->
 
     describe 'When loaded by glob pattern', ->
       dreddCommand = undefined
-      args = ['./test/fixtures/single-g*t.apib', "http://localhost:#{PORT}"]
+      args = ['./test/fixtures/single-g*t.apib', "http://127.0.0.1:#{PORT}"]
 
       beforeEach (done) ->
         execDredd args, (err, commandInfo) ->
@@ -62,7 +62,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/__non-existent__.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -79,7 +79,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         os.homedir(),
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -98,8 +98,8 @@ describe 'CLI - API Description Document', ->
     describe 'When successfully loaded from URL', ->
       dreddCommand = undefined
       args = [
-        "http://localhost:#{PORT}/single-get.apib"
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}/single-get.apib"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -117,8 +117,8 @@ describe 'CLI - API Description Document', ->
     describe 'When URL points to non-existent server', ->
       dreddCommand = undefined
       args = [
-        "http://localhost:#{PORT_NON_EXISTENT}/single-get.apib"
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT_NON_EXISTENT}/single-get.apib"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -133,13 +133,13 @@ describe 'CLI - API Description Document', ->
       it 'should print error message to stderr', ->
         assert.include dreddCommand.stderr, 'Error when loading file from URL'
         assert.include dreddCommand.stderr, 'Is the provided URL correct?'
-        assert.include dreddCommand.stderr, "http://localhost:#{PORT_NON_EXISTENT}/single-get.apib"
+        assert.include dreddCommand.stderr, "http://127.0.0.1:#{PORT_NON_EXISTENT}/single-get.apib"
 
     describe 'When URL points to non-existent resource', ->
       dreddCommand = undefined
       args = [
-        "http://localhost:#{PORT}/__non-existent__.apib"
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}/__non-existent__.apib"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -154,7 +154,7 @@ describe 'CLI - API Description Document', ->
       it 'should print error message to stderr', ->
         assert.include dreddCommand.stderr, 'Unable to load file from URL'
         assert.include dreddCommand.stderr, 'responded with status code 404'
-        assert.include dreddCommand.stderr, "http://localhost:#{PORT}/__non-existent__.apib"
+        assert.include dreddCommand.stderr, "http://127.0.0.1:#{PORT}/__non-existent__.apib"
 
 
   describe 'When loaded by -p/--path', ->
@@ -163,7 +163,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--path=./test/fixtures/single-get-uri-template.apib"
       ]
 
@@ -181,8 +181,8 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get-uri-template.apib'
-        "http://localhost:#{PORT}"
-        "--path=http://localhost:#{PORT}/single-get.apib"
+        "http://127.0.0.1:#{PORT}"
+        "--path=http://127.0.0.1:#{PORT}/single-get.apib"
       ]
 
       beforeEach (done) ->
@@ -201,7 +201,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--path=./test/fixtures/single-get-uri-template.apib"
         "--path=./test/fixtures/single-get-path.apib"
       ]
@@ -220,7 +220,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--path=./test/fixtures/single-get-uri-temp*.apib"
       ]
 
@@ -238,7 +238,7 @@ describe 'CLI - API Description Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--path=./test/fixtures/__non-existent__.apib"
       ]
 

--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -46,7 +46,7 @@ describe 'CLI', () ->
     describe "when executing the command and the server is responding as specified in the API description", () ->
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT}"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT}"
 
         app = express()
 
@@ -69,7 +69,7 @@ describe 'CLI', () ->
 
     describe "when executing the command and the server is responding as specified in the API description, endpoint with path", () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT}/v2/"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT}/v2/"
 
         app = express()
 
@@ -92,7 +92,7 @@ describe 'CLI', () ->
 
     describe "when executing the command and the server is sending different response", () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT}"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT}"
 
         app = express()
 
@@ -123,7 +123,7 @@ describe 'CLI', () ->
         before (done) ->
           languageCmd = "./foo/bar.sh"
           hookfiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -168,7 +168,7 @@ describe 'CLI', () ->
         before (done) ->
           languageCmd = "./test/fixtures/scripts/exit_3.sh"
           hookfiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --language=#{languageCmd} --hookfiles=#{hookfiles} --server-wait=0"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -210,7 +210,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/kill-self.sh"
           hookFiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
 
           app = express()
 
@@ -254,7 +254,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           hookFiles = "./test/fixtures/scripts/hooks-kill-after-all.coffee"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --server=#{serverCmd} --language=#{languageCmd} --hookfiles=#{hookFiles} --server-wait=0"
 
           killHandlerCmd = 'ps aux | grep "bash" | grep "endless-nosigterm.sh" | grep -v grep | awk \'{print $2}\' | xargs kill -9'
 
@@ -310,7 +310,7 @@ describe 'CLI', () ->
           serverCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           languageCmd = "./test/fixtures/scripts/endless-nosigterm.sh"
           hookFiles = "./test/fixtures/scripts/emptyfile"
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --server='#{serverCmd}' --language='#{languageCmd}' --hookfiles=#{hookFiles} --server-wait=0"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --server='#{serverCmd}' --language='#{languageCmd}' --hookfiles=#{hookFiles} --server-wait=0"
 
           app = express()
 
@@ -363,7 +363,7 @@ describe 'CLI', () ->
       receivedRequest = {}
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -h Accept:application/json"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -h Accept:application/json"
 
         app = express()
 
@@ -391,7 +391,7 @@ describe 'CLI', () ->
       receivedRequest = {}
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -u username:password"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -u username:password"
 
         app = express()
 
@@ -419,7 +419,7 @@ describe 'CLI', () ->
 
     describe "when sorting requests with -s", () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/apiary.apib http://localhost:#{PORT} -s"
+        cmd = "#{DREDD_BIN} ./test/fixtures/apiary.apib http://127.0.0.1:#{PORT} -s"
 
         app = express()
 
@@ -443,7 +443,7 @@ describe 'CLI', () ->
     describe 'when displaying errors inline with -e', () ->
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -e"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -e"
 
         app = express()
 
@@ -469,7 +469,7 @@ describe 'CLI', () ->
 
     describe 'when showing details for all requests with -d', () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -d"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -d"
 
         app = express()
 
@@ -498,7 +498,7 @@ describe 'CLI', () ->
         receivedRequest = {}
 
         before (done) ->
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -m POST"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -m POST"
 
           app = express()
 
@@ -525,7 +525,7 @@ describe 'CLI', () ->
         receivedRequest = {}
 
         before (done) ->
-          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -m GET"
+          cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -m GET"
 
           app = express()
 
@@ -552,7 +552,7 @@ describe 'CLI', () ->
       machineHit = false
       messageHit = false
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --path=./test/fixtures/multifile/*.apib --only=\"Message API > /message > GET\" --no-color"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --path=./test/fixtures/multifile/*.apib --only=\"Message API > /message > GET\" --no-color"
 
         app = express()
 
@@ -590,7 +590,7 @@ describe 'CLI', () ->
 
     describe 'when suppressing color with --no-color', () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color"
 
         app = express()
 
@@ -615,7 +615,7 @@ describe 'CLI', () ->
 
     describe 'when suppressing color with --color false', () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --color false"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --color false"
 
         app = express()
 
@@ -640,7 +640,7 @@ describe 'CLI', () ->
 
     describe 'when setting the log output level with -l', () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -l=error"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -l=error"
 
         app = express()
 
@@ -664,7 +664,7 @@ describe 'CLI', () ->
 
     describe 'when showing timestamps with -t', () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} -t"
+        cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} -t"
 
         app = express()
 
@@ -691,7 +691,7 @@ describe 'CLI', () ->
     receivedRequest = {}
 
     before (done) ->
-      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --hookfiles=./test/fixtures/*_hooks.*"
+      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --hookfiles=./test/fixtures/*_hooks.*"
 
       app = express()
 
@@ -723,7 +723,7 @@ describe 'CLI', () ->
       return false
 
     before (done) ->
-      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --hookfiles=./test/fixtures/*_events.*"
+      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --hookfiles=./test/fixtures/*_events.*"
 
       app = express()
 
@@ -758,7 +758,7 @@ describe 'CLI', () ->
       return ret.join(',')
 
     before (done) ->
-      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --hookfiles=./test/fixtures/*_all.*"
+      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --hookfiles=./test/fixtures/*_all.*"
 
       app = express()
 
@@ -786,7 +786,7 @@ describe 'CLI', () ->
     describe "and server is responding in accordance with the schema", () ->
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/schema.apib http://localhost:#{PORT}"
+        cmd = "#{DREDD_BIN} ./test/fixtures/schema.apib http://127.0.0.1:#{PORT}"
 
         app = express()
 
@@ -811,7 +811,7 @@ describe 'CLI', () ->
     describe "and server is NOT responding in accordance with the schema", () ->
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/schema.apib http://localhost:#{PORT}"
+        cmd = "#{DREDD_BIN} ./test/fixtures/schema.apib http://127.0.0.1:#{PORT}"
 
         app = express()
 
@@ -836,7 +836,7 @@ describe 'CLI', () ->
   describe "when API description document path is a glob", () ->
     describe "and called with --names options", () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/multifile/*.apib http://localhost --names"
+        cmd = "#{DREDD_BIN} ./test/fixtures/multifile/*.apib http://127.0.0.1 --names"
         execCommand cmd, () ->
           done()
 
@@ -853,7 +853,7 @@ describe 'CLI', () ->
       receivedRequests = []
 
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/multifile/*.apib http://localhost:#{PORT} --hookfiles=./test/fixtures/multifile/multifile_hooks.coffee"
+        cmd = "#{DREDD_BIN} ./test/fixtures/multifile/*.apib http://127.0.0.1:#{PORT} --hookfiles=./test/fixtures/multifile/multifile_hooks.coffee"
 
         app = express()
 
@@ -893,7 +893,7 @@ describe 'CLI', () ->
   describe "when called with additional --path argument which is a glob", () ->
     describe "and called with --names options", () ->
       before (done) ->
-        cmd = "#{DREDD_BIN} ./test/fixtures/multiple-examples.apib http://localhost --path=./test/fixtures/multifile/*.apib --names --no-color"
+        cmd = "#{DREDD_BIN} ./test/fixtures/multiple-examples.apib http://127.0.0.1 --path=./test/fixtures/multifile/*.apib --names --no-color"
         execCommand cmd, () ->
           done()
 
@@ -911,7 +911,7 @@ describe 'CLI', () ->
     resourceRequested = false
 
     before (done) ->
-      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --no-color --sandbox --hookfiles=./test/fixtures/sandboxed-hook.js"
+      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --no-color --sandbox --hookfiles=./test/fixtures/sandboxed-hook.js"
 
       app = express()
 

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -30,7 +30,7 @@ describe 'CLI - Reporters', ->
     dreddCommand = undefined
     args = [
       './test/fixtures/single-get.apib'
-      "http://localhost:#{PORT}"
+      "http://127.0.0.1:#{PORT}"
       '--reporter=nyan'
     ]
 
@@ -48,7 +48,7 @@ describe 'CLI - Reporters', ->
     apiary = undefined
 
     env = clone process.env
-    env.APIARY_API_URL = "http://localhost:#{PORT_APIARY}"
+    env.APIARY_API_URL = "http://127.0.0.1:#{PORT_APIARY}"
 
     configureApiary = (app) ->
       app.post '/apis/*', (req, res) ->
@@ -74,7 +74,7 @@ describe 'CLI - Reporters', ->
       stepRequest = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         '--reporter=apiary'
       ]
 
@@ -110,7 +110,7 @@ describe 'CLI - Reporters', ->
       stepRequest = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         '--reporter=apiary'
         '--hookfiles=./test/fixtures/hooks_log.coffee'
       ]
@@ -164,7 +164,7 @@ describe 'CLI - Reporters', ->
       stepRequest = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         '--reporter=apiary'
         '--level=info'
         '--sandbox'
@@ -209,7 +209,7 @@ describe 'CLI - Reporters', ->
     dreddCommand = undefined
     args = [
       './test/fixtures/single-get.apib'
-      "http://localhost:#{PORT}"
+      "http://127.0.0.1:#{PORT}"
       '--reporter=junit'
       '--output=__test_file_output__.xml'
     ]
@@ -230,7 +230,7 @@ describe 'CLI - Reporters', ->
     dreddCommand = undefined
     args = [
       './test/fixtures/single-get.apib'
-      "http://localhost:#{PORT}"
+      "http://127.0.0.1:#{PORT}"
       '--reporter=junit'
       '--output=__test_file_output1__.xml'
       '--reporter=junit'

--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -29,7 +29,7 @@ describe 'CLI - Server Process', ->
 
     describe 'When is running', ->
       dreddCommand = undefined
-      args = ['./test/fixtures/single-get.apib', "http://localhost:#{PORT}"]
+      args = ['./test/fixtures/single-get.apib', "http://127.0.0.1:#{PORT}"]
 
       beforeEach (done) ->
         execDredd args, (err, commandInfo) ->
@@ -43,7 +43,7 @@ describe 'CLI - Server Process', ->
 
     describe 'When is not running', ->
       dreddCommand = undefined
-      args = ['./test/fixtures/apiary.apib', "http://localhost:#{PORT_NON_EXISTENT}"]
+      args = ['./test/fixtures/apiary.apib', "http://127.0.0.1:#{PORT_NON_EXISTENT}"]
 
       beforeEach (done) ->
         execDredd args, (err, commandInfo) ->
@@ -70,7 +70,7 @@ describe 'CLI - Server Process', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--server=coffee ./test/fixtures/scripts/dummy-server.coffee #{PORT}"
         '--server-wait=1'
       ]
@@ -114,7 +114,7 @@ describe 'CLI - Server Process', ->
           dreddCommand = undefined
           args = [
             scenario.apiDescriptionDocument
-            "http://localhost:#{PORT}"
+            "http://127.0.0.1:#{PORT}"
             "--server=#{scenario.server}"
             '--server-wait=1'
           ]
@@ -141,7 +141,7 @@ describe 'CLI - Server Process', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/single-get.apib'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         "--server=coffee ./test/fixtures/scripts/dummy-server-nosigterm.coffee #{PORT}"
         '--server-wait=1'
       ]

--- a/test/integration/cli/swagger-cli-test.coffee
+++ b/test/integration/cli/swagger-cli-test.coffee
@@ -41,7 +41,7 @@ describe 'CLI - Swagger Document', ->
 
     describe 'When successfully loaded', ->
       dreddCommand = undefined
-      args = ['./test/fixtures/single-get.yaml', "http://localhost:#{PORT}"]
+      args = ['./test/fixtures/single-get.yaml', "http://127.0.0.1:#{PORT}"]
 
       beforeEach (done) ->
         execDredd args, (err, commandInfo) ->
@@ -57,7 +57,7 @@ describe 'CLI - Swagger Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/error-swagger.yaml'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
       ]
 
       beforeEach (done) ->
@@ -74,7 +74,7 @@ describe 'CLI - Swagger Document', ->
       dreddCommand = undefined
       args = [
         './test/fixtures/warning-swagger.yaml'
-        "http://localhost:#{PORT}"
+        "http://127.0.0.1:#{PORT}"
         '--no-color'
       ]
 

--- a/test/integration/dredd-command-test.coffee
+++ b/test/integration/dredd-command-test.coffee
@@ -72,7 +72,7 @@ describe "DreddCommand class Integration", () ->
     describe('When specifying custom configuration file by --config', ->
       configPath = '../../custom-dredd-config-path.yaml'
       cmd = {argv: ['--config', configPath]}
-      options = {_: ['api-description.apib', 'http://localhost']}
+      options = {_: ['api-description.apib', 'http://127.0.0.1']}
 
       fsExistsSync = undefined
       configUtilsLoad = undefined
@@ -101,7 +101,7 @@ describe "DreddCommand class Integration", () ->
     describe('When dredd.yml exists', ->
       configPath = './dredd.yml'
       cmd = {argv: []}
-      options = {_: ['api-description.apib', 'http://localhost']}
+      options = {_: ['api-description.apib', 'http://127.0.0.1']}
 
       fsExistsSync = undefined
       configUtilsLoad = undefined
@@ -130,7 +130,7 @@ describe "DreddCommand class Integration", () ->
     describe('When dredd.yml does not exist', ->
       configPath = './dredd.yml'
       cmd = {argv: []}
-      options = {_: ['api-description.apib', 'http://localhost']}
+      options = {_: ['api-description.apib', 'http://127.0.0.1']}
 
       fsExistsSync = undefined
       configUtilsLoad = undefined
@@ -161,16 +161,16 @@ describe "DreddCommand class Integration", () ->
     server = null
 
     errorCmd = argv: [
-      "http://localhost:#{PORT+1}/connection-error.apib"
-      "http://localhost:#{PORT+1}"
+      "http://127.0.0.1:#{PORT+1}/connection-error.apib"
+      "http://127.0.0.1:#{PORT+1}"
     ]
     wrongCmd = argv: [
-      "http://localhost:#{PORT}/not-found.apib"
-      "http://localhost:#{PORT}"
+      "http://127.0.0.1:#{PORT}/not-found.apib"
+      "http://127.0.0.1:#{PORT}"
     ]
     goodCmd = argv: [
-      "http://localhost:#{PORT}/file.apib"
-      "http://localhost:#{PORT}"
+      "http://127.0.0.1:#{PORT}/file.apib"
+      "http://127.0.0.1:#{PORT}"
     ]
 
     before (done) ->

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -33,7 +33,7 @@ execCommand = (options = {}, cb) ->
   stderr = ''
   exitStatus = null
   finished = false
-  options.server ?= "http://localhost:#{PORT}"
+  options.server ?= "http://127.0.0.1:#{PORT}"
   options.level ?= 'info'
   new Dredd(options).run (error, stats = {}) ->
     if not finished
@@ -340,17 +340,17 @@ describe 'Dredd class Integration', ->
     fileFound = null
 
     errorCmd =
-      server: "http://localhost:#{PORT + 1}"
+      server: "http://127.0.0.1:#{PORT + 1}"
       options:
-        path: ["http://localhost:#{PORT + 1}/connection-error.apib"]
+        path: ["http://127.0.0.1:#{PORT + 1}/connection-error.apib"]
 
     wrongCmd =
       options:
-        path: ["http://localhost:#{PORT}/not-found.apib"]
+        path: ["http://127.0.0.1:#{PORT}/not-found.apib"]
 
     goodCmd =
       options:
-        path: ["http://localhost:#{PORT}/file.apib"]
+        path: ["http://127.0.0.1:#{PORT}/file.apib"]
 
     afterEach ->
       connectedToServer = null

--- a/test/integration/helpers.coffee
+++ b/test/integration/helpers.coffee
@@ -8,7 +8,7 @@ DEFAULT_SERVER_PORT = 9876
 
 
 runDredd = (dredd, cb) ->
-  dredd.configuration.server ?= "http://localhost:#{DEFAULT_SERVER_PORT}"
+  dredd.configuration.server ?= "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
 
   silent = !!logger.transports.console.silent
   logger.transports.console.silent = true # supress Dredd's console output (remove if debugging)
@@ -32,7 +32,7 @@ runDredd = (dredd, cb) ->
 
 runDreddWithServer = (dredd, app, port, cb) ->
   [cb, port] = [port, DEFAULT_SERVER_PORT] if typeof port is 'function'
-  dredd.configuration.server ?= "http://localhost:#{port}"
+  dredd.configuration.server ?= "http://127.0.0.1:#{port}"
 
   server = app.listen(port, (err) ->
     return cb(err) if err

--- a/test/regressions/regression-152-test.coffee
+++ b/test/regressions/regression-152-test.coffee
@@ -42,7 +42,7 @@ describe "Regression: Issue #152", () ->
     receivedRequest = {}
 
     before (done) ->
-      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://localhost:#{PORT} --hookfiles=./test/fixtures/regression-152.coffee"
+      cmd = "#{DREDD_BIN} ./test/fixtures/single-get.apib http://127.0.0.1:#{PORT} --hookfiles=./test/fixtures/regression-152.coffee"
 
       app = express()
 

--- a/test/regressions/regression-319-354-test.coffee
+++ b/test/regressions/regression-319-354-test.coffee
@@ -10,7 +10,7 @@ DREDD_BIN = require.resolve '../../bin/dredd'
 
 runDredd = (descriptionFile, cb) ->
   result = {}
-  cmd = "#{DREDD_BIN} #{descriptionFile} http://localhost:#{PORT} -ed --no-color"
+  cmd = "#{DREDD_BIN} #{descriptionFile} http://127.0.0.1:#{PORT} -ed --no-color"
 
   cli = exec cmd, (err, stdout, stderr) ->
     result.exitStatus = err?.code or null

--- a/test/regressions/regression-615-test.coffee
+++ b/test/regressions/regression-615-test.coffee
@@ -10,7 +10,7 @@ DREDD_BIN = require.resolve '../../bin/dredd'
 
 runDredd = (descriptionFile, cb) ->
   result = {}
-  cmd = "#{DREDD_BIN} #{descriptionFile} http://localhost:#{PORT} -ed --no-color"
+  cmd = "#{DREDD_BIN} #{descriptionFile} http://127.0.0.1:#{PORT} -ed --no-color"
 
   cli = exec cmd, (err, stdout, stderr) ->
     result.exitStatus = err?.code or null

--- a/test/unit/dredd-command-test.coffee
+++ b/test/unit/dredd-command-test.coffee
@@ -139,7 +139,7 @@ describe "DreddCommand class", () ->
       dc = new DreddCommand({
         exit: ->
         custom:
-          argv: ['./file.apib', 'http://localhost:3000']
+          argv: ['./file.apib', 'http://127.0.0.1:3000']
           env: {'NO_KEY': 'NO_VAL'}
       })
 
@@ -197,7 +197,7 @@ describe "DreddCommand class", () ->
         custom:
           argv: [
             './test/fixtures/single-get.apib'
-            "http://localhost:#{PORT}"
+            "http://127.0.0.1:#{PORT}"
             '--path=./test/fixtures/single-get.apib'
           ]
         exit: (code) ->
@@ -219,7 +219,7 @@ describe "DreddCommand class", () ->
 
       it 'propagates configuration options to Dredd class', ->
         assert.equal dc.dreddInstance.configuration.options.path[0], "./test/fixtures/single-get.apib"
-        assert.equal dc.dreddInstance.configuration.server, "http://localhost:#{PORT}"
+        assert.equal dc.dreddInstance.configuration.server, "http://127.0.0.1:#{PORT}"
 
     describe 'with server returning wrong things', ->
 
@@ -231,7 +231,7 @@ describe "DreddCommand class", () ->
 
       it 'propagates configuration options to Dredd class', ->
         assert.equal dc.dreddInstance.configuration.options.path[0], "./test/fixtures/single-get.apib"
-        assert.equal dc.dreddInstance.configuration.server, "http://localhost:#{PORT}"
+        assert.equal dc.dreddInstance.configuration.server, "http://127.0.0.1:#{PORT}"
 
 
   describe "when called w/ OR wo/ exiting arguments", () ->
@@ -422,7 +422,7 @@ describe "DreddCommand class", () ->
   #       custom:
   #         argv: [
   #           "./test/fixtures/single-get.apib"
-  #           "http://localhost:#{PORT}"
+  #           "http://127.0.0.1:#{PORT}"
   #           "--server"
   #           "./test/fixtures/scripts/fake-server.sh"
   #         ]

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -31,7 +31,7 @@ describe 'Dredd class', ->
   describe 'with legacy configuration', ->
     before ->
       configuration =
-        server: 'http://localhost:3000/'
+        server: 'http://127.0.0.1:3000/'
         blueprintPath: './test/fixtures/apiary.apib'
        sinon.stub loggerStub, 'info', ->
        sinon.stub loggerStub, 'log', ->
@@ -56,7 +56,7 @@ describe 'Dredd class', ->
   describe 'with valid configuration', ->
     before ->
       configuration =
-        server: 'http://localhost:3000/'
+        server: 'http://127.0.0.1:3000/'
         options:
           silent: true
           method: 'get'
@@ -110,7 +110,7 @@ describe 'Dredd class', ->
     describe 'when paths specified with glob paterns', ->
       before ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
             silent: true
             path: ['./test/fixtures/multifile/*.apib', './test/fixtures/multifile/*.apib' ,'./test/fixtures/multifile/*.balony']
@@ -160,7 +160,7 @@ describe 'Dredd class', ->
     describe 'when glob pattern does not match any files', ->
       before ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
             silent: true
             path: ['./test/fixtures/multifile/*.balony']
@@ -182,7 +182,7 @@ describe 'Dredd class', ->
     describe 'when configuration contains data object with "filename" as key, and an API description document contents as value', ->
       beforeEach ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
             silent: true
           data:
@@ -270,7 +270,7 @@ describe 'Dredd class', ->
       blueprintCode = null
       before (done) ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
             silent: true
             path: ['http://some.path.to/file.apib', 'https://another.path.to/apiary.apib', './test/fixtures/multifile/*.apib']
@@ -397,7 +397,7 @@ describe 'Dredd class', ->
   describe 'when API description document parsing error', ->
     before ->
       configuration =
-        url: 'http://localhost:3000/'
+        url: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./test/fixtures/error-blueprint.apib']
@@ -423,7 +423,7 @@ describe 'Dredd class', ->
   describe 'when API description document parsing warning', ->
     before ->
       configuration =
-        url: 'http://localhost:3000/'
+        url: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./test/fixtures/warning-ambiguous.apib']
@@ -451,7 +451,7 @@ describe 'Dredd class', ->
   describe 'when non existing API description document path', ->
     beforeEach ->
       configuration =
-        url: 'http://localhost:3000/'
+        url: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./balony/path.apib']
@@ -475,7 +475,7 @@ describe 'Dredd class', ->
   describe 'when runtime contains any error', ->
     beforeEach ->
       configuration =
-        server: 'http://localhost:3000/'
+        server: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./test/fixtures/error-uri-template.apib']
@@ -500,7 +500,7 @@ describe 'Dredd class', ->
   describe 'when runtime contains any warning', ->
     beforeEach ->
       configuration =
-        server: 'http://localhost:3000/'
+        server: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./test/fixtures/warning-ambiguous.apib']
@@ -531,7 +531,7 @@ describe 'Dredd class', ->
   describe 'when runtime is without errors and warnings', ->
     beforeEach ->
       configuration =
-        server: 'http://localhost:3000/'
+        server: 'http://127.0.0.1:3000/'
         options:
           silent: true
           path: ['./test/fixtures/apiary.apib']
@@ -556,7 +556,7 @@ describe 'Dredd class', ->
 
       beforeEach (done) ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
             silent: true
             reporter: ['apiary']
@@ -606,7 +606,7 @@ describe 'Dredd class', ->
 
       beforeEach ->
         configuration =
-          server: 'http://localhost:3000/'
+          server: 'http://127.0.0.1:3000/'
           options:
 
             reporter: ['apiary']

--- a/test/unit/interactive-config-test.coffee
+++ b/test/unit/interactive-config-test.coffee
@@ -36,7 +36,7 @@ describe 'interactiveConfig', () ->
         answers =
           blueprint: 'apiary.apib'
           server: 'rails server'
-          endpoint: 'http://localhost:3000'
+          endpoint: 'http://127.0.0.1:3000'
           apiary: true
           apiaryApiKey: 'key'
           apiaryApiName: 'name'
@@ -56,7 +56,7 @@ describe 'interactiveConfig', () ->
 
         it 'should have properties set from the config on proper places', () ->
           assert.equal object['_'][0], 'apiary.apib'
-          assert.equal object['_'][1], 'http://localhost:3000'
+          assert.equal object['_'][1], 'http://127.0.0.1:3000'
           assert.equal object['server'], 'rails server'
           assert.equal object['reporter'], 'apiary'
           assert.equal object['custom']['apiaryApiKey'], 'key'
@@ -67,7 +67,7 @@ describe 'interactiveConfig', () ->
         answers =
           blueprint: 'apiary.apib',
           server: 'rails server',
-          endpoint: 'http://localhost:3000',
+          endpoint: 'http://127.0.0.1:3000',
           ciAdd: true
 
         config =
@@ -88,7 +88,7 @@ describe 'interactiveConfig', () ->
 
         it 'should have properties set from the config on proper places', () ->
             assert.equal object['_'][0], 'apiary.apib'
-            assert.equal object['_'][1], 'http://localhost:3000'
+            assert.equal object['_'][1], 'http://127.0.0.1:3000'
 
             assert.equal object['reporter'], 'apiary'
             assert.equal object['custom']['apiaryApiKey'], '123123123'

--- a/test/unit/reporters/apiary-reporter-test.coffee
+++ b/test/unit/reporters/apiary-reporter-test.coffee
@@ -58,7 +58,7 @@ describe 'ApiaryReporter', () ->
       tests = []
       emitter = new EventEmitter
       env = {'CIRCLE_VARIABLE': 'CIRCLE_VALUE'}
-      env['APIARY_API_URL'] = "https://localhost:#{PORT}"
+      env['APIARY_API_URL'] = "https://127.0.0.1:#{PORT}"
       delete env['APIARY_API_KEY']
       delete env['APIARY_API_NAME']
 
@@ -592,7 +592,7 @@ describe 'ApiaryReporter', () ->
       emitter = new EventEmitter
 
       env = {}
-      env['APIARY_API_URL'] = "https://localhost:#{PORT}"
+      env['APIARY_API_URL'] = "https://127.0.0.1:#{PORT}"
       env['APIARY_API_KEY'] = "aff888af9993db9ef70edf3c878ab521"
       env['APIARY_API_NAME'] = "jakubtest"
       test =

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -31,7 +31,7 @@ describe 'TransactionRunner', ->
 
   server = {}
   configuration =
-    server: 'http://localhost:3000'
+    server: 'http://127.0.0.1:3000'
     emitter: new EventEmitter()
     options:
       'dry-run': false
@@ -68,7 +68,7 @@ describe 'TransactionRunner', ->
     describe 'when single file in data is present', ->
       it 'should set multiBlueprint to false', ->
         configuration =
-          server: 'http://localhost:3000'
+          server: 'http://127.0.0.1:3000'
           emitter: new EventEmitter()
           data: {"file1": {"raw": "blueprint1"}}
           options:
@@ -86,7 +86,7 @@ describe 'TransactionRunner', ->
     describe 'when multiple files in data are present', ->
       it 'should set multiBlueprint to true', ->
         configuration =
-          server: 'http://localhost:3000'
+          server: 'http://127.0.0.1:3000'
           emitter: new EventEmitter()
           data: {"file1": {"raw": "blueprint1"}, "file2": {"raw": "blueprint2"} }
           options:
@@ -132,56 +132,56 @@ describe 'TransactionRunner', ->
 
       [
         description: 'is hostname'
-        input: {serverUrl: 'https://localhost:8000', requestPath: '/hello'}
-        expected: {host: 'localhost', port: '8000', protocol: 'https:', fullPath: '/hello'}
+        input: {serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello'}
       ,
         description: 'is IPv4'
         input: {serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello'}
         expected: {host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello'}
       ,
         description: 'has path'
-        input: {serverUrl: 'http://localhost:8000/v1', requestPath: '/hello'}
-        expected: {host: 'localhost', port: '8000', protocol: 'http:', fullPath: '/v1/hello'}
+        input: {serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello'}
       ,
         description: 'has path with trailing slash'
         input: {serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/hello'}
         expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello'}
       ,
         description: 'has path and request path is /'
-        input: {serverUrl: 'http://localhost:8000/v1', requestPath: '/'}
-        expected: {host: 'localhost', port: '8000', protocol: 'http:', fullPath: '/v1/'}
+        input: {serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/'}
+        expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/'}
       ,
         description: 'has path with trailing slash and request path is /'
         input: {serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/'}
         expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/'}
       ,
         description: 'has path and request has no path'
-        input: {serverUrl: 'http://localhost:8000/v1', requestPath: ''}
-        expected: {host: 'localhost', port: '8000', protocol: 'http:', fullPath: '/v1'}
+        input: {serverUrl: 'http://127.0.0.1:8000/v1', requestPath: ''}
+        expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1'}
       ,
         description: 'has path with trailing slash and request has no path'
         input: {serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: ''}
         expected: {host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/'}
       ,
         description: 'is hostname with no protocol'
-        input: {serverUrl: 'localhost', requestPath: '/hello'}
-        expected: {host: 'localhost', port: null, protocol: 'http:', fullPath: '/hello'}
+        input: {serverUrl: '127.0.0.1', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello'}
       ,
         description: 'is IPv4 with no protocol'
         input: {serverUrl: '127.0.0.1:4000', requestPath: '/hello'}
         expected: {host: '127.0.0.1', port: '4000', protocol: 'http:', fullPath: '/hello'}
       ,
         description: 'is hostname with // instead of protocol'
-        input: {serverUrl: '//localhost', requestPath: '/hello'}
-        expected: {host: 'localhost', port: null, protocol: 'http:', fullPath: '/hello'}
+        input: {serverUrl: '//127.0.0.1', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello'}
       ,
         description: 'is hostname with trailing slash'
-        input: {serverUrl: 'http://localhost/', requestPath: '/hello'}
-        expected: {host: 'localhost', port: null, protocol: 'http:', fullPath: '/hello'}
+        input: {serverUrl: 'http://127.0.0.1/', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello'}
       ,
         description: 'is hostname with no protocol and with trailing slash'
-        input: {serverUrl: 'localhost/', requestPath: '/hello'}
-        expected: {host: 'localhost', port: null, protocol: 'http:', fullPath: '/hello'}
+        input: {serverUrl: '127.0.0.1/', requestPath: '/hello'}
+        expected: {host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello'}
 
       ].forEach(({description, input, expected}) ->
         context("#{description}: '#{input.serverUrl}' + '#{input.requestPath}'", ->
@@ -361,7 +361,7 @@ describe 'TransactionRunner', ->
       transaction =
         name: 'Group Machine > Machine > Delete Message > Bogus example name'
         id: 'POST /machines'
-        host: 'localhost'
+        host: '127.0.0.1'
         port: '3000'
         request:
           body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n'
@@ -387,7 +387,7 @@ describe 'TransactionRunner', ->
 
       beforeEach ->
         delete transaction.request.headers["Content-Length"]
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
@@ -405,7 +405,7 @@ describe 'TransactionRunner', ->
 
       beforeEach ->
         transaction.request.headers["Content-Length"] = 44
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
@@ -472,7 +472,7 @@ describe 'TransactionRunner', ->
     describe 'when only certain names are allowed by the configuration', ->
 
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
@@ -561,12 +561,12 @@ describe 'TransactionRunner', ->
     describe 'when server uses https', ->
 
       beforeEach ->
-        server = nock('https://localhost:3000').
+        server = nock('https://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
             {'Content-Type': 'application/json'}
-        configuration.server = 'https://localhost:3000'
+        configuration.server = 'https://127.0.0.1:3000'
         transaction.protocol = 'https:'
         runner = new Runner(configuration)
 
@@ -581,12 +581,12 @@ describe 'TransactionRunner', ->
     describe 'when server uses http', ->
 
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
             {'Content-Type': 'application/json'}
-        configuration.server = 'http://localhost:3000'
+        configuration.server = 'http://127.0.0.1:3000'
         transaction.protocol = 'http:'
         runner = new Runner(configuration)
 
@@ -600,7 +600,7 @@ describe 'TransactionRunner', ->
 
     describe 'when backend responds as it should', ->
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply transaction['expected']['status'],
             transaction['expected']['body'],
@@ -622,7 +622,7 @@ describe 'TransactionRunner', ->
 
     describe 'when backend responds with invalid response', ->
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
           post('/machines', {"type":"bulldozer", "name":"willy"}).
           reply 400,
             'Foo bar',
@@ -671,7 +671,7 @@ describe 'TransactionRunner', ->
         transaction = clone {
           name: name
           id: 'POST /machines' + name
-          host: 'localhost'
+          host: '127.0.0.1'
           port: '3000'
           request:
             body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n'
@@ -728,13 +728,13 @@ describe 'TransactionRunner', ->
 
       runner.hooks = hooks
 
-      serverNock1 = nock('http://localhost:3000').
+      serverNock1 = nock('http://127.0.0.1:3000').
         post('/machines1', {"type":"bulldozer", "name":"willy"}).
         reply transaction['expected']['statusCode'],
           transaction['expected']['body'],
           {'Content-Type': 'application/json'}
 
-      serverNock2 = nock('http://localhost:3000').
+      serverNock2 = nock('http://127.0.0.1:3000').
         post('/machines2', {"type":"bulldozer", "name":"willy"}).
         reply transaction['expected']['statusCode'],
           transaction['expected']['body'],
@@ -1139,7 +1139,7 @@ describe 'TransactionRunner', ->
       multiPartTransaction =
           name: 'Group Machine > Machine > Post Message> Bogus example name'
           id: 'POST /machines/message'
-          host: 'localhost'
+          host: '127.0.0.1'
           port: '3000'
           request:
             body: '\n--BOUNDARY \ncontent-disposition: form-data; name="mess12"\n\n{"message":"mess1"}\n--BOUNDARY\n\nContent-Disposition: form-data; name="mess2"\n\n{"message":"mess1"}\n--BOUNDARY--'
@@ -1165,7 +1165,7 @@ describe 'TransactionRunner', ->
       notMultiPartTransaction =
           name: 'Group Machine > Machine > Post Message> Bogus example name'
           id: 'POST /machines/message'
-          host: 'localhost'
+          host: '127.0.0.1'
           port: '3000'
           request:
             body: '\n--BOUNDARY \ncontent-disposition: form-data; name="mess12"\n\n{"message":"mess1"}\n--BOUNDARY\n\nContent-Disposition: form-data; name="mess2"\n\n{"message":"mess1"}\n--BOUNDARY--'
@@ -1192,10 +1192,10 @@ describe 'TransactionRunner', ->
 
       parsedBody = '\r\n--BOUNDARY \r\ncontent-disposition: form-data; name="mess12"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY\r\n\r\nContent-Disposition: form-data; name="mess2"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY--'
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
         post('/machines/message').
         reply 204
-        configuration.server = 'http://localhost:3000'
+        configuration.server = 'http://127.0.0.1:3000'
 
       afterEach ->
         nock.cleanAll()
@@ -1211,10 +1211,10 @@ describe 'TransactionRunner', ->
 
       parsedBody = '\r\n--BOUNDARY \r\ncontent-disposition: form-data; name="mess12"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY\r\n\r\nContent-Disposition: form-data; name="mess2"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY--'
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
         post('/machines/message').
         reply 204
-        configuration.server = 'http://localhost:3000'
+        configuration.server = 'http://127.0.0.1:3000'
 
         delete multiPartTransaction['request']['headers']['Content-Type']
         multiPartTransaction['request']['headers']['content-type'] = 'multipart/form-data; boundary=BOUNDARY'
@@ -1231,10 +1231,10 @@ describe 'TransactionRunner', ->
 
     describe 'when multipart header in request, but body already has some CR (added in hooks e.g.s)', ->
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
         post('/machines/message').
         reply 204
-        configuration.server = 'http://localhost:3000'
+        configuration.server = 'http://127.0.0.1:3000'
         multiPartTransaction['request']['body'] = '\r\n--BOUNDARY \r\ncontent-disposition: form-data; name="mess12"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY\r\n\r\nContent-Disposition: form-data; name="mess2"\r\n\r\n{"message":"mess1"}\r\n--BOUNDARY--'
 
       afterEach ->
@@ -1248,10 +1248,10 @@ describe 'TransactionRunner', ->
 
     describe 'when multipart header is not in request', ->
       beforeEach ->
-        server = nock('http://localhost:3000').
+        server = nock('http://127.0.0.1:3000').
         post('/machines/message').
         reply 204
-        configuration.server = 'http://localhost:3000'
+        configuration.server = 'http://127.0.0.1:3000'
 
       afterEach ->
         nock.cleanAll()
@@ -1265,7 +1265,7 @@ describe 'TransactionRunner', ->
   describe '#executeAllTransactions', ->
 
     configuration =
-      server: 'http://localhost:3000'
+      server: 'http://127.0.0.1:3000'
       emitter: new EventEmitter()
       options:
         'dry-run': false
@@ -1283,7 +1283,7 @@ describe 'TransactionRunner', ->
       transaction = clone {
         name: 'Group Machine > Machine > Delete Message > Bogus example name'
         id: 'POST /machines'
-        host: 'localhost'
+        host: '127.0.0.1'
         port: '3000'
         request:
           body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n'
@@ -1305,7 +1305,7 @@ describe 'TransactionRunner', ->
         fullPath: '/machines'
       }
 
-      server = nock('http://localhost:3000').
+      server = nock('http://127.0.0.1:3000').
         post('/machines', {"type":"bulldozer", "name":"willy"}).
         reply transaction['expected']['statusCode'],
           transaction['expected']['body'],
@@ -1647,7 +1647,7 @@ describe 'TransactionRunner', ->
         transaction =
           name: 'Group Machine > Machine > Delete Message > Bogus example name'
           id: 'POST /machines'
-          host: 'localhost'
+          host: '127.0.0.1'
           port: '3000'
           request:
             body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n'
@@ -1681,7 +1681,7 @@ describe 'TransactionRunner', ->
 
         beforeEach ->
           runner.hooks.beforeEach beforeEachStub
-          server = nock('http://localhost:3000').
+          server = nock('http://127.0.0.1:3000').
             post('/machines', {"type":"bulldozer", "name":"willy"}).
             reply transactionsForExecution[0]['expected']['statusCode'],
               transactionsForExecution[0]['expected']['body'],
@@ -1710,7 +1710,7 @@ describe 'TransactionRunner', ->
 
         beforeEach ->
           runner.hooks.beforeEachValidation beforeEachValidationStub
-          server = nock('http://localhost:3000').
+          server = nock('http://127.0.0.1:3000').
             post('/machines', {"type":"bulldozer", "name":"willy"}).
             reply transactionsForExecution[0]['expected']['statusCode'],
               transactionsForExecution[0]['expected']['body'],
@@ -1747,7 +1747,7 @@ describe 'TransactionRunner', ->
 
         beforeEach ->
           runner.hooks.afterEach afterEachStub
-          server = nock('http://localhost:3000').
+          server = nock('http://127.0.0.1:3000').
             post('/machines', {"type":"bulldozer", "name":"willy"}).
             reply transactionsForExecution[0]['expected']['statusCode'],
               transactionsForExecution[0]['expected']['body'],


### PR DESCRIPTION
#### :rocket: Why this change?

Using 'localhost' can provably cause problems on Windows in some cases. Replacing 'localhost' with '127.0.0.1' avoids these problems. The change is made everywhere to be consistent and, especially in docs, to present just one way to do things to Dredd's users.

Also, `localhost` can be missing in people's `hosts` files or it can be directed to a different IP address for some reason, so it might be better not rely on the alias to always work. For that reason the PR changes also default values for some Dredd options.

#### :memo: Related issues and Pull Requests

- Related to https://github.com/apiaryio/dredd/issues/721
- Part of #204

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
