### PR TITLE
Have command ouput in the right order (test helpers)

### DIFF
--- a/test/integration/helpers.coffee
+++ b/test/integration/helpers.coffee
@@ -169,14 +169,21 @@ runCommand = (command, args, spawnOptions = {}, callback) ->
 
   stdout = ''
   stderr = ''
+  output = ''
 
   cli = spawn(command, args, spawnOptions)
 
-  cli.stdout.on('data', (data) -> stdout += data)
-  cli.stderr.on('data', (data) -> stderr += data)
+  cli.stdout.on('data', (data) ->
+    stdout += data
+    output += data
+  )
+  cli.stderr.on('data', (data) ->
+    stderr += data
+    output += data
+  )
 
   cli.on('close', (exitStatus) ->
-    callback(null, {stdout, stderr, output: stdout + stderr, exitStatus})
+    callback(null, {stdout, stderr, output, exitStatus})
   )
 
 


### PR DESCRIPTION
#### :rocket: Why this change?

When concatenating stdout and stderr to get the whole output, then the output contains first stdout and then stderr. For output to be useful, it needs to contain stdout and stderr entwined, in the same order as can be usually seen when the command is ran in the console.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
