### PR TITLE
Prevent newlines from disappearing

### DIFF
--- a/docs/usage-cli.md
+++ b/docs/usage-cli.md
@@ -16,12 +16,12 @@ $ dredd ./apiary.md http://127.0.0.1:3000
 
 ### API Description Document (string)
 
-URL or path to the API description document (API Blueprint, Swagger).
+URL or path to the API description document (API Blueprint, Swagger).<br>
 **Sample values:** `./api-blueprint.apib`, `./swagger.yml`, `./swagger.json`, `http://example.com/api-blueprint.apib`
 
 ### API Location (string)
 
-URL, the root address of your API.
+URL, the root address of your API.<br>
 **Sample values:** `http://127.0.0.1:3000`, `http://api.example.com`
 
 ## Configuration File
@@ -77,124 +77,124 @@ endpoint: "http://127.0.0.1:3000"
 Remember you can always list all available arguments by `dredd --help`.
 
 ### --color, -c
-Determines whether console output should include colors.  
+Determines whether console output should include colors.<br>
 **Default value:** `true`
 
 ### --config
-Path to dredd.yml config file.  
+Path to dredd.yml config file.<br>
 **Default value:** `"./dredd.yml"`
 
 ### --custom, -j
-Pass custom key-value configuration data delimited by a colon. E.g. -j 'a:b'  
+Pass custom key-value configuration data delimited by a colon. E.g. -j 'a:b'<br>
 **Default value:** `[]`
 
 ### --details, -d
-Determines whether request/response details are included in passing tests.  
+Determines whether request/response details are included in passing tests.<br>
 
 ### --dry-run, -y
-Do not run any real HTTP transaction, only parse API description document and compile transactions.  
+Do not run any real HTTP transaction, only parse API description document and compile transactions.<br>
 
 ### --header, -h
-Extra header to include in every request. This option can be used multiple times to add multiple headers.  
+Extra header to include in every request. This option can be used multiple times to add multiple headers.<br>
 **Default value:** `[]`
 
 ### --help
-Show usage information.  
+Show usage information.<br>
 
 ### --hookfiles, -f
-Specifies a pattern to match files with before/after hooks for running tests  
+Specifies a pattern to match files with before/after hooks for running tests<br>
 
 ### --hooks-worker-after-connect-wait
-How long to wait between connecting to hooks worker and start of testing. [ms]  
+How long to wait between connecting to hooks worker and start of testing. [ms]<br>
 **Default value:** `100`
 
 ### --hooks-worker-connect-retry
-How long to wait between attempts to connect to hooks worker. [ms]  
+How long to wait between attempts to connect to hooks worker. [ms]<br>
 **Default value:** `500`
 
 ### --hooks-worker-connect-timeout
-Total hook worker connection timeout (includes all retries). [ms]  
+Total hook worker connection timeout (includes all retries). [ms]<br>
 **Default value:** `1500`
 
 ### --hooks-worker-handler-host
-Host of the hook worker.  
+Host of the hook worker.<br>
 **Default value:** `"127.0.0.1"`
 
 ### --hooks-worker-handler-port
-Port of the hook worker.  
+Port of the hook worker.<br>
 **Default value:** `61321`
 
 ### --hooks-worker-term-retry
-How long to wait between attempts to terminate hooks worker. [ms]  
+How long to wait between attempts to terminate hooks worker. [ms]<br>
 **Default value:** `500`
 
 ### --hooks-worker-term-timeout
-How long to wait between trying to terminate hooks worker and killing it. [ms]  
+How long to wait between trying to terminate hooks worker and killing it. [ms]<br>
 **Default value:** `5000`
 
 ### --hooks-worker-timeout
-How long to wait for hooks worker to start. [ms]  
+How long to wait for hooks worker to start. [ms]<br>
 **Default value:** `5000`
 
 ### --init, -i
-Run interactive configuration. Creates dredd.yml configuration file.  
+Run interactive configuration. Creates dredd.yml configuration file.<br>
 
 ### --inline-errors, -e
-Determines whether failures and errors are displayed as they occur (true) or aggregated and displayed at the end (false).  
+Determines whether failures and errors are displayed as they occur (true) or aggregated and displayed at the end (false).<br>
 
 ### --language, -a
-Language of hookfiles. Possible options are: nodejs, ruby, python, php, perl, go  
+Language of hookfiles. Possible options are: nodejs, ruby, python, php, perl, go<br>
 **Default value:** `"nodejs"`
 
 ### --level, -l
-The level of logging to output. Options: silly, debug, verbose, info, warn, error.  
+The level of logging to output. Options: silly, debug, verbose, info, warn, error.<br>
 **Default value:** `"info"`
 
 ### --method, -m
-Restrict tests to a particular HTTP method (GET, PUT, POST, DELETE, PATCH). This option can be used multiple times to allow multiple methods.  
+Restrict tests to a particular HTTP method (GET, PUT, POST, DELETE, PATCH). This option can be used multiple times to allow multiple methods.<br>
 **Default value:** `[]`
 
 ### --names, -n
-Only list names of requests (for use in a hookfile). No requests are made.  
+Only list names of requests (for use in a hookfile). No requests are made.<br>
 
 ### --only, -x
-Run only specified transaction name. Can be used multiple times  
+Run only specified transaction name. Can be used multiple times<br>
 **Default value:** `[]`
 
 ### --output, -o
-Specifies output file when using additional file-based reporter. This option can be used multiple times if multiple file-based reporters are used.  
+Specifies output file when using additional file-based reporter. This option can be used multiple times if multiple file-based reporters are used.<br>
 **Default value:** `[]`
 
 ### --path, -p
-Additional API description paths or URLs. Can be used multiple times with glob pattern for paths.  
+Additional API description paths or URLs. Can be used multiple times with glob pattern for paths.<br>
 **Default value:** `[]`
 
 ### --reporter, -r
-Output additional report format. This option can be used multiple times to add multiple reporters. Options: junit, nyan, dot, markdown, html, apiary.  
+Output additional report format. This option can be used multiple times to add multiple reporters. Options: junit, nyan, dot, markdown, html, apiary.<br>
 **Default value:** `[]`
 
 ### --sandbox, -b
-Load and run non trusted hooks code in sandboxed container  
+Load and run non trusted hooks code in sandboxed container<br>
 
 ### --server, -g
-Run API backend server command and kill it after Dredd execution. E.g. `rails server`  
+Run API backend server command and kill it after Dredd execution. E.g. `rails server`<br>
 
 ### --server-wait
-Set delay time in seconds between running a server and test run.  
+Set delay time in seconds between running a server and test run.<br>
 **Default value:** `3`
 
 ### --silent, -q
-Silences commandline output.  
+Silences commandline output.<br>
 
 ### --sorted, -s
-Sorts requests in a sensible way so that objects are not modified before they are created. Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.  
+Sorts requests in a sensible way so that objects are not modified before they are created. Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.<br>
 
 ### --timestamp, -t
-Determines whether console output should include timestamps.  
+Determines whether console output should include timestamps.<br>
 
 ### --user, -u
-Basic Auth credentials in the form username:password.  
+Basic Auth credentials in the form username:password.<br>
 
 ### --version
-Show version number.  
+Show version number.<br>
 

--- a/docs/usage-cli.md-template
+++ b/docs/usage-cli.md-template
@@ -16,12 +16,12 @@ $ dredd ./apiary.md http://127.0.0.1:3000
 
 ### API Description Document (string)
 
-URL or path to the API description document (API Blueprint, Swagger).
+URL or path to the API description document (API Blueprint, Swagger).<br>
 **Sample values:** `./api-blueprint.apib`, `./swagger.yml`, `./swagger.json`, `http://example.com/api-blueprint.apib`
 
 ### API Location (string)
 
-URL, the root address of your API.
+URL, the root address of your API.<br>
 **Sample values:** `http://127.0.0.1:3000`, `http://api.example.com`
 
 ## Configuration File
@@ -79,7 +79,7 @@ Remember you can always list all available arguments by `dredd --help`.
 <% for option in @options: %>
 ### --<%= option.name %><% if option.alias: %>, -<%= option.alias %><% end %>
 
-<%= option.description %>  
+<%= option.description %><br>
 <% if option.default: %>
 **Default value:** `<%- JSON.stringify(option.default) %>`
 <% end %>


### PR DESCRIPTION
#### :rocket: Why this change?

Markdown syntax for newlines is two spaces at the end of the line (see https://daringfireball.net/projects/markdown/syntax#p for reference). But such syntax is very prone to many problems:

*  It's invisible to anyone who opens the file and doesn't know about it in advance. It's very easy to miss the spaces when editing and to accidentally remove them.
*  Many editors intended for coding trim trailing spaces. Again, since the syntax is invisible and many don't even know about it, they often don't even notice during code review (the only place where it turns out to be visible at least a bit).

For that reason, let's use explicit `<br>` instead of two spaces.

#### :memo: Related issues and Pull Requests

This PR corrects mistakes in https://github.com/apiaryio/dredd/pull/732.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
