### PR TITLE
Use the request library instead of custom implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "optimist": "^0.6.1",
     "pitboss-ng": "^0.3.2",
     "proxyquire": "^1.7.10",
-    "request": "^2.74.0",
+    "request": "^2.79.0",
     "spawn-args": "^0.2.0",
     "sync-exec": "^0.6.2",
     "uuid": "^3.0.0",

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -15,14 +15,10 @@ clone = require 'clone'
 htmlStub = require 'html'
 loggerStub = require '../../src/logger'
 addHooks = require '../../src/add-hooks'
-httpStub = require 'http'
-httpsStub = require 'https'
 
 Runner = proxyquire  '../../src/transaction-runner', {
   'html': htmlStub,
   './logger': loggerStub
-  'http': httpStub
-  'https': httpsStub
 }
 CliReporter = require '../../src/reporters/cli-reporter'
 Hooks = require '../../src/hooks'
@@ -441,16 +437,16 @@ describe 'TransactionRunner', ->
       beforeEach ->
         configuration.options['dry-run'] = true
         runner = new Runner(configuration)
-        sinon.stub httpStub, 'request'
+        sinon.spy runner, 'performRequest'
 
 
       afterEach ->
         configuration.options['dry-run'] = false
-        httpStub.request.restore()
+        runner.performRequest.restore()
 
       it 'should skip the tests', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok httpStub.request.notCalled
+          assert.ok runner.performRequest.notCalled
           done()
 
     describe 'when only certain methods are allowed by the configuration', ->
@@ -691,6 +687,7 @@ describe 'TransactionRunner', ->
             actionName: 'Delete Message'
             exampleName: 'Bogus example name'
           fullPath: '/machines' + name
+          protocol: 'http:'
         }
 
         transactions.push transaction
@@ -1303,6 +1300,7 @@ describe 'TransactionRunner', ->
           actionName: 'Delete Message'
           exampleName: 'Bogus example name'
         fullPath: '/machines'
+        protocol: 'http:'
       }
 
       server = nock('http://localhost:3000').
@@ -1667,6 +1665,7 @@ describe 'TransactionRunner', ->
             actionName: 'Delete Message'
             exampleName: 'Bogus example name'
           fullPath: '/machines'
+          protocol: 'http:'
 
         for i in [1, 2]
           clonedTransaction = clone transaction


### PR DESCRIPTION
#### :rocket: Why this change?

I'm not sure why Dredd uses custom implementation for requesting the server under test. I experienced some problems with it on Windows. This PR introduces the `request` library as a way to request the server under test. It should also help in the future to support proxies, because the library supports it out of the box 😎 

#### :memo: Related issues and Pull Requests

- #204 
- #51 & #591

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
