### PR TITLE
The sync-exec should be just a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "proxyquire": "^1.7.10",
     "request": "^2.81.0",
     "spawn-args": "^0.2.0",
-    "sync-exec": "^0.6.2",
     "uuid": "^3.0.0",
     "which": "^1.2.14",
     "winston": "^2.2.0"
@@ -70,7 +69,8 @@
     "nock": "^9.0.13",
     "ps-node": "^0.1.5",
     "semantic-release": "^6.3.2",
-    "sinon": "^2.1.0"
+    "sinon": "^2.1.0",
+    "sync-exec": "^0.6.2"
   },
   "keywords": [
     "api",


### PR DESCRIPTION
#### :rocket: Why this change?

The sync-exec library is now used only in the hook handlers integration tests. Moreover, the tests are currently turned off (for various reasons: #672, #644, and more). For that reason, it should be only a dev dependency. Also, this should resolve the red Snyk badge as a side-effect (only production dependencies are being continuously checked for vulnerabilities).

#### :memo: Related issues and Pull Requests

- https://snyk.io/vuln/npm:sync-exec:20160124

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
