### PR TITLE
Fix exit status for failing builds

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Runs tests and collects code coverage to ./cov.info file
 
+set -e # aborts as soon as anything returns non-zero exit status
+
 
 PROJECT_DIR=$(pwd -P)
 


### PR DESCRIPTION
#### :rocket: Why this change?

The `coverage.sh` won't set proper exit status code in case the tests are failing. The exit status code of `npm test` will get forgotten and the `coverage.sh` script will always finish with success 😱 (luckily, AppVeyor holds our back because of #763 - it does not use the `npm run test:coverage` script).

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/726

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
