### PR TITLE
Syntax highlight API Blueprint in documentation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,7 +49,7 @@ In order to retrieve transaction names please run Dredd with the `--names` argum
 
 For example, given an API Blueprint file `api-description.apib` as following:
 
-```markdown
+```apiblueprint
 FORMAT: 1A
 
 # Machines API

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -16,7 +16,7 @@ To solve the situation, it's recommended to isolate the deletion test by [hooks]
 
 #### API Blueprint
 
-```markdown
+```apiblueprint
 FORMAT: 1A
 
 # Categories API
@@ -169,7 +169,7 @@ For workflows to work properly, you'll also need to keep **shared context** betw
 
 Imagine we have a simple workflow described:
 
-```markdown
+```apiblueprint
 FORMAT: 1A
 
 # My Scenario
@@ -443,7 +443,7 @@ Most of the authentication schemes use HTTP header for carrying the authenticati
 
 API Blueprint format supports `multipart/form-data` media type and so does Dredd. In the example below, Dredd will automatically add `LF` to all lines in request body:
 
-```markdown
+```apiblueprint
 # POST /images
 
 + Request (multipart/form-data;boundary=---BOUNDARY)
@@ -473,7 +473,7 @@ API Blueprint format supports `multipart/form-data` media type and so does Dredd
 
 To test multiple requests and responses within one action in Dredd, you need to cluster them into pairs:
 
-```markdown
+```apiblueprint
 FORMAT: 1A
 
 # My API

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ First, let's design the API we are about to build and test. That means you will 
 
 If you choose API Blueprint, create a file called `api-description.apib` in the root of your project and save it with following content:
 
-```markdown
+```apiblueprint
 FORMAT: 1A
 
 # GET /

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,14 @@
+appdirs==1.4.3
+click==6.7
+Jinja2==2.9.6
+livereload==2.5.1
+Markdown==2.6.8
+MarkupSafe==1.0
+mkdocs==0.16.3
+packaging==16.8
+Pygments==2.2.0
+pygments-markdown-lexer==0.1.0.dev39
+pyparsing==2.2.0
+PyYAML==3.12
+six==1.10.0
+tornado==4.5.1


### PR DESCRIPTION
This PR uses [pygments-apiblueprint](https://github.com/kylef/pygments-apiblueprint) to add syntax highlighting for API Blueprint to the rendered documentation on readthedocs. While pygments-apiblueprint is not perfect, it is certainly better than no syntax highlighting. If you spot any rendering issues with API Blueprints feel free to open issues over there and I'll try fixing (I did find https://github.com/kylef/pygments-apiblueprint/issues/1 which I'll fix but no need to block this PR).

Note, this also version locks all of the mkdocs/pygments and related dependencies so that they are not changed and break the docs. If you'd rather not lock the versions I can change requirements.txt to not specify versions, but I think it would be a good idea to lock them so documentation doesn't silently break when a version of mkdocs or dependency has a breaking change.

For readthedocs to install the dependencies declared in `docs/requirements.txt` the path must be specified on read the docs admin. Please enter it there before merging:

![screen shot 2017-05-09 at 20 04 22](https://cloud.githubusercontent.com/assets/44164/25867975/37781fd4-34f3-11e7-857e-f335b2ebbb7a.png)


##### Before

![screen shot 2017-05-09 at 20 01 08](https://cloud.githubusercontent.com/assets/44164/25867835/bf9079d0-34f2-11e7-9247-c14f60395612.png)

##### After

![screen shot 2017-05-09 at 20 01 05](https://cloud.githubusercontent.com/assets/44164/25867839/c06f25b8-34f2-11e7-8744-fc2bcd3647cf.png)
