### PR TITLE
Listen on 'exit' event instead of 'close'

### DIFF
--- a/src/child-process.coffee
+++ b/src/child-process.coffee
@@ -14,7 +14,7 @@ signalKill = (childProcess, callback) ->
   childProcess.emit('signalKill')
   if IS_WINDOWS
     taskkill = spawn('taskkill', ['/F', '/T', '/PID', childProcess.pid])
-    taskkill.on('close', (exitStatus) ->
+    taskkill.on('exit', (exitStatus) ->
       if exitStatus
         err = new Error("Unable to forcefully terminate process #{childProcess.pid}")
         return callback(err)
@@ -77,10 +77,10 @@ terminate = (childProcess, options = {}, callback) ->
   retryDelay = if options.retryDelay? then options.retryDelay else TERM_DEFAULT_RETRY_MS
 
   terminated = false
-  onClose = ->
+  onExit = ->
     terminated = true
-    childProcess.removeListener('close', onClose)
-  childProcess.on('close', onClose)
+    childProcess.removeListener('exit', onExit)
+  childProcess.on('exit', onExit)
 
   start = Date.now()
   t = undefined
@@ -140,7 +140,7 @@ spawn = (args...) ->
       childProcess.emit('error', err) if err
     )
 
-  childProcess.on('close', (exitStatus, signal) ->
+  childProcess.on('exit', (exitStatus, signal) ->
     childProcess.terminated = true
     childProcess.killedIntentionally = killedIntentionally
     childProcess.terminatedIntentionally = terminatedIntentionally

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -61,7 +61,7 @@ class DreddCommand
       return callback()
     logger.verbose('Terminating backend server process, PID', @serverProcess.pid)
     @serverProcess.terminate({force: true})
-    @serverProcess.on('close', -> callback())
+    @serverProcess.on('exit', -> callback())
 
   # This thing-a-ma-bob here is only for purpose of testing
   # It's basically a dependency injection for the process.exit function
@@ -216,7 +216,7 @@ class DreddCommand
       @serverProcess.on 'crash', (exitStatus, killed) =>
         logger.info('Backend server process was killed') if killed
 
-      @serverProcess.on 'close', =>
+      @serverProcess.on 'exit', =>
         logger.info('Backend server process exited')
 
       @serverProcess.on 'error', (error) =>

--- a/test/integration/child-process-test.coffee
+++ b/test/integration/child-process-test.coffee
@@ -26,11 +26,11 @@ runChildProcess = (command, fn, callback) ->
   childProcess.stdout.on('data', (data) -> processInfo.stdout += data.toString())
   childProcess.stderr.on('data', (data) -> processInfo.stderr += data.toString())
 
-  onClose = (exitStatus, signal) ->
+  onExit = (exitStatus, signal) ->
     processInfo.terminated = true
     processInfo.exitStatus = exitStatus
     processInfo.signal = signal
-  childProcess.on('close', onClose)
+  childProcess.on('exit', onExit)
 
   onError = (err) ->
     processInfo.error = err
@@ -42,7 +42,7 @@ runChildProcess = (command, fn, callback) ->
     fn(childProcess)
 
     setTimeout( ->
-      childProcess.removeListener('close', onClose)
+      childProcess.removeListener('exit', onExit)
       childProcess.removeListener('error', onError)
       childProcess.removeListener('crash', onCrash)
 

--- a/test/integration/helpers.coffee
+++ b/test/integration/helpers.coffee
@@ -182,7 +182,7 @@ runCommand = (command, args, spawnOptions = {}, callback) ->
     output += data
   )
 
-  cli.on('close', (exitStatus) ->
+  cli.on('exit', (exitStatus) ->
     callback(null, {stdout, stderr, output, exitStatus})
   )
 
@@ -220,7 +220,7 @@ isProcessRunning = (pattern, callback) ->
 kill = (pid, callback) ->
   if process.platform is 'win32'
     taskkill = spawn('taskkill', ['/F', '/T', '/PID', pid])
-    taskkill.on('close', -> callback())
+    taskkill.on('exit', -> callback())
     # no error handling - we don't care about the result of the command
   else
     try


### PR DESCRIPTION
#### :rocket: Why this change?

When working with spawned subprocesses, it seems like under some circumstances the 'close' event isn't emitted on Linux when the process terminates. The 'exit' event seems to be called consistently accross operating systems.

#### :memo: Related issues and Pull Requests

- Close https://github.com/apiaryio/dredd/issues/670#issuecomment-291900957

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A (I'm not really sure why in tests the `close` event gets called correctly while manually it doesn't work 😢 )
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
