### PR TITLE
#795: HTTP client should not follow redirects

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -457,6 +457,7 @@ class TransactionRunner
     options.headers = transaction.request.headers
     options.body = transaction.request.body
     options.proxy = false
+    options.followRedirect = false
     return options
 
   # This is actually doing more some pre-flight and conditional skipping of


### PR DESCRIPTION
#### :rocket: Why this change?
Dredd is following 3xx redirections (as a result of a GET request, not for POST requests) because that is the default behavior implemented in the `request` package. This makes it impossible to validate API specs that produce a redirection.

#### :memo: Related issues and Pull Requests
#795 
#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
