### PR TITLE
Parse hook handler command string, lookup only the command part

### DIFF
--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -52,10 +52,10 @@ class HooksWorkerClient
     @terminateHandler callback
 
   terminateHandler: (callback) ->
-    logger.verbose('Gracefully terminating hooks handler process.')
+    logger.verbose('Terminating hooks handler process.')
 
     term = =>
-      logger.info('Sending SIGTERM to hooks handler process.')
+      logger.info('Gracefully terminating hooks handler process.')
       @handlerKilledIntentionally = true
       @handler.kill 'SIGTERM'
 
@@ -165,6 +165,7 @@ class HooksWorkerClient
       @handlerCommand = parsedArgs.shift()
       @handlerCommandArgs = parsedArgs
 
+      logger.verbose("Using '#{@handlerCommand}' as a hook handler command, '#{@handlerCommandArgs.join(' ')}' as arguments")
       unless which.which(@handlerCommand)
         msg = "Hooks handler command not found: #{@handlerCommand}"
         return callback(new Error(msg))

--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -154,7 +154,7 @@ describe 'CLI - Server Process', ->
       it 'should inform about starting server with custom command', ->
         assert.include dreddCommand.stdout, 'Starting backend server process with command'
       it 'should inform about sending SIGTERM', ->
-        assert.include dreddCommand.stdout, 'Sending SIGTERM to backend server process'
+        assert.include dreddCommand.stdout, 'Gracefully terminating backend server process'
       it 'should redirect server\'s message about ignoring SIGTERM', ->
         assert.include dreddCommand.stdout, 'ignoring sigterm'
       it 'should inform about sending SIGKILL', ->


### PR DESCRIPTION
#### :rocket: Why this change?

If hook handler command string is 'node hello.js --option=1', we want to find out only whether the 'node' executable is present in the system. For that reason, we first parse the command and lookup (using 'which') only the actual command part, without parameters. Looking up the whole string may or may not work on UNIX/Linux, but it does not work at all on Windows.

The PR also contains several minor improvements:

- Improved logging (wording, information) in `DreddCommand` class
- Using spawn instead of exec for dynamically determining the package version (debugging info in `DreddCommand` class)

#### 😱 The coverage has dropped! Why?!

The coverage has dropped because there is one more relevant line of code in part of Dredd, which is historically uncovered by tests. It's the part which takes care of killing server/hook handler processes and I plan to separate it and rewrite it in the future, so I don't consider the coverage change to be important in this case.

#### :memo: Related issues and Pull Requests

- #204

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
