### PR TITLE
Use Chai's assert.isOk() instead of assert.ok()

### DIFF
--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -343,10 +343,10 @@ describe 'CLI', ->
         )
 
       it 'should have an authorization header in the request', ->
-        assert.ok runtimeInfo.server.requests['/machines'][0].headers.authorization
+        assert.isOk runtimeInfo.server.requests['/machines'][0].headers.authorization
 
       it 'should contain a base64 encoded string of the username and password', ->
-        assert.ok runtimeInfo.server.requests['/machines'][0].headers.authorization is 'Basic ' + new Buffer('username:password').toString('base64')
+        assert.isOk runtimeInfo.server.requests['/machines'][0].headers.authorization is 'Basic ' + new Buffer('username:password').toString('base64')
 
 
     describe "when sorting requests with -s", ->
@@ -368,7 +368,7 @@ describe 'CLI', ->
         )
 
       it 'should perform the POST, GET, PUT, DELETE in order', ->
-        assert.ok runtimeInfo.dredd.stdout.indexOf('POST') < runtimeInfo.dredd.stdout.indexOf('GET') < runtimeInfo.dredd.stdout.indexOf('PUT') < runtimeInfo.dredd.stdout.indexOf('DELETE')
+        assert.isOk runtimeInfo.dredd.stdout.indexOf('POST') < runtimeInfo.dredd.stdout.indexOf('GET') < runtimeInfo.dredd.stdout.indexOf('PUT') < runtimeInfo.dredd.stdout.indexOf('DELETE')
 
     describe 'when displaying errors inline with -e', ->
       runtimeInfo = undefined
@@ -414,7 +414,7 @@ describe 'CLI', ->
 
       it 'should display details on passing tests', ->
         # the request: block is not shown for passing tests normally
-        assert.ok runtimeInfo.dredd.stdout.indexOf('request') > -1
+        assert.isOk runtimeInfo.dredd.stdout.indexOf('request') > -1
 
     describe "when filtering request methods with -m", ->
 
@@ -560,7 +560,7 @@ describe 'CLI', ->
 
       it 'should not display anything', ->
         # at the "error" level, complete should not be shown
-        assert.ok runtimeInfo.dredd.stdout.indexOf('complete') is -1
+        assert.isOk runtimeInfo.dredd.stdout.indexOf('complete') is -1
 
     describe 'when showing timestamps with -t', ->
       runtimeInfo = undefined
@@ -631,8 +631,8 @@ describe 'CLI', ->
       )
 
     it 'should execute the before and after events', ->
-      assert.ok containsLine(runtimeInfo.dredd.stdout, 'hooks.beforeAll'), (runtimeInfo.dredd.stdout)
-      assert.ok containsLine(runtimeInfo.dredd.stdout, 'hooks.afterAll'), (runtimeInfo.dredd.stdout)
+      assert.isOk containsLine(runtimeInfo.dredd.stdout, 'hooks.beforeAll'), (runtimeInfo.dredd.stdout)
+      assert.isOk containsLine(runtimeInfo.dredd.stdout, 'hooks.afterAll'), (runtimeInfo.dredd.stdout)
 
   describe 'when describing both hooks and events in hookfiles', ->
     runtimeInfo = undefined
@@ -662,7 +662,7 @@ describe 'CLI', ->
 
     it 'should execute hooks and events in order', ->
       events = getResults(runtimeInfo.dredd.stdout)
-      assert.ok events is 'beforeAll,before,after,afterAll'
+      assert.isOk events is 'beforeAll,before,after,afterAll'
 
   describe "tests an API description containing an endpoint with schema", ->
     describe "and server is responding in accordance with the schema", ->

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -225,7 +225,7 @@ describe 'CLI - Reporters', ->
       fs.unlinkSync "#{process.cwd()}/__test_file_output__.xml"
 
     it 'should create given file', ->
-      assert.ok fs.existsSync "#{process.cwd()}/__test_file_output__.xml"
+      assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output__.xml"
 
 
   describe 'When -o/--output is used multiple times to specify output files', ->
@@ -249,5 +249,5 @@ describe 'CLI - Reporters', ->
       fs.unlinkSync "#{process.cwd()}/__test_file_output2__.xml"
 
     it 'should create given files', ->
-      assert.ok fs.existsSync "#{process.cwd()}/__test_file_output1__.xml"
-      assert.ok fs.existsSync "#{process.cwd()}/__test_file_output2__.xml"
+      assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output1__.xml"
+      assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output2__.xml"

--- a/test/integration/regressions/regression-319-354-test.coffee
+++ b/test/integration/regressions/regression-319-354-test.coffee
@@ -229,7 +229,7 @@ describe 'Regression: Issues #319 and #354', ->
       )
 
     it 'outputs failures', ->
-      assert.ok results.failures.length
+      assert.isOk results.failures.length
     it 'results in exactly four tests', ->
       assert.include results.summary, '4 total'
     it 'results in four failing tests', ->

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -84,7 +84,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
 
     it 'should not expand any glob', (done) ->
       addHooks runner, transactions, (err) ->
-        assert.ok globStub.sync.notCalled
+        assert.isOk globStub.sync.notCalled
         done()
 
   describe 'with non `nodejs` language option', () ->
@@ -121,7 +121,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
       sinon.spy globStub, 'sync'
       addHooks runner, transactions, (err) ->
         return done err if err
-        assert.ok globStub.sync.called
+        assert.isOk globStub.sync.called
         globStub.sync.restore()
         done()
 
@@ -144,7 +144,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
       it 'should load the files', (done) ->
         addHooks runner, transactions, (err) ->
           return done err if err
-          assert.ok pathStub.resolve.called
+          assert.isOk pathStub.resolve.called
           done()
 
       it 'should add configuration object to the hooks object proxyquired to the each hookfile', (done) ->

--- a/test/unit/configure-reporters-test.coffee
+++ b/test/unit/configure-reporters-test.coffee
@@ -63,7 +63,7 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
     it 'should only add a CliReporter', (done) ->
       configureReporters(configuration, {}, {}, null)
-      assert.ok CliReporterStub.called
+      assert.isOk CliReporterStub.called
       done()
 
     describe 'when silent', ()->
@@ -95,7 +95,7 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
     it 'should add a cli-based reporter', (done) ->
       configureReporters(configuration, {}, {}, null)
-      assert.ok DotReporterStub.called
+      assert.isOk DotReporterStub.called
       done()
 
     it 'should not add more than one cli-based reporters', (done) ->
@@ -117,7 +117,7 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
     it 'should add a CliReporter', (done) ->
       configureReporters(configuration, {}, {}, () -> )
-      assert.ok CliReporterStub.called
+      assert.isOk CliReporterStub.called
       done()
 
     describe 'when the number of outputs is greater than or equals the number of reporters', () ->
@@ -133,8 +133,8 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
       it 'should use the output paths in the order provided', (done) ->
         configureReporters(configuration, {}, {}, () -> )
-        assert.ok XUnitReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
-        assert.ok MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file2')
+        assert.isOk XUnitReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
+        assert.isOk MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file2')
         done()
 
     describe 'when the number of outputs is less than the number of reporters', () ->
@@ -150,8 +150,8 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
       it 'should use the default output paths for the additional reporters', (done) ->
         configureReporters(configuration, {}, {}, () -> )
-        assert.ok XUnitReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
-        assert.ok MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, null)
+        assert.isOk XUnitReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
+        assert.isOk MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, null)
         done()
 
   describe 'when there are both cli-based and file-based reporters', () ->
@@ -167,7 +167,7 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
     it 'should add a cli-based reporter', (done) ->
       configureReporters(configuration, {}, {}, () ->)
-      assert.ok NyanCatReporterStub.called
+      assert.isOk NyanCatReporterStub.called
       done()
 
     it 'should not add more than one cli-based reporters', (done) ->
@@ -189,8 +189,8 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
       it 'should use the output paths in the order provided', (done) ->
         configureReporters(configuration, {}, {}, () -> )
-        assert.ok MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
-        assert.ok HtmlReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file2')
+        assert.isOk MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
+        assert.isOk HtmlReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file2')
         done()
 
     describe 'when the number of outputs is less than the number of file-based reporters', () ->
@@ -205,6 +205,6 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
 
       it 'should use the default output paths for the additional reporters', (done) ->
         configureReporters(configuration, {}, {}, () -> )
-        assert.ok MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
-        assert.ok HtmlReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, null)
+        assert.isOk MarkdownReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, 'file1')
+        assert.isOk HtmlReporterStub.calledWith(emitterStub, {'fileBasedReporters': 2}, {}, null)
         done()

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -47,7 +47,7 @@ describe 'Dredd class', ->
         sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
           callback()
         dredd.run (error) ->
-          assert.ok dredd.runner.executeTransaction.called
+          assert.isOk dredd.runner.executeTransaction.called
           dredd.runner.executeTransaction.restore()
           done()
 
@@ -67,7 +67,7 @@ describe 'Dredd class', ->
 
     it 'should copy configuration on creation', ->
       dredd = new Dredd(configuration)
-      assert.ok(dredd.configuration.options.silent)
+      assert.isOk(dredd.configuration.options.silent)
       assert.notOk(dredd.configuration.options['dry-run'])
 
     it 'should load the file on given path', (done) ->
@@ -75,7 +75,7 @@ describe 'Dredd class', ->
       sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
-        assert.ok fsStub.readFile.calledWith configuration.options.path[0]
+        assert.isOk fsStub.readFile.calledWith configuration.options.path[0]
         dredd.runner.executeTransaction.restore()
         done()
 
@@ -103,7 +103,7 @@ describe 'Dredd class', ->
       sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
-        assert.ok dreddTransactionsStub.compile.called
+        assert.isOk dreddTransactionsStub.compile.called
         dredd.runner.executeTransaction.restore()
         done()
 
@@ -175,7 +175,7 @@ describe 'Dredd class', ->
 
       it 'should return error', (done) ->
         dredd.run (error) ->
-          assert.ok error
+          assert.isOk error
           done()
 
 
@@ -359,7 +359,7 @@ describe 'Dredd class', ->
 
         it 'should exit with an error', (done) ->
           dredd.run (error) ->
-            assert.ok error
+            assert.isOk error
             assert.instanceOf error, Error
             assert.property error, 'message'
             assert.include error.message, 'Unable to load file from URL'
@@ -383,7 +383,7 @@ describe 'Dredd class', ->
 
         it 'should exit with an error', (done) ->
           dredd.run (error) ->
-            assert.ok error
+            assert.isOk error
             assert.instanceOf error, Error
             assert.property error, 'message'
             assert.include error.message, 'Error when loading file from URL'
@@ -412,7 +412,7 @@ describe 'Dredd class', ->
 
     it 'should exit with an error', (done) ->
       dredd.run (error) ->
-        assert.ok error
+        assert.isOk error
         done()
 
     it 'should NOT execute any transaction', (done) ->
@@ -440,12 +440,12 @@ describe 'Dredd class', ->
 
     it 'should execute the runtime', (done) ->
       dredd.run ->
-        assert.ok dredd.runner.run.called
+        assert.isOk dredd.runner.run.called
         done()
 
     it 'should write warnings to warn logger', (done) ->
       dredd.run ->
-        assert.ok loggerStub.warn.called
+        assert.isOk loggerStub.warn.called
         done()
 
   describe 'when non existing API description document path', ->
@@ -464,7 +464,7 @@ describe 'Dredd class', ->
 
     it 'should pass the error to the callback function', (done) ->
       dredd.run (error) ->
-        assert.ok error
+        assert.isOk error
         done()
 
     it 'should NOT execute any transaction', (done) ->
@@ -494,7 +494,7 @@ describe 'Dredd class', ->
 
     it 'should exit with an error', (done) ->
       dredd.run (error) ->
-        assert.ok error
+        assert.isOk error
         done()
 
   describe 'when runtime contains any warning', ->
@@ -515,12 +515,12 @@ describe 'Dredd class', ->
 
     it 'should execute some transaction', (done) ->
       dredd.run (error) ->
-        assert.ok dredd.runner.executeTransaction.called
+        assert.isOk dredd.runner.executeTransaction.called
         done()
 
     it 'should print runtime warnings to stdout', (done) ->
       dredd.run (error) ->
-        assert.ok loggerStub.warn.called
+        assert.isOk loggerStub.warn.called
         done()
 
     it 'should not exit', (done) ->
@@ -544,7 +544,7 @@ describe 'Dredd class', ->
 
     it 'should execute the runtime', (done) ->
       dredd.run (error) ->
-        assert.ok dredd.runner.executeTransaction.called
+        assert.isOk dredd.runner.executeTransaction.called
         done()
 
   describe "#emitStart", ->
@@ -592,7 +592,7 @@ describe 'Dredd class', ->
       it 'should call the callback', (done) ->
         callback = sinon.spy (error) ->
           done error if error
-          assert.ok callback.called
+          assert.isOk callback.called
           done()
 
         dredd.emitStart callback
@@ -620,7 +620,7 @@ describe 'Dredd class', ->
       it 'should call the callback with error', (done) ->
         callback = sinon.spy (error) ->
           assert.isNotNull error
-          assert.ok callback.called
+          assert.isOk callback.called
           done()
 
         dredd.emitStart callback

--- a/test/unit/handle-runtime-problems-test.coffee
+++ b/test/unit/handle-runtime-problems-test.coffee
@@ -68,13 +68,13 @@ describe('handleRuntimeProblems()', ->
     )
 
     it('returns error', ->
-      assert.ok(error)
+      assert.isOk(error)
     )
     it('has no warning output', ->
       assert.equal(warnOutput, '')
     )
     it('has error output', ->
-      assert.ok(errorOutput)
+      assert.isOk(errorOutput)
     )
     context('the error output', ->
       it('mentions it is from parser', ->
@@ -122,7 +122,7 @@ describe('handleRuntimeProblems()', ->
       assert.equal(errorOutput, '')
     )
     it('has warning output', ->
-      assert.ok(warnOutput)
+      assert.isOk(warnOutput)
     )
     context('the warning output', ->
       it('mentions it is from parser', ->
@@ -167,7 +167,7 @@ describe('handleRuntimeProblems()', ->
       assert.equal(errorOutput, '')
     )
     it('has warning output', ->
-      assert.ok(warnOutput)
+      assert.isOk(warnOutput)
     )
     context('the warning output', ->
       it('mentions it is from parser', ->

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -134,7 +134,7 @@ describe 'Hooks worker client', ->
         setTimeout ->
           hooksWorkerClient.stop (stopError) ->
             return done stopError if stopError
-            assert.ok runner.hookHandlerError
+            assert.isOk runner.hookHandlerError
             assert.include runner.hookHandlerError.message, '3'
             done()
         , MIN_COMMAND_EXECUTION_DURATION_MS
@@ -147,7 +147,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint that native hooks should be used', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, 'native Node.js hooks instead'
           done()
 
@@ -211,7 +211,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, "gem install dredd_hooks"
           done()
 
@@ -274,7 +274,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, "pip install dredd_hooks"
           done()
 
@@ -337,7 +337,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, "composer require ddelnano/dredd-hooks-php --dev"
           done()
 
@@ -354,7 +354,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, "go get github.com/snikch/goodman/cmd/goodman"
           done()
 
@@ -463,7 +463,7 @@ describe 'Hooks worker client', ->
 
       it 'should write a hint how to install', (done) ->
         loadWorkerClient (err) ->
-          assert.ok err
+          assert.isOk err
           assert.include err.message, "cpanm Dredd::Hooks"
           done()
 

--- a/test/unit/prettify-response-test.coffee
+++ b/test/unit/prettify-response-test.coffee
@@ -54,7 +54,7 @@ describe 'prettifyResponse(response)', () ->
       sinon.stub loggerStub.debug.restore()
 
     it 'should\'ve printed into debug', () ->
-      assert.ok loggerStub.debug.called
+      assert.isOk loggerStub.debug.called
       assert.isObject loggerStub.debug.firstCall
       assert.isArray loggerStub.debug.firstCall.args
       assert.lengthOf loggerStub.debug.firstCall.args, 1

--- a/test/unit/reporters/apiary-reporter-test.coffee
+++ b/test/unit/reporters/apiary-reporter-test.coffee
@@ -536,7 +536,7 @@ describe 'ApiaryReporter', () ->
         apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
         apiaryReporter.remoteId = runId
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledWith 'See results in Apiary at: https://app.apiary.io/public/tests/run/507f1f77bcf86cd799439011'
+          assert.isOk loggerStub.complete.calledWith 'See results in Apiary at: https://app.apiary.io/public/tests/run/507f1f77bcf86cd799439011'
           done()
 
       it 'should return reportUrl from testRun entity', (done) ->
@@ -545,7 +545,7 @@ describe 'ApiaryReporter', () ->
         apiaryReporter.remoteId = runId
         apiaryReporter.reportUrl = "https://absolutely.fancy.url/wich-can-change/some/id"
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledWith 'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'
+          assert.isOk loggerStub.complete.calledWith 'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'
           done()
 
       it 'should send runner.logs to Apiary at the end of testRun', (done) ->
@@ -805,7 +805,7 @@ describe 'ApiaryReporter', () ->
         apiaryReporter = new ApiaryReporter emitter, {}, {}, {custom:apiaryReporterEnv:env}
         apiaryReporter.remoteId = runId
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledWith 'See results in Apiary at: https://app.apiary.io/jakubtest/tests/run/507f1f77bcf86cd799439011'
+          assert.isOk loggerStub.complete.calledWith 'See results in Apiary at: https://app.apiary.io/jakubtest/tests/run/507f1f77bcf86cd799439011'
           done()
 
       it 'should return reportUrl from testRun entity', (done) ->
@@ -814,5 +814,5 @@ describe 'ApiaryReporter', () ->
         apiaryReporter.remoteId = runId
         apiaryReporter.reportUrl = "https://absolutely.fancy.url/wich-can-change/some/id"
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledWith 'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'
+          assert.isOk loggerStub.complete.calledWith 'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'
           done()

--- a/test/unit/reporters/base-reporter-test.coffee
+++ b/test/unit/reporters/base-reporter-test.coffee
@@ -38,7 +38,7 @@ describe 'BaseReporter', () ->
 
     it 'should set the start date', (done) ->
       emitter.emit 'start', '', () ->
-        assert.ok stats.start
+        assert.isOk stats.start
         done()
 
   describe 'when ending', () ->
@@ -49,7 +49,7 @@ describe 'BaseReporter', () ->
 
     it 'should set the end date', (done) ->
       emitter.emit 'end', () ->
-        assert.ok stats.end
+        assert.isOk stats.end
         done()
 
   describe 'when test starts', () ->
@@ -61,7 +61,7 @@ describe 'BaseReporter', () ->
 
     it 'should add the test', () ->
       emitter.emit 'test start', test
-      assert.ok tests.length is 1
+      assert.isOk tests.length is 1
 
   describe 'when test passes', () ->
 
@@ -76,7 +76,7 @@ describe 'BaseReporter', () ->
       assert.equal stats.passes, 1
 
     it 'should set the end time', () ->
-      assert.ok tests[0].end
+      assert.isOk tests[0].end
 
   describe 'when test is skipped', () ->
     beforeEach () ->
@@ -87,7 +87,7 @@ describe 'BaseReporter', () ->
       emitter.emit 'test skip', test
 
     it 'should increment the counter', () ->
-      assert.ok stats.skipped is 1
+      assert.isOk stats.skipped is 1
 
   describe 'when test fails', () ->
 
@@ -99,10 +99,10 @@ describe 'BaseReporter', () ->
       emitter.emit 'test fail', test
 
     it 'should increment the counter', () ->
-      assert.ok stats.failures is 1
+      assert.isOk stats.failures is 1
 
     it 'should set the end time', () ->
-      assert.ok tests[0].end
+      assert.isOk tests[0].end
 
   describe 'when test errors', () ->
 
@@ -114,7 +114,7 @@ describe 'BaseReporter', () ->
       emitter.emit 'test error', new Error('Error'), test
 
     it 'should increment the counter', () ->
-      assert.ok stats.errors is 1
+      assert.isOk stats.errors is 1
 
     it 'should set the end time', () ->
-      assert.ok tests[0].end
+      assert.isOk tests[0].end

--- a/test/unit/reporters/cli-reporter-test.coffee
+++ b/test/unit/reporters/cli-reporter-test.coffee
@@ -32,7 +32,7 @@ describe 'CliReporter', () ->
       emitter = new EventEmitter()
       cliReporter = new CliReporter(emitter, {}, {}, true)
       emitter.emit 'start', '', () ->
-        assert.ok loggerStub.info.calledOnce
+        assert.isOk loggerStub.info.calledOnce
         done()
 
   describe 'when adding passing test', () ->
@@ -51,7 +51,7 @@ describe 'CliReporter', () ->
       emitter = new EventEmitter()
       cliReporter = new CliReporter(emitter, {}, {}, true)
       emitter.emit 'test pass', test
-      assert.ok loggerStub.pass.calledOnce
+      assert.isOk loggerStub.pass.calledOnce
 
     describe 'when details=true', () ->
 
@@ -65,7 +65,7 @@ describe 'CliReporter', () ->
         emitter = new EventEmitter()
         cliReporter = new CliReporter(emitter, {}, {}, true, true)
         emitter.emit 'test pass', test
-        assert.ok loggerStub.request.calledOnce
+        assert.isOk loggerStub.request.calledOnce
 
   describe 'when adding failing test', () ->
 
@@ -86,7 +86,7 @@ describe 'CliReporter', () ->
         emitter = new EventEmitter()
         cliReporter = new CliReporter(emitter, {}, {}, true)
         emitter.emit 'test fail', test
-        assert.ok loggerStub.fail.calledTwice
+        assert.isOk loggerStub.fail.calledTwice
 
     describe 'when errors are aggregated', () ->
 
@@ -100,14 +100,14 @@ describe 'CliReporter', () ->
         emitter = new EventEmitter()
         cliReporter = new CliReporter(emitter, {}, {}, false)
         emitter.emit 'test fail', test
-        assert.ok loggerStub.fail.calledOnce
+        assert.isOk loggerStub.fail.calledOnce
 
       it 'should write full failure to the console after execution is complete', (done) ->
         emitter = new EventEmitter()
         cliReporter = new CliReporter(emitter, {}, {}, false)
         cliReporter.errors = [ test ]
         emitter.emit 'end', () ->
-          assert.ok loggerStub.fail.calledTwice
+          assert.isOk loggerStub.fail.calledTwice
           done()
 
   describe 'when adding error test', () ->
@@ -127,7 +127,7 @@ describe 'CliReporter', () ->
       emitter = new EventEmitter()
       cliReporter = new CliReporter(emitter, {}, {}, false)
       emitter.emit 'test error', new Error('Error'), test
-      assert.ok loggerStub.error.calledTwice
+      assert.isOk loggerStub.error.calledTwice
 
 
   describe 'when adding error test with connection refused', () ->
@@ -175,7 +175,7 @@ describe 'CliReporter', () ->
       emitter = new EventEmitter()
       cliReporter = new CliReporter(emitter, {}, {}, false)
       emitter.emit 'test skip', test
-      assert.ok loggerStub.skip.calledOnce
+      assert.isOk loggerStub.skip.calledOnce
 
 
   describe 'when creating report', () ->
@@ -199,7 +199,7 @@ describe 'CliReporter', () ->
         cliReporter.tests = [ test ]
         cliReporter.stats.tests = 1
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledTwice
+          assert.isOk loggerStub.complete.calledTwice
           done()
 
     describe 'when there are no tests', () ->
@@ -208,7 +208,7 @@ describe 'CliReporter', () ->
         emitter = new EventEmitter()
         cliReporter = new CliReporter(emitter, {}, {}, false)
         emitter.emit 'end', () ->
-          assert.ok loggerStub.complete.calledOnce
+          assert.isOk loggerStub.complete.calledOnce
           done()
 
 

--- a/test/unit/reporters/dot-reporter-test.coffee
+++ b/test/unit/reporters/dot-reporter-test.coffee
@@ -45,7 +45,7 @@ describe 'DotReporter', () ->
 
     it 'should log that testing has begun', () ->
       emitter.emit 'start', '', () ->
-        assert.ok loggerStub.info.called
+        assert.isOk loggerStub.info.called
 
   describe 'when ending', () ->
 
@@ -60,7 +60,7 @@ describe 'DotReporter', () ->
 
     it 'should log that testing is complete', () ->
       emitter.emit 'end', () ->
-        assert.ok loggerStub.complete.calledTwice
+        assert.isOk loggerStub.complete.calledTwice
 
     describe 'when there are failures', () ->
 
@@ -80,7 +80,7 @@ describe 'DotReporter', () ->
 
       it 'should log the failures at the end of testing', (done) ->
         emitter.emit 'end', () ->
-          assert.ok loggerStub.fail.called
+          assert.isOk loggerStub.fail.called
           done()
 
   describe 'when test passes', () ->
@@ -99,7 +99,7 @@ describe 'DotReporter', () ->
       dotReporter.write.restore()
 
     it 'should write a .', () ->
-      assert.ok dotReporter.write.calledWith '.'
+      assert.isOk dotReporter.write.calledWith '.'
 
   describe 'when test is skipped', () ->
     before () ->
@@ -116,7 +116,7 @@ describe 'DotReporter', () ->
       dotReporter.write.restore()
 
     it 'should write a -', () ->
-      assert.ok dotReporter.write.calledWith('-')
+      assert.isOk dotReporter.write.calledWith('-')
 
   describe 'when test fails', () ->
 
@@ -134,7 +134,7 @@ describe 'DotReporter', () ->
       dotReporter.write.restore()
 
     it 'should write an F', () ->
-      assert.ok dotReporter.write.calledWith('F')
+      assert.isOk dotReporter.write.calledWith('F')
 
   describe 'when test errors', () ->
 
@@ -152,4 +152,4 @@ describe 'DotReporter', () ->
       dotReporter.write.restore()
 
     it 'should write an E', () ->
-      assert.ok dotReporter.write.calledWith('E')
+      assert.isOk dotReporter.write.calledWith('E')

--- a/test/unit/reporters/html-reporter-test.coffee
+++ b/test/unit/reporters/html-reporter-test.coffee
@@ -52,7 +52,7 @@ describe 'HtmlReporter', () ->
         loggerStub.info.restore()
 
       it 'should inform about the existing file', () ->
-        assert.ok loggerStub.info.called
+        assert.isOk loggerStub.info.called
 
     describe 'when file does not exist', () ->
 
@@ -66,11 +66,11 @@ describe 'HtmlReporter', () ->
         fsStub.unlinkSync.restore()
 
       it 'should not attempt to delete a file', () ->
-        assert.ok fsStub.unlinkSync.notCalled
+        assert.isOk fsStub.unlinkSync.notCalled
 
     it 'should write the prelude to the buffer', (done) ->
       emitter.emit 'start', '' , () ->
-        assert.ok ~htmlReporter.buf.indexOf 'Dredd'
+        assert.isOk ~htmlReporter.buf.indexOf 'Dredd'
         done()
 
   describe 'when ending', () ->
@@ -87,7 +87,7 @@ describe 'HtmlReporter', () ->
 
     it 'should write the file', (done) ->
       emitter.emit 'end', () ->
-        assert.ok fsStub.writeFile.called
+        assert.isOk fsStub.writeFile.called
         done()
 
   describe 'when test passes', () ->
@@ -100,14 +100,14 @@ describe 'HtmlReporter', () ->
     it 'should call the pass event', () ->
       emitter.emit 'test start', test
       emitter.emit 'test pass', test
-      assert.ok ~htmlReporter.buf.indexOf 'Pass'
+      assert.isOk ~htmlReporter.buf.indexOf 'Pass'
 
     describe 'when details=true', () ->
 
       it 'should write details for passing tests', () ->
         htmlReporter.details = true
         emitter.emit 'test pass', test
-        assert.ok ~htmlReporter.buf.indexOf 'Request'
+        assert.isOk ~htmlReporter.buf.indexOf 'Request'
 
   describe 'when test is skipped', () ->
     before () ->
@@ -118,7 +118,7 @@ describe 'HtmlReporter', () ->
     it 'should call the skip event', () ->
       emitter.emit 'test start', test
       emitter.emit 'test skip', test
-      assert.ok ~htmlReporter.buf.indexOf 'Skip'
+      assert.isOk ~htmlReporter.buf.indexOf 'Skip'
 
   describe 'when test fails', () ->
 
@@ -130,7 +130,7 @@ describe 'HtmlReporter', () ->
     it 'should call the fail event', () ->
       emitter.emit 'test start', test
       emitter.emit 'test fail', test
-      assert.ok ~htmlReporter.buf.indexOf 'Fail'
+      assert.isOk ~htmlReporter.buf.indexOf 'Fail'
 
   describe 'when test errors', () ->
 
@@ -142,4 +142,4 @@ describe 'HtmlReporter', () ->
     it 'should call the error event', () ->
       emitter.emit 'test start', test
       emitter.emit 'test error', new Error('Error'), test
-      assert.ok ~htmlReporter.buf.indexOf 'Error'
+      assert.isOk ~htmlReporter.buf.indexOf 'Error'

--- a/test/unit/reporters/markdown-reporter-test.coffee
+++ b/test/unit/reporters/markdown-reporter-test.coffee
@@ -53,7 +53,7 @@ describe 'MarkdownReporter', () ->
         loggerStub.info.restore()
 
       it 'should inform about the existing file', () ->
-        assert.ok loggerStub.info.called
+        assert.isOk loggerStub.info.called
 
     describe 'when file does not exist', () ->
 
@@ -67,14 +67,14 @@ describe 'MarkdownReporter', () ->
         fsStub.unlinkSync.restore()
 
       it 'should create the file', (done) ->
-        assert.ok fsStub.unlinkSync.notCalled
+        assert.isOk fsStub.unlinkSync.notCalled
         done()
 
   describe 'when starting', () ->
 
     it 'should write the title to the buffer', (done) ->
       emitter.emit 'start', '', () ->
-        assert.ok ~mdReporter.buf.indexOf 'Dredd'
+        assert.isOk ~mdReporter.buf.indexOf 'Dredd'
         done()
 
   describe 'when ending', () ->
@@ -87,7 +87,7 @@ describe 'MarkdownReporter', () ->
 
     it 'should write buffer to file', (done) ->
       emitter.emit 'end'
-      assert.ok fsStub.writeFile.called
+      assert.isOk fsStub.writeFile.called
       done()
 
   describe 'when test passes', () ->
@@ -100,7 +100,7 @@ describe 'MarkdownReporter', () ->
       emitter.emit 'test pass', test
 
     it 'should write pass to the buffer', (done) ->
-      assert.ok ~mdReporter.buf.indexOf 'Pass'
+      assert.isOk ~mdReporter.buf.indexOf 'Pass'
       done()
 
     describe 'when details=true', () ->
@@ -108,7 +108,7 @@ describe 'MarkdownReporter', () ->
       it 'should write details for passing tests', (done) ->
         mdReporter.details = true
         emitter.emit 'test pass', test
-        assert.ok ~mdReporter.buf.indexOf 'Request'
+        assert.isOk ~mdReporter.buf.indexOf 'Request'
         done()
 
   describe 'when test is skipped', () ->
@@ -120,7 +120,7 @@ describe 'MarkdownReporter', () ->
       emitter.emit 'test skip', test
 
     it 'should write skip to the buffer', (done) ->
-      assert.ok ~mdReporter.buf.indexOf 'Skip'
+      assert.isOk ~mdReporter.buf.indexOf 'Skip'
       done()
 
   describe 'when test fails', () ->
@@ -133,7 +133,7 @@ describe 'MarkdownReporter', () ->
       emitter.emit 'test fail', test
 
     it 'should write fail to the buffer', (done) ->
-      assert.ok ~mdReporter.buf.indexOf 'Fail'
+      assert.isOk ~mdReporter.buf.indexOf 'Fail'
       done()
 
   describe 'when test errors', () ->
@@ -146,5 +146,5 @@ describe 'MarkdownReporter', () ->
       emitter.emit 'test error', new Error('Error'), test
 
     it 'should write error to the buffer', (done) ->
-      assert.ok ~mdReporter.buf.indexOf 'Error'
+      assert.isOk ~mdReporter.buf.indexOf 'Error'
       done()

--- a/test/unit/reporters/nyan-reporter-test.coffee
+++ b/test/unit/reporters/nyan-reporter-test.coffee
@@ -49,8 +49,8 @@ describe 'NyanCatReporter', () ->
 
     it 'should hide the cursor and draw the cat', (done) ->
       emitter.emit 'start', '', () ->
-        assert.ok nyanReporter.cursorHide.calledOnce
-        assert.ok nyanReporter.draw.calledOnce
+        assert.isOk nyanReporter.cursorHide.calledOnce
+        assert.isOk nyanReporter.draw.calledOnce
         done()
 
   describe 'when ending', () ->
@@ -67,7 +67,7 @@ describe 'NyanCatReporter', () ->
 
     it 'should log that testing is complete', (done) ->
       emitter.emit 'end', () ->
-        assert.ok loggerStub.complete.calledTwice
+        assert.isOk loggerStub.complete.calledTwice
         done()
 
     describe 'when there are failures', () ->
@@ -85,7 +85,7 @@ describe 'NyanCatReporter', () ->
 
       it 'should log the failures at the end of testing', (done) ->
         emitter.emit 'end', ()->
-          assert.ok loggerStub.fail.calledTwice
+          assert.isOk loggerStub.fail.calledTwice
           done()
 
   describe 'when test finished', () ->
@@ -105,7 +105,7 @@ describe 'NyanCatReporter', () ->
         nyanReporter.write.restore()
 
       it 'should draw the cat', () ->
-        assert.ok nyanReporter.draw.calledOnce
+        assert.isOk nyanReporter.draw.calledOnce
 
     describe 'when test is skipped', () ->
       beforeEach () ->
@@ -121,7 +121,7 @@ describe 'NyanCatReporter', () ->
         nyanReporter.write.restore()
 
       it 'should draw the cat', () ->
-        assert.ok nyanReporter.draw.calledOnce
+        assert.isOk nyanReporter.draw.calledOnce
 
     describe 'when test fails', () ->
 
@@ -138,7 +138,7 @@ describe 'NyanCatReporter', () ->
         nyanReporter.write.restore()
 
       it 'should draw the cat', () ->
-        assert.ok nyanReporter.draw.calledOnce
+        assert.isOk nyanReporter.draw.calledOnce
 
     describe 'when test errors', () ->
 
@@ -155,5 +155,5 @@ describe 'NyanCatReporter', () ->
         nyanReporter.draw.restore()
 
       it 'should draw the cat', () ->
-        assert.ok nyanReporter.draw.calledOnce
+        assert.isOk nyanReporter.draw.calledOnce
 

--- a/test/unit/reporters/x-unit-reporter-test.coffee
+++ b/test/unit/reporters/x-unit-reporter-test.coffee
@@ -39,7 +39,7 @@ describe 'XUnitReporter', () ->
       it 'should inform about the existing file', () ->
         emitter = new EventEmitter()
         xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
-        assert.ok loggerStub.info.called
+        assert.isOk loggerStub.info.called
 
     describe 'when file does not exist', () ->
 
@@ -55,7 +55,7 @@ describe 'XUnitReporter', () ->
       it 'should create the file', () ->
         emitter = new EventEmitter()
         xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
-        assert.ok fsStub.unlinkSync.notCalled
+        assert.isOk fsStub.unlinkSync.notCalled
 
   describe 'when starting', () ->
 
@@ -69,7 +69,7 @@ describe 'XUnitReporter', () ->
       emitter = new EventEmitter()
       xUnitReporter = new XUnitReporter(emitter, {}, {})
       emitter.emit 'start', '', () ->
-        assert.ok fsStub.appendFileSync.called
+        assert.isOk fsStub.appendFileSync.called
         done()
 
   describe 'when ending', () ->
@@ -94,7 +94,7 @@ describe 'XUnitReporter', () ->
         xUnitReporter.tests = [ test ]
         xUnitReporter.stats.tests = 1
         emitter.emit 'test pass', test
-        assert.ok fsStub.appendFileSync.called
+        assert.isOk fsStub.appendFileSync.called
 
       describe 'when the file writes successfully', () ->
 
@@ -105,7 +105,7 @@ describe 'XUnitReporter', () ->
           xUnitReporter.stats.tests = 1
 
           emitter.emit 'end', () ->
-            assert.ok fsStub.writeFile.called
+            assert.isOk fsStub.writeFile.called
             done()
 
     describe 'when there are no tests', () ->
@@ -114,7 +114,7 @@ describe 'XUnitReporter', () ->
         emitter = new EventEmitter()
         xUnitReporter = new XUnitReporter(emitter, {}, {})
         emitter.emit 'end', () ->
-          assert.ok fsStub.writeFile.called
+          assert.isOk fsStub.writeFile.called
           done()
 
   describe 'when test passes', () ->
@@ -149,7 +149,7 @@ describe 'XUnitReporter', () ->
       xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
       emitter.emit 'test start', test
       emitter.emit 'test pass', test
-      assert.ok fsStub.appendFileSync.called
+      assert.isOk fsStub.appendFileSync.called
 
     describe 'when details=true', () ->
 
@@ -158,7 +158,7 @@ describe 'XUnitReporter', () ->
         cliReporter = new XUnitReporter(emitter, {}, {}, "test.xml", true)
         emitter.emit 'test start', test
         emitter.emit 'test pass', test
-        assert.ok fsStub.appendFileSync.called
+        assert.isOk fsStub.appendFileSync.called
 
   describe 'when test is skipped', () ->
     before () ->
@@ -177,7 +177,7 @@ describe 'XUnitReporter', () ->
       xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
       emitter.emit 'test start', test
       emitter.emit 'test skip', test
-      assert.ok fsStub.appendFileSync.called
+      assert.isOk fsStub.appendFileSync.called
 
   describe 'when test fails', () ->
 
@@ -197,7 +197,7 @@ describe 'XUnitReporter', () ->
       xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
       emitter.emit 'test start', test
       emitter.emit 'test fail', test
-      assert.ok fsStub.appendFileSync.called
+      assert.isOk fsStub.appendFileSync.called
 
   describe 'when test errors', () ->
 
@@ -217,4 +217,4 @@ describe 'XUnitReporter', () ->
       xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
       emitter.emit 'test start', test
       emitter.emit 'test error', new Error('Error'), test
-      assert.ok fsStub.appendFileSync.called
+      assert.isOk fsStub.appendFileSync.called

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -52,7 +52,7 @@ describe 'TransactionRunner', ->
       runner = new Runner(configuration)
 
     it 'should copy configuration', ->
-      assert.ok runner.configuration.server
+      assert.isOk runner.configuration.server
 
     it 'should have an empty hookStash object', ->
       assert.deepEqual runner.hookStash, {}
@@ -94,7 +94,7 @@ describe 'TransactionRunner', ->
         runner = new Runner(configuration)
         runner.config(configuration)
 
-        assert.ok runner.multiBlueprint
+        assert.isOk runner.multiBlueprint
 
   describe 'configureTransaction(transaction, callback)', ->
     beforeEach ->
@@ -303,7 +303,7 @@ describe 'TransactionRunner', ->
 
       it 'should add the Dredd User-Agent', (done) ->
         runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.ok configuredTransaction.request.headers['User-Agent']
+          assert.isOk configuredTransaction.request.headers['User-Agent']
           done()
 
     describe 'when an additional header has a colon', ->
@@ -323,9 +323,9 @@ describe 'TransactionRunner', ->
         runner.configureTransaction transaction, (err, configuredTransaction) ->
           assert.equal configuredTransaction.name, 'Group Machine > Machine > Delete Message > Bogus example name'
           assert.equal configuredTransaction.id, 'POST /machines'
-          assert.ok configuredTransaction.host
-          assert.ok configuredTransaction.request
-          assert.ok configuredTransaction.expected
+          assert.isOk configuredTransaction.host
+          assert.isOk configuredTransaction.request
+          assert.isOk configuredTransaction.expected
           assert.strictEqual transaction.origin, configuredTransaction.origin
           done()
 
@@ -394,7 +394,7 @@ describe 'TransactionRunner', ->
 
       it 'should add a Content-Length header', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok transaction.request.headers['Content-Length']
+          assert.isOk transaction.request.headers['Content-Length']
           done()
 
     describe 'when Content-Length header is present', ->
@@ -429,7 +429,7 @@ describe 'TransactionRunner', ->
 
       it 'should print the names and return', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok loggerStub.info.called
+          assert.isOk loggerStub.info.called
           done()
 
     describe 'when a dry run', ->
@@ -446,7 +446,7 @@ describe 'TransactionRunner', ->
 
       it 'should skip the tests', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok runner.performRequest.notCalled
+          assert.isOk runner.performRequest.notCalled
           done()
 
     describe 'when only certain methods are allowed by the configuration', ->
@@ -462,7 +462,7 @@ describe 'TransactionRunner', ->
 
       it 'should only perform those requests', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok runner.skipTransaction.called
+          assert.isOk runner.skipTransaction.called
           done()
 
     describe 'when only certain names are allowed by the configuration', ->
@@ -491,7 +491,7 @@ describe 'TransactionRunner', ->
       it 'should skip transactions with different names', (done) ->
         transaction['name'] = 'Group Machine > Machine > Delete Message > Bogus different example name'
         runner.executeTransaction transaction, ->
-          assert.ok runner.skipTransaction.called
+          assert.isOk runner.skipTransaction.called
           done()
 
     describe 'when a test has been manually set to skip in a hook', ->
@@ -522,7 +522,7 @@ describe 'TransactionRunner', ->
 
       it 'should skip the test', (done) ->
         runner.executeAllTransactions [clonedTransaction], runner.hooks, (err) ->
-          assert.ok configuration.emitter.emit.calledWith 'test skip'
+          assert.isOk configuration.emitter.emit.calledWith 'test skip'
           done(err)
 
       it 'should add skip message as a warning under `general` to the results on transaction', (done) ->
@@ -571,7 +571,7 @@ describe 'TransactionRunner', ->
 
       it 'should make the request with https', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           done()
 
     describe 'when server uses http', ->
@@ -591,7 +591,7 @@ describe 'TransactionRunner', ->
 
       it 'should make the request with http', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           done()
 
     describe 'when backend responds as it should', ->
@@ -608,7 +608,7 @@ describe 'TransactionRunner', ->
 
       it 'should perform the request', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           done()
 
       it 'should not return an error', (done) ->
@@ -630,7 +630,7 @@ describe 'TransactionRunner', ->
 
       it 'should perform the request', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           done()
 
 
@@ -644,7 +644,7 @@ describe 'TransactionRunner', ->
 
       it 'should report a error', (done) ->
         runner.executeTransaction transaction, ->
-          assert.ok configuration.emitter.emit.called
+          assert.isOk configuration.emitter.emit.called
           events = Object.keys(configuration.emitter.emit.args).map (value, index) ->
             configuration.emitter.emit.args[value][0]
           assert.include events, 'test error'
@@ -1199,7 +1199,7 @@ describe 'TransactionRunner', ->
 
       it 'should replace line feed in body', (done) ->
         runner.executeTransaction multiPartTransaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           assert.equal multiPartTransaction['request']['body'], parsedBody, 'Body'
           assert.include multiPartTransaction['request']['body'], "\r\n"
           done()
@@ -1221,7 +1221,7 @@ describe 'TransactionRunner', ->
 
       it 'should replace line feed in body', (done) ->
         runner.executeTransaction multiPartTransaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           assert.equal multiPartTransaction['request']['body'], parsedBody, 'Body'
           assert.include multiPartTransaction['request']['body'], "\r\n"
           done()
@@ -1239,7 +1239,7 @@ describe 'TransactionRunner', ->
 
       it 'should not add CR again', (done) ->
         runner.executeTransaction multiPartTransaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           assert.notInclude multiPartTransaction['request']['body'], "\r\r"
           done()
 
@@ -1255,7 +1255,7 @@ describe 'TransactionRunner', ->
 
       it 'should not include any line-feed in body', (done) ->
         runner.executeTransaction notMultiPartTransaction, ->
-          assert.ok server.isDone()
+          assert.isOk server.isDone()
           assert.notInclude multiPartTransaction['request']['body'], "\r\n"
           done()
 
@@ -1342,9 +1342,9 @@ describe 'TransactionRunner', ->
 
       it 'should run the hooks', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok loggerStub.info.calledWith "before"
-          assert.ok loggerStub.info.calledWith "beforeValidation"
-          assert.ok loggerStub.info.calledWith "after"
+          assert.isOk loggerStub.info.calledWith "before"
+          assert.isOk loggerStub.info.calledWith "beforeValidation"
+          assert.isOk loggerStub.info.calledWith "after"
           done()
 
     describe 'with hooks, but without hooks.transactions set', ->
@@ -1374,9 +1374,9 @@ describe 'TransactionRunner', ->
       it 'should run the hooks', (done) ->
         runner.hooks.transactions = null
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok loggerStub.info.calledWith "before"
-          assert.ok loggerStub.info.calledWith "beforeValidation"
-          assert.ok loggerStub.info.calledWith "after"
+          assert.isOk loggerStub.info.calledWith "before"
+          assert.isOk loggerStub.info.calledWith "beforeValidation"
+          assert.isOk loggerStub.info.calledWith "after"
           done()
 
     describe 'with multiple hooks for the same transaction', ->
@@ -1396,8 +1396,8 @@ describe 'TransactionRunner', ->
 
       it 'should run all hooks', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok loggerStub.info.calledWith "first"
-          assert.ok loggerStub.info.calledWith "second"
+          assert.isOk loggerStub.info.calledWith "first"
+          assert.isOk loggerStub.info.calledWith "second"
           done()
 
     describe '‘*All’ hooks with legacy async interface (fist argument is a callback)', ->
@@ -1416,8 +1416,8 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok beforeAllStub.called
-            assert.ok beforeAllStubAnother.called
+            assert.isOk beforeAllStub.called
+            assert.isOk beforeAllStubAnother.called
             done()
 
       describe 'with an ‘afterAll’ hook', ->
@@ -1435,8 +1435,8 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok afterAllStub.called
-            assert.ok afterAllStubAnother.called
+            assert.isOk afterAllStub.called
+            assert.isOk afterAllStubAnother.called
             done()
 
       describe 'with multiple hooks for the same events', ->
@@ -1456,11 +1456,11 @@ describe 'TransactionRunner', ->
 
         it 'should run all the events in order', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok beforeAllStub1.calledBefore(beforeAllStub2)
-            assert.ok beforeAllStub2.called
-            assert.ok beforeAllStub2.calledBefore(afterAllStub1)
-            assert.ok afterAllStub1.calledBefore(afterAllStub2)
-            assert.ok afterAllStub2.called
+            assert.isOk beforeAllStub1.calledBefore(beforeAllStub2)
+            assert.isOk beforeAllStub2.called
+            assert.isOk beforeAllStub2.calledBefore(afterAllStub1)
+            assert.isOk afterAllStub1.calledBefore(afterAllStub2)
+            assert.isOk afterAllStub2.called
             done()
 
     describe '‘*All’ hooks with standard async API (first argument transactions, second callback)', ->
@@ -1476,7 +1476,7 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok beforeAllStub.called
+            assert.isOk beforeAllStub.called
             done()
 
       describe 'with an ‘afterAll’ hook', ->
@@ -1490,7 +1490,7 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok afterAllStub.called
+            assert.isOk afterAllStub.called
             done()
 
       describe 'with multiple hooks for the same events', ->
@@ -1510,11 +1510,11 @@ describe 'TransactionRunner', ->
 
         it 'should run all the events in order', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok beforeAllStub1.calledBefore(beforeAllStub2)
-            assert.ok beforeAllStub2.called
-            assert.ok beforeAllStub2.calledBefore(afterAllStub1)
-            assert.ok afterAllStub1.calledBefore(afterAllStub2)
-            assert.ok afterAllStub2.called
+            assert.isOk beforeAllStub1.calledBefore(beforeAllStub2)
+            assert.isOk beforeAllStub2.called
+            assert.isOk beforeAllStub2.calledBefore(afterAllStub1)
+            assert.isOk afterAllStub1.calledBefore(afterAllStub2)
+            assert.isOk afterAllStub2.called
             done()
 
     describe '‘*All’ hooks with sandboxed API (functions as strings)', ->
@@ -1538,7 +1538,7 @@ describe 'TransactionRunner', ->
 
           runner.executeAllTransactions [], runner.hooks, (err) ->
             call = configuration.emitter.emit.getCall(0)
-            assert.ok configuration.emitter.emit.calledWith "test error"
+            assert.isOk configuration.emitter.emit.calledWith "test error"
             done(err)
 
         it 'should not have access to require', (done) ->
@@ -1551,7 +1551,7 @@ describe 'TransactionRunner', ->
 
           runner.executeAllTransactions [], runner.hooks, (err) ->
             call = configuration.emitter.emit.getCall(0)
-            assert.ok configuration.emitter.emit.calledWith "test error"
+            assert.isOk configuration.emitter.emit.calledWith "test error"
             assert.include call.args[1].message, 'require'
             done(err)
 
@@ -1692,7 +1692,7 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions transactionsForExecution, runner.hooks, ->
-            assert.ok beforeEachStub.called
+            assert.isOk beforeEachStub.called
             done()
 
         it 'should run the hook for each transaction', (done) ->
@@ -1722,7 +1722,7 @@ describe 'TransactionRunner', ->
         it 'should run the hooks', (done) ->
           transaction = clone(transactionsForExecution[0])
           runner.executeAllTransactions [transaction], runner.hooks, ->
-            assert.ok beforeEachValidationStub.called
+            assert.isOk beforeEachValidationStub.called
             assert.equal transaction.test.status, 'fail'
             done()
 
@@ -1758,7 +1758,7 @@ describe 'TransactionRunner', ->
 
         it 'should run the hooks', (done) ->
           runner.executeAllTransactions transactionsForExecution, runner.hooks, ->
-            assert.ok afterEachStub.called
+            assert.isOk afterEachStub.called
             done()
 
         it 'should run the hook for each transaction', (done) ->
@@ -1783,10 +1783,10 @@ describe 'TransactionRunner', ->
 
         it 'should run all the events in order', (done) ->
           runner.executeAllTransactions [], runner.hooks, ->
-            assert.ok beforeAllStub1.calledBefore(beforeAllStub2)
-            assert.ok beforeAllStub2.called
-            assert.ok afterAllStub1.calledBefore(afterAllStub2)
-            assert.ok afterAllStub2.called
+            assert.isOk beforeAllStub1.calledBefore(beforeAllStub2)
+            assert.isOk beforeAllStub2.called
+            assert.isOk afterAllStub1.calledBefore(afterAllStub2)
+            assert.isOk afterAllStub2.called
             done()
 
     describe 'with ‘before’ hook that throws an error', ->
@@ -1803,7 +1803,7 @@ describe 'TransactionRunner', ->
 
       it 'should report an error with the test', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok configuration.emitter.emit.calledWith "test error"
+          assert.isOk configuration.emitter.emit.calledWith "test error"
           done()
 
     describe 'with ‘after’ hook that throws an error', ->
@@ -1820,7 +1820,7 @@ describe 'TransactionRunner', ->
 
       it 'should report an error with the test', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok configuration.emitter.emit.calledWith "test error"
+          assert.isOk configuration.emitter.emit.calledWith "test error"
           done()
 
     describe 'with ‘before’ hook that throws a chai expectation error', ->
@@ -1828,7 +1828,7 @@ describe 'TransactionRunner', ->
         runner.hooks.beforeHooks =
           'Group Machine > Machine > Delete Message > Bogus example name' : [
             (transaction) ->
-              assert.ok false
+              assert.isOk false
           ]
         sinon.stub configuration.emitter, 'emit'
 
@@ -1842,7 +1842,7 @@ describe 'TransactionRunner', ->
 
       it 'should report a fail', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok configuration.emitter.emit.calledWith "test fail"
+          assert.isOk configuration.emitter.emit.calledWith "test fail"
           done()
 
       it 'should add fail message as a error under `general` to the results on transaction', (done) ->
@@ -1867,7 +1867,7 @@ describe 'TransactionRunner', ->
         runner.hooks.afterHooks =
           'Group Machine > Machine > Delete Message > Bogus example name' : [
             (transaction) ->
-              assert.ok false
+              assert.isOk false
           ]
         sinon.stub configuration.emitter, 'emit'
 
@@ -1881,7 +1881,7 @@ describe 'TransactionRunner', ->
 
       it 'should report a fail', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, ->
-          assert.ok configuration.emitter.emit.calledWith "test fail"
+          assert.isOk configuration.emitter.emit.calledWith "test fail"
           done()
 
       it 'should set test as failed', (done) ->
@@ -1923,7 +1923,7 @@ describe 'TransactionRunner', ->
 
         it 'should fail the test', (done) ->
           runner.executeAllTransactions [clonedTransaction], runner.hooks, ->
-            assert.ok configuration.emitter.emit.calledWith "test fail"
+            assert.isOk configuration.emitter.emit.calledWith "test fail"
             done()
 
         it 'should not run the transaction', (done) ->
@@ -2030,7 +2030,7 @@ describe 'TransactionRunner', ->
 
         it 'should make the request', (done) ->
           runner.executeAllTransactions [modifiedTransaction], runner.hooks, ->
-            assert.ok server.isDone()
+            assert.isOk server.isDone()
             done()
 
         it 'should not fail again', (done) ->
@@ -2096,12 +2096,12 @@ describe 'TransactionRunner', ->
 
         it 'should make the request', (done) ->
           runner.executeAllTransactions [clonedTransaction], runner.hooks, ->
-            assert.ok server.isDone()
+            assert.isOk server.isDone()
             done()
 
         it 'it should fail the test', (done) ->
           runner.executeAllTransactions [clonedTransaction], runner.hooks, ->
-            assert.ok configuration.emitter.emit.calledWith "test fail"
+            assert.isOk configuration.emitter.emit.calledWith "test fail"
             done()
 
         it 'it should not pass the test', (done) ->
@@ -2164,7 +2164,7 @@ describe 'TransactionRunner', ->
       it 'should pass the transactions', (done) ->
         runner.executeAllTransactions [transaction], runner.hooks, (error) ->
           done error if error
-          assert.ok configuration.emitter.emit.calledWith "test pass"
+          assert.isOk configuration.emitter.emit.calledWith "test pass"
           done()
 
     describe 'with hook modifying the transaction body and backend Express app using the body parser', ->
@@ -2198,7 +2198,7 @@ describe 'TransactionRunner', ->
         server = app.listen transaction.port, ->
           runner.executeAllTransactions [transaction], runner.hooks, ->
             #should not hang here
-            assert.ok true
+            assert.isOk true
             server.close()
 
         server.on 'close', ->
@@ -2227,7 +2227,7 @@ describe 'TransactionRunner', ->
           """
 
           runner.runHooksForData [hook], {}, false, ->
-            assert.ok configuration.emitter.emit.calledWith "test error"
+            assert.isOk configuration.emitter.emit.calledWith "test error"
             messages = []
             callCount = configuration.emitter.emit.callCount
             for callNo in [0.. callCount - 1]


### PR DESCRIPTION
#### :rocket: Why this change?

`assert.isOk()` is present in current Chai docs, `assert.ok()` is now just an alias to support older code.

#### :memo: Related issues and Pull Requests

Follow-up to #737 

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
