### PR TITLE
Upgrade chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "async": "^2.3.0",
     "caseless": "^0.12.0",
-    "chai": "^3.5.0",
+    "chai": "^4.0.2",
     "clone": "^2.1.1",
     "coffee-script": "^1.12.5",
     "colors": "^1.1.2",

--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -309,7 +309,7 @@ describe 'CLI', ->
         )
 
       it 'should have an additional header in the request', ->
-        assert.deepPropertyVal runtimeInfo.server.requests['/machines'][0], 'headers.accept', 'application/json'
+        assert.nestedPropertyVal runtimeInfo.server.requests['/machines'][0], 'headers.accept', 'application/json'
 
 
     describe "when adding basic auth credentials with -u", ->

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -99,12 +99,12 @@ describe 'CLI - Reporters', ->
           '/apis/public/tests/steps?testRunId=1234_id': 1
       it 'should send results from gavel', ->
         assert.isObject stepRequest.body
-        assert.deepProperty stepRequest.body, 'resultData.request'
-        assert.deepProperty stepRequest.body, 'resultData.realResponse'
-        assert.deepProperty stepRequest.body, 'resultData.expectedResponse'
-        assert.deepProperty stepRequest.body, 'resultData.result.body.validator'
-        assert.deepProperty stepRequest.body, 'resultData.result.headers.validator'
-        assert.deepProperty stepRequest.body, 'resultData.result.statusCode.validator'
+        assert.nestedProperty stepRequest.body, 'resultData.request'
+        assert.nestedProperty stepRequest.body, 'resultData.realResponse'
+        assert.nestedProperty stepRequest.body, 'resultData.expectedResponse'
+        assert.nestedProperty stepRequest.body, 'resultData.result.body.validator'
+        assert.nestedProperty stepRequest.body, 'resultData.result.headers.validator'
+        assert.nestedProperty stepRequest.body, 'resultData.result.statusCode.validator'
 
     describe 'When hooks file uses hooks.log function for logging', ->
       dreddCommandInfo = undefined
@@ -145,23 +145,23 @@ describe 'CLI - Reporters', ->
       context 'the update request', ->
         it 'should have result stats with logs', ->
           assert.isObject updateRequest.body
-          assert.deepPropertyVal updateRequest.body, 'status', 'passed'
-          assert.deepProperty updateRequest.body, 'endedAt'
-          assert.deepProperty updateRequest.body, 'logs'
+          assert.nestedPropertyVal updateRequest.body, 'status', 'passed'
+          assert.nestedProperty updateRequest.body, 'endedAt'
+          assert.nestedProperty updateRequest.body, 'logs'
           assert.isArray updateRequest.body.logs
           assert.lengthOf updateRequest.body.logs, 3
           assert.property updateRequest.body.logs[0], 'timestamp'
           assert.include updateRequest.body.logs[0].content, 'Error object!'
           assert.property updateRequest.body.logs[1], 'timestamp'
-          assert.deepPropertyVal updateRequest.body.logs[1], 'content', 'true'
+          assert.nestedPropertyVal updateRequest.body.logs[1], 'content', 'true'
           assert.property updateRequest.body.logs[2], 'timestamp'
-          assert.deepPropertyVal updateRequest.body.logs[2], 'content', 'using hooks.log to debug'
-          assert.deepProperty updateRequest.body, 'result.tests'
-          assert.deepProperty updateRequest.body, 'result.failures'
-          assert.deepProperty updateRequest.body, 'result.errors'
-          assert.deepProperty updateRequest.body, 'result.passes'
-          assert.deepProperty updateRequest.body, 'result.start'
-          assert.deepProperty updateRequest.body, 'result.end'
+          assert.nestedPropertyVal updateRequest.body.logs[2], 'content', 'using hooks.log to debug'
+          assert.nestedProperty updateRequest.body, 'result.tests'
+          assert.nestedProperty updateRequest.body, 'result.failures'
+          assert.nestedProperty updateRequest.body, 'result.errors'
+          assert.nestedProperty updateRequest.body, 'result.passes'
+          assert.nestedProperty updateRequest.body, 'result.start'
+          assert.nestedProperty updateRequest.body, 'result.end'
         it 'should have startedAt larger than \'before\' hook log timestamp', ->
           assert.isObject stepRequest.body
           assert.isNumber stepRequest.body.startedAt
@@ -212,15 +212,15 @@ describe 'CLI - Reporters', ->
       context 'the update request', ->
         it 'should have result stats with logs', ->
           assert.isObject updateRequest.body
-          assert.deepPropertyVal updateRequest.body, 'status', 'passed'
-          assert.deepProperty updateRequest.body, 'endedAt'
-          assert.deepProperty updateRequest.body, 'logs'
+          assert.nestedPropertyVal updateRequest.body, 'status', 'passed'
+          assert.nestedProperty updateRequest.body, 'endedAt'
+          assert.nestedProperty updateRequest.body, 'logs'
           assert.isArray updateRequest.body.logs
           assert.lengthOf updateRequest.body.logs, 2
           assert.property updateRequest.body.logs[0], 'timestamp'
-          assert.deepPropertyVal updateRequest.body.logs[0], 'content', 'shall not print, but be present in logs'
+          assert.nestedPropertyVal updateRequest.body.logs[0], 'content', 'shall not print, but be present in logs'
           assert.property updateRequest.body.logs[1], 'timestamp'
-          assert.deepPropertyVal updateRequest.body.logs[1], 'content', 'using sandboxed hooks.log'
+          assert.nestedPropertyVal updateRequest.body.logs[1], 'content', 'using sandboxed hooks.log'
         it 'should have startedAt larger than \'before\' hook log timestamp', ->
           assert.isObject stepRequest.body
           assert.isNumber stepRequest.body.startedAt

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -176,12 +176,12 @@ describe 'Dredd class Integration', ->
 
     it 'should send results from Gavel', ->
       assert.isObject receivedRequest
-      assert.deepProperty receivedRequest, 'resultData.request'
-      assert.deepProperty receivedRequest, 'resultData.realResponse'
-      assert.deepProperty receivedRequest, 'resultData.expectedResponse'
-      assert.deepProperty receivedRequest, 'resultData.result.body.validator'
-      assert.deepProperty receivedRequest, 'resultData.result.headers.validator'
-      assert.deepProperty receivedRequest, 'resultData.result.statusCode.validator'
+      assert.nestedProperty receivedRequest, 'resultData.request'
+      assert.nestedProperty receivedRequest, 'resultData.realResponse'
+      assert.nestedProperty receivedRequest, 'resultData.expectedResponse'
+      assert.nestedProperty receivedRequest, 'resultData.result.body.validator'
+      assert.nestedProperty receivedRequest, 'resultData.result.headers.validator'
+      assert.nestedProperty receivedRequest, 'resultData.result.statusCode.validator'
 
       it 'prints out an error message', ->
         assert.notEqual exitStatus, 0
@@ -255,9 +255,9 @@ describe 'Dredd class Integration', ->
 
       it 'should send results from gavel', () ->
         assert.isObject receivedRequest
-        assert.deepProperty receivedRequest, 'resultData.request'
-        assert.deepProperty receivedRequest, 'resultData.expectedResponse'
-        assert.deepProperty receivedRequest, 'resultData.result.general'
+        assert.nestedProperty receivedRequest, 'resultData.request'
+        assert.nestedProperty receivedRequest, 'resultData.expectedResponse'
+        assert.nestedProperty receivedRequest, 'resultData.result.general'
 
       it 'report should have message about server being down', () ->
         message = receivedRequest['resultData']['result']['general'][0]['message']
@@ -318,12 +318,12 @@ describe 'Dredd class Integration', ->
 
       it 'should send results from Gavel', ->
         assert.isObject receivedRequest
-        assert.deepProperty receivedRequest, 'resultData.request'
-        assert.deepProperty receivedRequest, 'resultData.realResponse'
-        assert.deepProperty receivedRequest, 'resultData.expectedResponse'
-        assert.deepProperty receivedRequest, 'resultData.result.body.validator'
-        assert.deepProperty receivedRequest, 'resultData.result.headers.validator'
-        assert.deepProperty receivedRequest, 'resultData.result.statusCode.validator'
+        assert.nestedProperty receivedRequest, 'resultData.request'
+        assert.nestedProperty receivedRequest, 'resultData.realResponse'
+        assert.nestedProperty receivedRequest, 'resultData.expectedResponse'
+        assert.nestedProperty receivedRequest, 'resultData.result.body.validator'
+        assert.nestedProperty receivedRequest, 'resultData.result.headers.validator'
+        assert.nestedProperty receivedRequest, 'resultData.result.statusCode.validator'
 
 
   describe "when API description document should be loaded from 'http(s)://...' url", ->

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -52,7 +52,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
         assert.isDefined runner.hooks
         assert.instanceOf runner.hooks, hooksStub
         assert.strictEqual runner.hooks, runner.hooks
-        assert.deepProperty runner, 'hooks.transactions'
+        assert.nestedProperty runner, 'hooks.transactions'
         done()
 
 
@@ -61,7 +61,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
         return err if err
         assert.isDefined runner.hooks
         assert.instanceOf runner.hooks, hooksStub
-        assert.deepProperty runner, 'hooks.logs'
+        assert.nestedProperty runner, 'hooks.logs'
         assert.isDefined runner.hooks.logs
         assert.strictEqual runner.hooks.logs, runner.logs
         done()

--- a/test/unit/configuration-test.coffee
+++ b/test/unit/configuration-test.coffee
@@ -63,10 +63,10 @@ describe('configuration.applyConfiguration()', ->
         level: 'debug'
     )
 
-    assert.deepPropertyVal(config, 'options.color', true)
+    assert.nestedPropertyVal(config, 'options.color', true)
     assert.equal(logger.transports.console.colorize, true)
 
-    assert.deepPropertyVal(config, 'options.level', 'debug')
+    assert.nestedPropertyVal(config, 'options.level', 'debug')
     assert.equal(logger.transports.console.level, 'debug')
   )
 )

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -221,18 +221,18 @@ describe 'Dredd class', ->
         dredd.run (error) ->
           return done error if error
           assert.isObject dredd.configuration.data
-          assert.notDeepProperty dredd, 'configuration.data.testingDirectObject'
-          assert.deepPropertyVal dredd, 'configuration.data.testingDirectObjectFilename.filename', 'testingDirectObjectFilename'
-          assert.deepProperty    dredd, 'configuration.data.testingDirectObjectFilename.raw'
-          assert.deepPropertyVal dredd, 'configuration.data.testingDirectBlueprintString.filename', 'testingDirectBlueprintString'
-          assert.deepProperty    dredd, 'configuration.data.testingDirectBlueprintString.raw'
+          assert.notNestedProperty dredd, 'configuration.data.testingDirectObject'
+          assert.nestedPropertyVal dredd, 'configuration.data.testingDirectObjectFilename.filename', 'testingDirectObjectFilename'
+          assert.nestedProperty    dredd, 'configuration.data.testingDirectObjectFilename.raw'
+          assert.nestedPropertyVal dredd, 'configuration.data.testingDirectBlueprintString.filename', 'testingDirectBlueprintString'
+          assert.nestedProperty    dredd, 'configuration.data.testingDirectBlueprintString.raw'
           done()
 
       it 'should parse passed data contents', (done) ->
         dredd.run (error) ->
           return done error if error
-          assert.deepProperty dredd, 'configuration.data.testingDirectObjectFilename.annotations'
-          assert.deepProperty dredd, 'configuration.data.testingDirectBlueprintString.annotations'
+          assert.nestedProperty dredd, 'configuration.data.testingDirectObjectFilename.annotations'
+          assert.nestedProperty dredd, 'configuration.data.testingDirectBlueprintString.annotations'
           done()
 
       describe 'and I also set configuration.options.path to an existing file', ->
@@ -257,12 +257,12 @@ describe 'Dredd class', ->
             assert.propertyVal localdredd.configuration.data['./test/fixtures/apiary.apib'], 'filename', './test/fixtures/apiary.apib'
             assert.property    localdredd.configuration.data['./test/fixtures/apiary.apib'], 'raw'
             assert.property    localdredd.configuration.data['./test/fixtures/apiary.apib'], 'annotations'
-            assert.deepPropertyVal localdredd, 'configuration.data.testingDirectObjectFilename.filename', 'testingDirectObjectFilename'
-            assert.deepProperty    localdredd, 'configuration.data.testingDirectObjectFilename.raw'
-            assert.deepProperty    localdredd, 'configuration.data.testingDirectObjectFilename.annotations'
-            assert.deepPropertyVal localdredd, 'configuration.data.testingDirectBlueprintString.filename', 'testingDirectBlueprintString'
-            assert.deepProperty    localdredd, 'configuration.data.testingDirectBlueprintString.raw'
-            assert.deepProperty    localdredd, 'configuration.data.testingDirectBlueprintString.annotations'
+            assert.nestedPropertyVal localdredd, 'configuration.data.testingDirectObjectFilename.filename', 'testingDirectObjectFilename'
+            assert.nestedProperty    localdredd, 'configuration.data.testingDirectObjectFilename.raw'
+            assert.nestedProperty    localdredd, 'configuration.data.testingDirectObjectFilename.annotations'
+            assert.nestedPropertyVal localdredd, 'configuration.data.testingDirectBlueprintString.filename', 'testingDirectBlueprintString'
+            assert.nestedProperty    localdredd, 'configuration.data.testingDirectBlueprintString.raw'
+            assert.nestedProperty    localdredd, 'configuration.data.testingDirectBlueprintString.annotations'
             done()
 
 

--- a/test/unit/hooks-log-sandboxed-test.coffee
+++ b/test/unit/hooks-log-sandboxed-test.coffee
@@ -23,7 +23,7 @@ describe 'hooksLogSandboxed()', () ->
       assert.lengthOf data, 1
       assert.strictEqual data, originLogs
       assert.deepEqual data, originLogs
-      assert.deepPropertyVal data[0], 'content', 'one message'
+      assert.propertyVal data[0], 'content', 'one message'
 
     it 'should push message to undefined logs and return new array instead', ->
       originLogs = undefined
@@ -32,7 +32,7 @@ describe 'hooksLogSandboxed()', () ->
       assert.lengthOf data, 1
       assert.isUndefined originLogs
       assert.notDeepEqual data, originLogs
-      assert.deepPropertyVal data[0], 'content', 'another message'
+      assert.propertyVal data[0], 'content', 'another message'
 
     it 'should append message to an existing logs array', ->
       originLogs = clone exampleLog
@@ -41,7 +41,7 @@ describe 'hooksLogSandboxed()', () ->
       assert.lengthOf data, 2
       assert.deepEqual data, originLogs
       assert.deepEqual data[0], exampleLog[0]
-      assert.deepPropertyVal data[1], 'content', 'some other idea'
+      assert.propertyVal data[1], 'content', 'some other idea'
 
   describe 'passes arguments further to hooks-log', ->
     beforeEach ->

--- a/test/unit/hooks-log-test.coffee
+++ b/test/unit/hooks-log-test.coffee
@@ -46,7 +46,7 @@ describe 'hooksLog()', () ->
       assert.lengthOf data, 1
       assert.strictEqual data, originLogs
       assert.deepEqual data, originLogs
-      assert.deepPropertyVal data[0], 'content', 'one message'
+      assert.propertyVal data[0], 'content', 'one message'
 
     it 'should push message to undefined logs and return new array instead', ->
       originLogs = undefined
@@ -55,7 +55,7 @@ describe 'hooksLog()', () ->
       assert.lengthOf data, 1
       assert.isUndefined originLogs
       assert.notDeepEqual data, originLogs
-      assert.deepPropertyVal data[0], 'content', 'another message'
+      assert.propertyVal data[0], 'content', 'another message'
 
     it 'should append message to an existing logs array', ->
       originLogs = clone exampleLogs
@@ -64,7 +64,7 @@ describe 'hooksLog()', () ->
       assert.lengthOf data, 2
       assert.deepEqual data, originLogs
       assert.deepEqual data[0], exampleLogs[0]
-      assert.deepPropertyVal data[1], 'content', 'some other idea'
+      assert.propertyVal data[1], 'content', 'some other idea'
 
     it 'should use "hook" logger level', ->
       hooksLog [], loggerStub, 'there is a log'

--- a/test/unit/hooks-test.coffee
+++ b/test/unit/hooks-test.coffee
@@ -46,10 +46,10 @@ describe 'Hooks', () ->
       hooks.log 'messageX'
       assert.isTrue options.logger.hook.called
       assert.isFalse options.logger.error.called
-      assert.deepProperty hooks.logs[2], 'timestamp'
-      assert.deepPropertyVal hooks.logs[0], 'content', 'message1'
-      assert.deepPropertyVal hooks.logs[1], 'content', 'message2'
-      assert.deepPropertyVal hooks.logs[2], 'content', 'messageX'
+      assert.property hooks.logs[2], 'timestamp'
+      assert.propertyVal hooks.logs[0], 'content', 'message1'
+      assert.propertyVal hooks.logs[1], 'content', 'message2'
+      assert.propertyVal hooks.logs[2], 'content', 'messageX'
 
   describe '#before', () ->
     hooks = null


### PR DESCRIPTION
#### :rocket: Why this change?

Bundled chai version starts to be outdated.

**BREAKING CHANGE:** The chai library is available in the sandboxed JS hooks' interface. For that reason, it is also a part of Dredd's public interface (and for the same reason it's not a devDependency, but dependency). The new version of chai is not backwards compatible in some cases, which means this is a breaking change.

**HOW DO ONE KNOWS ALL OCCURRENCES ARE ADDRESSED?** Simple! The tests would crash/fail in case I'd forget to change something 😄 

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
