### PR TITLE
Fix hooks examples

### DIFF
--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -234,7 +234,7 @@ after('/login > POST', function (transaction) {
 // Add the token to all HTTP transactions
 beforeEach(function (transaction) {
   if (stash.token) {
-    transaction.headers['X-Api-Key'] = stash.token
+    transaction.request.headers['X-Api-Key'] = stash.token
   };
 });
 
@@ -361,7 +361,7 @@ after('/login > POST > 200 > application/json', function (transaction) {
 // Add the token to all HTTP transactions
 beforeEach(function (transaction) {
   if (stash.token) {
-    transaction.headers['X-Api-Key'] = stash.token
+    transaction.request.headers['X-Api-Key'] = stash.token
   };
 });
 


### PR DESCRIPTION
#### :rocket: Why this change?

Current examples won't work. There's a typo regarding where the request headers live in the transaction object.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
