### PR TITLE
fix: don't set Content-Length for empty request bodies

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -455,7 +455,9 @@ class TransactionRunner
     for key, value of transaction.request.headers
       caseInsensitiveRequestHeadersMap[key.toLowerCase()] = key
 
-    if not caseInsensitiveRequestHeadersMap['content-length'] and transaction.request['body'] != ''
+    if not caseInsensitiveRequestHeadersMap['content-length'] and
+        transaction.request['body']? and
+        transaction.request['body'] != ''
       logger.verbose('Calculating Content-Length of the request body')
       transaction.request.headers['Content-Length'] = Buffer.byteLength(transaction.request['body'], 'utf8')
 

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -455,9 +455,7 @@ class TransactionRunner
     for key, value of transaction.request.headers
       caseInsensitiveRequestHeadersMap[key.toLowerCase()] = key
 
-    if not caseInsensitiveRequestHeadersMap['content-length'] and
-        transaction.request['body']? and
-        transaction.request['body'] != ''
+    if transaction.request.body and not caseInsensitiveRequestHeadersMap['content-length']
       logger.verbose('Calculating Content-Length of the request body')
       transaction.request.headers['Content-Length'] = Buffer.byteLength(transaction.request['body'], 'utf8')
 


### PR DESCRIPTION
#### :rocket: Why this change?

I use Dredd with a hooks handler in Go and my API blueprint contains a request without body (only the headers are important). In this scenario, the current release produces the following error:

```
verbose: Running 'before' hooks
verbose: Calculating Content-Length of the request body
buffer.js:363
    throw new TypeError('"string" must be a string, Buffer, or ArrayBuffer');
    ^

TypeError: "string" must be a string, Buffer, or ArrayBuffer
    at Function.byteLength (buffer.js:363:11)
    at TransactionRunner.setContentLength (/usr/local/lib/node_modules/dredd/lib/transaction-runner.js:496:69)
    at TransactionRunner.executeTransaction (/usr/local/lib/node_modules/dredd/lib/transaction-runner.js:505:10)
    at TransactionRunner.executeTransaction (/usr/local/lib/node_modules/dredd/lib/transaction-runner.js:3:57)
    at /usr/local/lib/node_modules/dredd/lib/transaction-runner.js:103:28
    at TransactionRunner.runHooksForData (/usr/local/lib/node_modules/dredd/lib/transaction-runner.js:189:14)
    at /usr/local/lib/node_modules/dredd/lib/transaction-runner.js:99:26
    at /usr/local/lib/node_modules/dredd/lib/transaction-runner.js:186:16
    at /usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:1012:9
    at /usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:359:16
    at replenish (/usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:876:25)
    at iterateeCallback (/usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:866:17)
    at /usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:843:16
    at /usr/local/lib/node_modules/dredd/node_modules/async/dist/async.js:1009:13
    at /usr/local/lib/node_modules/dredd/lib/transaction-runner.js:166:24
    at /usr/local/lib/node_modules/dredd/lib/transaction-runner.js:281:18
    at EventEmitter.messageHandler (/usr/local/lib/node_modules/dredd/lib/hooks-worker-client.js:344:20)
    at emitOne (events.js:96:13)
    at EventEmitter.emit (events.js:191:7)
    at Socket.<anonymous> (/usr/local/lib/node_modules/dredd/lib/hooks-worker-client.js:297:44)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:191:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:563:20)
```