### PR TITLE
fix(transaction-runner): use => in validateTransaction gavel callbacks

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -612,7 +612,7 @@ class TransactionRunner
 
     logger.verbose('Validating HTTP transaction by Gavel.js')
     logger.debug('Determining whether HTTP transaction is valid (getting boolean verdict)')
-    gavel.isValid transaction.real, transaction.expected, 'response', (isValidError, isValid) ->
+    gavel.isValid transaction.real, transaction.expected, 'response', (isValidError, isValid) =>
       if isValidError
         logger.debug('Gavel.js validation errored:', isValidError)
         @emitError(isValidError, test)
@@ -628,7 +628,7 @@ class TransactionRunner
         test.status = 'fail'
 
       logger.debug('Validating HTTP transaction (getting verbose validation result)')
-      gavel.validate transaction.real, transaction.expected, 'response', (validateError, gavelResult) ->
+      gavel.validate transaction.real, transaction.expected, 'response', (validateError, gavelResult) =>
         if not isValidError and validateError
           logger.debug('Gavel.js validation errored:', validateError)
           @emitError(validateError, test)


### PR DESCRIPTION
#### :rocket: Why this change?

Because the current syntax is broken.

#### :memo: Related issues and Pull Requests

I think an issue https://github.com/apiaryio/dredd/issues/731 is because of that. Also, I stumbled upon it today when having `+ Response 200 (content-type: application/json; charset=UTF-8)` where `content-type: application/json` is clearly a wrong mime-type. After removing `content-type: ` it worked fine.

#### :white_check_mark: What didn't I forget?

Docs not related. I didn't write any tests because `validateTransaction` has no tests and this is really a syntax error, unfortunately not figured out by Coffee.

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
