### PR TITLE
Reformulate installation guidelines and add section about proxies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,6 +86,17 @@ Also mind that CoffeeScript is production dependency (not dev dependency),
 because it's needed not only for compiling Dredd package before uploading
 to npm, but also for running user-provided hooks written in CoffeeScript.
 
+### Compiled vs pure JavaScript
+
+Dredd uses [Drafter][] for parsing [API Blueprint][] documents. Drafter is written in C++11 and needs to be compiled during installation. Since that can be problematic for some environments and leads to a lot of troubleshooting, there's also pure JavaScript version of the parser, [drafter.js][]. While drafter.js is fully equivalent, it can have slower performance. That's why there's [drafter-npm][] package, which first tries to compile the C++11 version of the parser and if it's unsuccessful, uses the JavaScript equivalent.
+
+Dredd depends on the [drafter-npm][] package. That's why you can see `node-gyp` errors and failures during Dredd installation, although after the installation is done, Dredd seems to normally work and correctly parses API Blueprint documents. Usual problems leading to the JavaScript version of the parser being used as fallback:
+
+- **Your machine is missing a C++11 compiler.** See how to fix this on [Windows][Windows C++11] or [Travis CI][Travis CI C++11].
+- **npm was used with Python 3.** `node-gyp`, which performs the compilation, doesn't support Python 3. If your default Python is 3 (see `python --version`), [tell npm to use an older version][npm Python].
+
+The `--no-optional` option forces the JavaScript version of Drafter and avoids any compilation attempts when installing Dredd.
+
 ### Versioning
 
 Dredd follows [Semantic Versioning][]. To ensure certain stability of Dredd installations (e.g. in CI builds), users can pin their version. They can also use release tags:
@@ -239,11 +250,18 @@ There is also one environment variable you could find useful:
 [md-two-spaces]: https://daringfireball.net/projects/markdown/syntax#p
 [AppVeyor]: http://appveyor.com/
 
+[Drafter]: https://github.com/apiaryio/drafter
+[API Blueprint]: https://apiblueprint.org/
+[drafter.js]: https://github.com/apiaryio/drafter.js
+[drafter-npm]: https://github.com/apiaryio/drafter-npm/
+[Windows C++11]: https://github.com/apiaryio/drafter/wiki/Building-on-Windows
+[Travis CI C++11]: https://github.com/apiaryio/protagonist/blob/master/.travis.yml
+[npm Python]: http://stackoverflow.com/a/22433804/325365
+
 [existing commits]: https://github.com/apiaryio/dredd/commits/master
 [docs]: https://github.com/apiaryio/dredd/tree/master/docs
 [coffeelint.json]: https://github.com/apiaryio/dredd/tree/master/coffeelint.json
 [GitHub Releases]: https://github.com/apiaryio/dredd/releases
-
 
 [upstream repository]: https://github.com/apiaryio/dredd
 [issues]: https://github.com/apiaryio/dredd/issues

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,14 +88,24 @@ to npm, but also for running user-provided hooks written in CoffeeScript.
 
 ### Compiled vs pure JavaScript
 
-Dredd uses [Drafter][] for parsing [API Blueprint][] documents. Drafter is written in C++11 and needs to be compiled during installation. Since that can be problematic for some environments and leads to a lot of troubleshooting, there's also pure JavaScript version of the parser, [drafter.js][]. While drafter.js is fully equivalent, it can have slower performance. That's why there's [drafter-npm][] package, which first tries to compile the C++11 version of the parser and if it's unsuccessful, uses the JavaScript equivalent.
+Dredd uses [Drafter][] for parsing [API Blueprint][] documents. Drafter is written in C++11 and needs to be compiled during installation. Because that can cause a lot of problems in some environments, there's also pure JavaScript version of the parser, [drafter.js][]. Drafter.js is fully equivalent, but it can have slower performance. Therefore there's [drafter-npm][] package, which tries to compile the C++11 version of the parser and uses the JavaScript equivalent in case of failure.
 
-Dredd depends on the [drafter-npm][] package. That's why you can see `node-gyp` errors and failures during Dredd installation, although after the installation is done, Dredd seems to normally work and correctly parses API Blueprint documents. Usual problems leading to the JavaScript version of the parser being used as fallback:
+Dredd depends on the [drafter-npm][] package. That's the reason why you can see `node-gyp` errors and failures during the installation process, even though when it's done, Dredd seems to normally work and correctly parses API Blueprint documents.
+
+#### Forcing the JavaScript version
+
+The `--no-optional` option forces the JavaScript version of Drafter and avoids any compilation attempts when installing Dredd:
+
+```sh
+$ npm install -g dredd --no-optional
+```
+
+#### Troubleshooting the compilation
+
+If you need the performance of the C++11 parser, but you are struggling to get it installed, it's usually because of the following problems:
 
 - **Your machine is missing a C++11 compiler.** See how to fix this on [Windows][Windows C++11] or [Travis CI][Travis CI C++11].
 - **npm was used with Python 3.** `node-gyp`, which performs the compilation, doesn't support Python 3. If your default Python is 3 (see `python --version`), [tell npm to use an older version][npm Python].
-
-The `--no-optional` option forces the JavaScript version of Drafter and avoids any compilation attempts when installing Dredd.
 
 ### Versioning
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,38 +33,32 @@ Dredd is a command-line application written in [CoffeeScript][], a dialect of th
 
 If the second command works, you're done!
 
-> **Note:** The installation process can print several errors related to `node-gyp`. If `dredd --version` works for you after the installation ends, feel free to ignore the errors ([learn more about this](#compiled-vs-pure-javascript)).
-
 ### Globally vs locally
 
 The `-g` ensures Dredd will be installed "globally". That means you'll be able to access it from any directory just by typing `dredd`.
 
 If you work on projects installable by `npm`, i.e. projects containing `package.json`, you might want to have Dredd installed as a development dependency instead. Just install Dredd by `npm install dredd --save-dev`. See `package.json` of the [Dredd Example][] repository for inspiration.
 
-### Which version?
+### Which Version?
 
 - **For development**, always go with the latest version.
-- **For testing in [CI][]**, always pin your Dredd version to a specific number and upgrade to newer releases manually.
+- **For testing in [CI][]**, always pin your Dredd version to a specific number and upgrade to newer releases manually (but often!).
 
-Dredd sometimes issues a pre-release version to test experimental features or to ensure that significant internal revamp of existing features didn't cause any regressions. It's possible to use `npm install dredd@stable` to avoid installing the pre-release versions. However, for most of the time, there are no pre-releases and the `stable` tag just points to the latest version.
+### Why I'm Seeing Some `node-gyp` Errors?
 
-#### Compiled vs pure JavaScript
+The installation process features compilation of some C++ components, which may not be successful. In that case, errors related to `node-gyp` are printed. However, if `dredd --version` works for you when the installation is done, feel free to ignore the errors.
 
-You can simplify and speedup your installation using `npm install dredd --no-optional` if you are:
+In case of compilation errors, Dredd automatically uses a less performant solution written in pure JavaScript. Next time when installing Dredd, you can use `npm install -g dredd --no-optional` to skip the compilation step ([learn more about this][C++11 vs JS]).
 
-- using Dredd with Swagger,
-- using Dredd with smaller API Bluepint files,
+### Why Is the Installation So Slow?
+
+The installation process features compilation of some C++ components, which may take some time ([learn more about this][C++11 vs JS]). You can simplify and speed up the process using `npm install -g dredd --no-optional` if you are:
+
+- using Dredd exclusively with [Swagger][],
+- using Dredd with small [API Bluepint][] files,
 - using Dredd on Windows or other environments with complicated C++11 compiler setup.
 
-Dredd uses [Drafter][] for parsing [API Blueprint][] documents. Drafter is written in C++11 and needs to be compiled during installation. Since that can be problematic for some environments and leads to a lot of troubleshooting, there's also pure JavaScript version of the parser, [drafter.js][]. While drafter.js is fully equivalent, it can have slower performance. That's why there's [drafter-npm][] package, which first tries to compile the C++11 version of the parser and if it's unsuccessful, uses the JavaScript equivalent.
-
-Dredd depends on the [drafter-npm][] package. That's why you can see `node-gyp` errors and failures during Dredd installation, although after the installation is done, Dredd seems to normally work and correctly parses API Blueprint documents. Usual problems leading to the JavaScript version of the parser being used as fallback:
-
-- **Your machine is missing a C++11 compiler.** See how to fix this on [Windows](Windows C++11) or [Travis CI][Travis CI C++11].
-- **npm was used with Python 3.** `node-gyp`, which performs the compilation, doesn't support Python 3. If your default Python is 3 (see `python --version`), [tell npm to use an older version][npm Python].
-- The `protagonist` package got manually deleted from Dredd's `node_modules` directory.
-
-The `--no-optional` option forces the JavaScript version of Drafter and avoids any compilation attempts when installing Dredd.
+The `--no-optional` option avoids any compilation attempts when installing Dredd, but causes slower reading of the API Blueprint files, especially the large ones.
 
 ### Windows Support
 
@@ -72,6 +66,8 @@ There are still [several known limitations][Windows Issues] when using Dredd on 
 
 
 [API Blueprint]: https://apiblueprint.org/
+[Swagger]: http://swagger.io/
+
 [CoffeeScript]: http://coffeescript.org/
 [CI]: how-to-guides.md#continuous-integration
 
@@ -84,10 +80,5 @@ There are still [several known limitations][Windows Issues] when using Dredd on 
 [Download Node.js]: https://nodejs.org/en/#download
 [Install Node.js as system package]: https://nodejs.org/en/download/package-manager/
 
-[Drafter]: https://github.com/apiaryio/drafter
-[drafter.js]: https://github.com/apiaryio/drafter.js
-[drafter-npm]: https://github.com/apiaryio/drafter-npm/
-[Windows C++11]: https://github.com/apiaryio/drafter/wiki/Building-on-Windows
-[Travis CI C++11]: https://github.com/apiaryio/protagonist/blob/master/.travis.yml
-[npm Python]: http://stackoverflow.com/a/22433804/325365
+[C++11 vs JS]: CONTRIBUTING.md#compiled-vs-pure-javascript
 [Dredd Example]: https://github.com/apiaryio/dredd-example/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,7 +44,37 @@ If you work on projects installable by `npm`, i.e. projects containing `package.
 - **For development**, always go with the latest version.
 - **For testing in [CI][]**, always pin your Dredd version to a specific number and upgrade to newer releases manually (but often!).
 
-### Why I'm Seeing Some `node-gyp` Errors?
+### Why I'm Seeing Network Errors?
+
+If you're in restricted network (VPN, firewall, proxy), it's possible you see errors similar to the following ones:
+
+```text
+npmERR! Cannot read property 'path' of null
+npmERR!code ECONNRESET
+npmERR!network socket hang up
+```
+
+```text
+Error: Command failed: git config --get remote.origin.url
+ssh: connect to host github.com port 22: Operation timed out
+fatal: Could not read from remote repository.
+```
+
+To solve these issues, you need to set your proxy settings for both `npm` and `git`:
+
+```sh
+$ npm config set proxy "http://proxy.company.com:8080"
+$ npm config set https-proxy "https://proxy.company.com:8080"
+
+$ git config --global http.proxy "http://proxy.company.com:8080"
+$ git config --global https.proxy "https://proxy.company.com:8080"
+```
+
+When using `git config`, make sure you have the port specified even
+when it's the standard `:80`. Also check out
+[how to set up Dredd to correctly work with proxies][Dredd Proxy].
+
+### Why I'm Seeing `node-gyp` Errors?
 
 The installation process features compilation of some C++ components, which may not be successful. In that case, errors related to `node-gyp` are printed. However, if `dredd --version` works for you when the installation is done, feel free to ignore the errors.
 
@@ -81,4 +111,5 @@ There are still [several known limitations][Windows Issues] when using Dredd on 
 [Install Node.js as system package]: https://nodejs.org/en/download/package-manager/
 
 [C++11 vs JS]: CONTRIBUTING.md#compiled-vs-pure-javascript
+[Dredd Proxy]: how-it-works.md#using-http-s-proxy
 [Dredd Example]: https://github.com/apiaryio/dredd-example/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,9 +44,9 @@ If you work on projects installable by `npm`, i.e. projects containing `package.
 - **For development**, always go with the latest version.
 - **For testing in [CI][]**, always pin your Dredd version to a specific number and upgrade to newer releases manually (but often!).
 
-### Why I'm Seeing Network Errors?
+### Why Am I Seeing Network Errors?
 
-If you're in restricted network (VPN, firewall, proxy), it's possible you see errors similar to the following ones:
+In a restricted network (VPN, firewall, proxy) you can see errors similar to the following ones:
 
 ```text
 npmERR! Cannot read property 'path' of null


### PR DESCRIPTION
#### :rocket: Why this change?

Installation of Dredd in restricted environment isn't completely straightforward. I added a section about the necessary steps. At the same time, I tried to simplify other sections as well and to make them more use-case-oriented.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/gavel.js/issues/83

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
