### PR TITLE
Add missing reference to the Dredd Example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,3 +90,4 @@ There are still [several known limitations][Windows Issues] when using Dredd on 
 [Windows C++11]: https://github.com/apiaryio/drafter/wiki/Building-on-Windows
 [Travis CI C++11]: https://github.com/apiaryio/protagonist/blob/master/.travis.yml
 [npm Python]: http://stackoverflow.com/a/22433804/325365
+[Dredd Example]: https://github.com/apiaryio/dredd-example/


### PR DESCRIPTION
#### :rocket: Why this change?

The Dredd Example is linked, but the link is missing at the bottom of the Markdown document.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
