### PR TITLE
Use 4 spaces as indentation

### DIFF
--- a/test/fixtures/multiple-examples.apib
+++ b/test/fixtures/multiple-examples.apib
@@ -5,33 +5,33 @@ FORMAT: 1A
 # Group Machines
 
 # Machines collection [/machines/{id}]
-  + Parameters
-    - id (number, `1`)
+    + Parameters
+        + id (number, `1`)
 
 ## Get Machines [GET]
 
-- Request (application/json)
-  + Parameters
-    - id (number, `2`)
++ Request (application/json)
+    + Parameters
+        + id (number, `2`)
 
-- Response 200 (application/json; charset=utf-8)
++ Response 200 (application/json; charset=utf-8)
 
-    [
-      {
-        "type": "bulldozer",
-        "name": "willy"
-      }
-    ]
+        [
+          {
+            "type": "bulldozer",
+            "name": "willy"
+          }
+        ]
 
-- Request (application/json)
-  + Parameters
-    - id (number, `3`)
++ Request (application/json)
+    + Parameters
+        + id (number, `3`)
 
-- Response 200 (application/json; charset=utf-8)
++ Response 200 (application/json; charset=utf-8)
 
-    [
-      {
-        "type": "bulldozer",
-        "name": "willy"
-      }
-    ]
+        [
+          {
+            "type": "bulldozer",
+            "name": "willy"
+          }
+        ]


### PR DESCRIPTION
#### :rocket: Why this change?

API Blueprint format supports just indentation with 4 spaces. Different formatting may cause issues and parser warnings.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
