### PR TITLE
Fix #376 (NaNms duration)

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -7,6 +7,7 @@ Documentation of various data structures in both [Gavel.js][] and Dredd. [MSON n
 
 Transaction object is passed as a first argument to [hook functions](hooks.md) and is one of the main public interfaces in Dredd.
 
+- id: `GET /greetings` - identifier for this transaction
 - name: `./api-description.apib > My API > Greetings > Hello, world! > Retrieve Message > Example 2` (string) - reference to the transaction definition in the original API description document (see also [Dredd Transactions][])
 - origin (object) - reference to the transaction definition in the original API description document (see also [Dredd Transactions][])
     - filename: `./api-description.apib` (string)

--- a/src/reporters/base-reporter.coffee
+++ b/src/reporters/base-reporter.coffee
@@ -27,6 +27,8 @@ class BaseReporter
     emitter.on 'test pass', (test) =>
       @stats.passes += 1
       test['end'] = new Date()
+      if typeof test['start'] is 'string'
+        test['start'] = new Date(test['start'])
       test['duration'] = test.end - test.start
 
     emitter.on 'test skip', (test) =>
@@ -35,11 +37,15 @@ class BaseReporter
     emitter.on 'test fail', (test) =>
       @stats.failures += 1
       test['end'] = new Date()
+      if typeof test['start'] is 'string'
+        test['start'] = new Date(test['start'])
       test['duration'] = test.end - test.start
 
     emitter.on 'test error', (error, test) =>
       @stats.errors += 1
       test['end'] = new Date()
+      if typeof test['start'] is 'string'
+        test['start'] = new Date(test['start'])
       test['duration'] = test.end - test.start
 
 

--- a/test/unit/reporters/base-reporter-test.coffee
+++ b/test/unit/reporters/base-reporter-test.coffee
@@ -118,3 +118,42 @@ describe 'BaseReporter', () ->
 
     it 'should set the end time', () ->
       assert.isOk tests[0].end
+
+  describe 'when passing test start is UTC string', () ->
+
+    beforeEach () ->
+      test =
+        status: 'pass'
+        title: 'Passing Test'
+      emitter.emit 'test start', test
+      test.start = '2017-06-15T09:29:50.588Z'
+      emitter.emit 'test pass', test
+
+    it 'should set the duration', () ->
+      assert.isNotNaN tests[0].duration
+
+  describe 'when failed test start is UTC string', () ->
+
+    beforeEach () ->
+      test =
+        status: 'pass'
+        title: 'Failed Test'
+      emitter.emit 'test start', test
+      test.start = '2017-06-15T09:29:50.588Z'
+      emitter.emit 'test fail', test
+
+    it 'should set the duration', () ->
+      assert.isNotNaN tests[0].duration
+
+  describe 'when errored test start is UTC string', () ->
+
+    beforeEach () ->
+      test =
+        status: 'pass'
+        title: 'Errored Test'
+      emitter.emit 'test start', test
+      test.start = '2017-06-15T09:29:50.588Z'
+      emitter.emit 'test error', new Error('Error'), test
+
+    it 'should set the duration', () ->
+      assert.isNotNaN tests[0].duration


### PR DESCRIPTION
#### :rocket: Why this change?

See #376 

Sometimes test.start is transformed into a string (I haven't figured out where - maybe from a hooks handler). The duration can no longer be calculated in that case.

#### :white_check_mark: What didn't I forget?

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
