### PR TITLE
Make Dredd installable in restricted network

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cross-spawn": "^5.0.1",
     "dredd-transactions": "^4.0.0",
     "file": "^0.2.2",
-    "gavel": "^1.1.0",
+    "gavel": "^1.1.1",
     "glob": "^7.0.5",
     "html": "^1.0.0",
     "htmlencode": "0.0.4",


### PR DESCRIPTION
#### :rocket: Why this change?

One dependency of Gavel.js was specified as `josdejong/jsonlint`, which doesn't work in restricted networks. While it's difficult to remove dependency on a GitHub repository at the moment, we can at least specify it as `git+https://git@github.com/josdejong/jsonlint.git`, which should be more portable.

#### :memo: Related issues and Pull Requests

Related to https://github.com/apiaryio/gavel.js/pull/92

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
