### PR TITLE
Document how to make Dredd validation stricter

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -76,7 +76,7 @@ To validate the structure Dredd uses [JSON Schema][] inferred from the API descr
 
 #### API Blueprint
 
-1. [`+ Schema`][schema-section] section - provided custom JSON Schema (draft v4 or v3) will be used.
+1. [`+ Schema`][schema-section] section - provided custom JSON Schema ([Draft v4][] and [v3][Draft v3]) will be used.
 2. [`+ Attributes`][attributes-section] section with data structure description in [MSON][] - API Blueprint parser automatically generates JSON Schema from MSON.
 3. [`+ Body`][body-section] section with sample JSON payload - [Gavel.js][], which is responsible for validation in Dredd, automatically infers some basic expectations described below.
 
@@ -220,6 +220,8 @@ Dredd intentionally **does not support HTTP(S) proxies for testing**. Proxy can 
 [JSON Schema]: http://json-schema.org/
 [Swagger Adapter]: https://github.com/apiaryio/fury-adapter-swagger/
 [RFC6570]: https://tools.ietf.org/html/rfc6570
+[Draft v4]: https://tools.ietf.org/html/draft-zyp-json-schema-04
+[Draft v3]: https://tools.ietf.org/html/draft-zyp-json-schema-03
 
 [CircleCI]: https://circleci.com/
 [Travis CI]: http://travis-ci.org/


### PR DESCRIPTION
#### :rocket: Why this change?

Currently, in the API Blueprint  the default JSON Schema inferred by Gavel or generated from [MSON](https://github.com/apiaryio/mson) (the Attributes section) is quite benevolent. That results in Dredd tests passing easily even though the payloads are missing attributes or having extra attributes. User is given the freedom to specify stricter conditions and achieve stricter testing if they wish.

While such freedom is intended, usually users don't know about it and just expect Dredd to test everything strictly out of the box. That's why Dredd docs should explicitly mention how benevolent Dredd is and how to make it stricter (`fixed-type`, `fixed`, `required`, custom JSON Schema, etc.).

#### :memo: Related issues and Pull Requests

Fixes https://github.com/apiaryio/dredd/issues/232
Fixes https://github.com/apiaryio/dredd/issues/710
See also: [Why optional attributes will ruin your API Blueprint documentation](https://medium.com/@jessica.ulyate/why-optional-attributes-will-ruin-your-api-blueprint-documentation-1629b95546e2#.tgaa4zdwm) by Jessica Ulyate.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
