### PR TITLE
Update sinon.stub() calls from deprecated to the new syntax

### DIFF
--- a/test/integration/dredd-command-test.coffee
+++ b/test/integration/dredd-command-test.coffee
@@ -56,9 +56,9 @@ describe "DreddCommand class Integration", () ->
 
   before ->
     for method in ['warn', 'error'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stderr += "\n#{method}: #{chunk}"
     for method in ['log', 'info', 'silly', 'verbose', 'test', 'hook', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stdout += "\n#{method}: #{chunk}"
     return
 
   after ->
@@ -78,8 +78,8 @@ describe "DreddCommand class Integration", () ->
       configUtilsLoad = undefined
 
       before((done) ->
-        fsExistsSync = sinon.stub(fs, 'existsSync', -> true)
-        configUtilsLoad = sinon.stub(configUtils, 'load', -> options)
+        fsExistsSync = sinon.stub(fs, 'existsSync').callsFake( -> true)
+        configUtilsLoad = sinon.stub(configUtils, 'load').callsFake( -> options)
         execCommand(cmd, done)
       )
       after( ->
@@ -107,8 +107,8 @@ describe "DreddCommand class Integration", () ->
       configUtilsLoad = undefined
 
       before((done) ->
-        fsExistsSync = sinon.stub(fs, 'existsSync', -> true)
-        configUtilsLoad = sinon.stub(configUtils, 'load', -> options)
+        fsExistsSync = sinon.stub(fs, 'existsSync').callsFake( -> true)
+        configUtilsLoad = sinon.stub(configUtils, 'load').callsFake( -> options)
         execCommand(cmd, done)
       )
       after( ->
@@ -136,7 +136,7 @@ describe "DreddCommand class Integration", () ->
       configUtilsLoad = undefined
 
       before((done) ->
-        fsExistsSync = sinon.stub(fs, 'existsSync', -> false)
+        fsExistsSync = sinon.stub(fs, 'existsSync').callsFake( -> false)
         configUtilsLoad = sinon.spy(configUtils, 'load')
         execCommand(cmd, done)
       )

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -51,9 +51,9 @@ describe 'Dredd class Integration', ->
 
   before ->
     for method in ['warn', 'error'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stderr += "\n#{method}: #{chunk}"
     for method in ['log', 'info', 'silly', 'verbose', 'test', 'hook', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stdout += "\n#{method}: #{chunk}"
     return
 
   after ->

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -97,7 +97,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
             language: 'ruby'
             hookfiles: './some/ruby/file.rb'
 
-      sinon.stub hooksWorkerClientStub.prototype, 'start', (cb) -> cb()
+      sinon.stub(hooksWorkerClientStub.prototype, 'start').callsFake (cb) -> cb()
 
     afterEach ->
       hooksWorkerClientStub.prototype.start.restore()
@@ -132,9 +132,9 @@ describe 'addHooks(runner, transactions, callback)', () ->
           configuration:
             options:
               hookfiles: './**/*_hooks.*'
-        sinon.stub globStub, 'sync', (pattern) ->
+        sinon.stub(globStub, 'sync').callsFake (pattern) ->
           ['file1.js', 'file2.coffee']
-        sinon.stub pathStub, 'resolve', (path, rel) ->
+        sinon.stub(pathStub, 'resolve').callsFake (path, rel) ->
           '/Users/netmilk/projects/dredd/file2.coffee'
 
       after () ->

--- a/test/unit/config-utils-test.coffee
+++ b/test/unit/config-utils-test.coffee
@@ -170,7 +170,7 @@ describe 'configUtils', () ->
     """
 
     beforeEach () ->
-      sinon.stub fsStub, 'readFileSync', (file) -> return yamlData
+      sinon.stub(fsStub, 'readFileSync').callsFake (file) -> return yamlData
 
     afterEach () ->
       fsStub.readFileSync.restore()

--- a/test/unit/dredd-command-test.coffee
+++ b/test/unit/dredd-command-test.coffee
@@ -65,9 +65,9 @@ describe "DreddCommand class", () ->
 
   before ->
     for method in ['warn', 'error'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stderr += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stderr += "\n#{method}: #{chunk}"
     for method in ['log', 'info', 'silly', 'verbose', 'test', 'hook', 'complete', 'pass', 'skip', 'debug', 'fail', 'request', 'expected', 'actual'] then do (method) ->
-      sinon.stub loggerStub, method, (chunk) -> stdout += "\n#{method}: #{chunk}"
+      sinon.stub(loggerStub, method).callsFake (chunk) -> stdout += "\n#{method}: #{chunk}"
     return
 
   after ->
@@ -143,7 +143,7 @@ describe "DreddCommand class", () ->
           env: {'NO_KEY': 'NO_VAL'}
       })
 
-      initDreddStub = sinon.stub dc, 'initDredd', (configuration) ->
+      initDreddStub = sinon.stub(dc, 'initDredd').callsFake (configuration) ->
         dredd = new dreddStub configuration
         sinon.stub dredd, 'run'
         return dredd
@@ -257,7 +257,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (nodejs)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'nodejs'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -275,7 +275,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (python)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'python'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -294,7 +294,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (php)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'php'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -312,7 +312,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (ruby)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'ruby'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -330,7 +330,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (perl)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'perl'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -348,7 +348,7 @@ describe "DreddCommand class", () ->
 
     describe '"init" (go)', ->
       before (done) ->
-        sinon.stub interactiveConfigStub, 'run', (argv, cb) ->
+        sinon.stub(interactiveConfigStub, 'run').callsFake (argv, cb) ->
           cb({language: 'go'})
         sinon.stub configUtilsStub, 'save'
         execCommand argv: ['init'], ->
@@ -376,7 +376,7 @@ describe "DreddCommand class", () ->
   describe 'when configuration was saved', () ->
     before (done) ->
       sinon.spy dreddStub.prototype, 'init'
-      sinon.stub dreddStub.prototype, 'run', (cb) ->
+      sinon.stub(dreddStub.prototype, 'run').callsFake (cb) ->
         stats =
           tests: 0
           failures: 0
@@ -388,12 +388,12 @@ describe "DreddCommand class", () ->
           duration: 0
         cb(null, stats)
 
-      sinon.stub interactiveConfigStub, 'run', (config, cb) ->
+      sinon.stub(interactiveConfigStub, 'run').callsFake (config, cb) ->
         cb()
 
-      sinon.stub fsStub, 'existsSync', () -> true
+      sinon.stub(fsStub, 'existsSync').callsFake () -> true
 
-      sinon.stub configUtilsStub, 'load', () ->
+      sinon.stub(configUtilsStub, 'load').callsFake () ->
         {
           "_": [ 'blueprint', 'endpoint' ]
           'dry-run': true
@@ -449,7 +449,7 @@ describe "DreddCommand class", () ->
 
     beforeEach (done) ->
       sinon.spy crossSpawnStub, 'spawn'
-      sinon.stub transactionRunner.prototype, 'executeAllTransactions', (transactions, hooks, cb) -> cb()
+      sinon.stub(transactionRunner.prototype, 'executeAllTransactions').callsFake (transactions, hooks, cb) -> cb()
       execCommand argv: [
         './test/fixtures/single-get.apib'
         "http://127.0.0.1:#{PORT}"

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -33,8 +33,8 @@ describe 'Dredd class', ->
       configuration =
         server: 'http://127.0.0.1:3000/'
         blueprintPath: './test/fixtures/apiary.apib'
-       sinon.stub loggerStub, 'info', ->
-       sinon.stub loggerStub, 'log', ->
+       sinon.stub(loggerStub, 'info').callsFake( -> )
+       sinon.stub(loggerStub, 'log').callsFake( -> )
 
     after ->
       loggerStub.info.restore()
@@ -44,7 +44,7 @@ describe 'Dredd class', ->
 
       fn = ->
         dredd = new Dredd(configuration)
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
           callback()
         dredd.run (error) ->
           assert.isOk dredd.runner.executeTransaction.called
@@ -72,7 +72,7 @@ describe 'Dredd class', ->
 
     it 'should load the file on given path', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.isOk fsStub.readFile.calledWith configuration.options.path[0]
@@ -81,7 +81,7 @@ describe 'Dredd class', ->
 
     it 'should not pass any error to the callback function', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.isNull(error)
@@ -90,7 +90,7 @@ describe 'Dredd class', ->
 
     it 'should pass the reporter as second argument', (done) ->
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
       dredd.run (error, reporter) ->
         assert.isDefined reporter
@@ -100,7 +100,7 @@ describe 'Dredd class', ->
     it 'should convert ast to runtime', (done) ->
       sinon.spy dreddTransactionsStub, 'compile'
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
       dredd.run (error) ->
         assert.isOk dreddTransactionsStub.compile.called
@@ -117,7 +117,7 @@ describe 'Dredd class', ->
         dredd = new Dredd(configuration)
 
       beforeEach ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
           callback()
 
       afterEach ->
@@ -167,7 +167,7 @@ describe 'Dredd class', ->
         dredd = new Dredd(configuration)
 
       beforeEach ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
           callback()
 
       afterEach ->
@@ -205,7 +205,7 @@ describe 'Dredd class', ->
                       {"a":"b"}'
               """
         dredd = new Dredd(configuration)
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
           callback()
 
       afterEach ->
@@ -241,7 +241,7 @@ describe 'Dredd class', ->
           configuration.options ?= {}
           configuration.options.path = ['./test/fixtures/apiary.apib']
           localdredd = new Dredd(configuration)
-          sinon.stub localdredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+          sinon.stub(localdredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
             callback()
 
         afterEach ->
@@ -280,7 +280,7 @@ describe 'Dredd class', ->
           done err
 
       beforeEach ->
-        sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
           callback()
 
       afterEach ->
@@ -288,7 +288,7 @@ describe 'Dredd class', ->
 
       describe 'when all URLs can be downloaded', ->
         before ->
-          sinon.stub requestStub, 'get', (receivedArgs = {}, cb) ->
+          sinon.stub(requestStub, 'get').callsFake (receivedArgs = {}, cb) ->
             cb null, {statusCode:200}, blueprintCode
 
         after ->
@@ -349,7 +349,7 @@ describe 'Dredd class', ->
 
       describe 'when an URL for one API description document returns 404 not-found', ->
         before ->
-          sinon.stub requestStub, 'get', (receivedArgs = {}, cb) ->
+          sinon.stub(requestStub, 'get').callsFake (receivedArgs = {}, cb) ->
             if receivedArgs?.url is 'https://another.path.to/apiary.apib'
               return cb null, {statusCode: 404}, 'Page Not Found'
             cb null, {statusCode:200}, blueprintCode
@@ -372,7 +372,7 @@ describe 'Dredd class', ->
 
       describe 'when an URL for one API description document is unreachable (erroneous)', ->
         before ->
-          sinon.stub requestStub, 'get', (receivedArgs = {}, cb) ->
+          sinon.stub(requestStub, 'get').callsFake (receivedArgs = {}, cb) ->
             if receivedArgs?.url is 'http://some.path.to/file.apib'
               # server not found on
               return cb {code: 'ENOTFOUND'}
@@ -404,7 +404,7 @@ describe 'Dredd class', ->
       dredd = new Dredd(configuration)
 
     beforeEach ->
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
 
     afterEach ->
@@ -430,7 +430,7 @@ describe 'Dredd class', ->
       dredd = new Dredd(configuration)
 
     beforeEach ->
-      sinon.stub dredd.runner, 'run', (transaction, callback) ->
+      sinon.stub(dredd.runner, 'run').callsFake (transaction, callback) ->
         callback()
       sinon.spy loggerStub, 'warn'
 
@@ -456,7 +456,7 @@ describe 'Dredd class', ->
           silent: true
           path: ['./balony/path.apib']
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
 
     afterEach ->
@@ -481,7 +481,7 @@ describe 'Dredd class', ->
           path: ['./test/fixtures/error-uri-template.apib']
 
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
 
     afterEach ->
@@ -506,7 +506,7 @@ describe 'Dredd class', ->
           path: ['./test/fixtures/warning-ambiguous.apib']
       sinon.spy loggerStub, 'warn'
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
 
     afterEach ->
@@ -536,7 +536,7 @@ describe 'Dredd class', ->
           silent: true
           path: ['./test/fixtures/apiary.apib']
       dredd = new Dredd(configuration)
-      sinon.stub dredd.runner, 'executeTransaction', (transaction, hooks, callback) ->
+      sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
         callback()
 
     afterEach ->

--- a/test/unit/handle-runtime-problems-test.coffee
+++ b/test/unit/handle-runtime-problems-test.coffee
@@ -37,10 +37,10 @@ describe('handleRuntimeProblems()', ->
     warnOutput = ''
     errorOutput = ''
 
-    sinon.stub(logger, 'warn', (args...) ->
+    sinon.stub(logger, 'warn').callsFake((args...) ->
       warnOutput += args.join(' ').toLowerCase()
     )
-    sinon.stub(logger, 'error', (args...) ->
+    sinon.stub(logger, 'error').callsFake((args...) ->
       errorOutput += args.join(' ').toLowerCase()
     )
   )

--- a/test/unit/hooks-log-test.coffee
+++ b/test/unit/hooks-log-test.coffee
@@ -13,9 +13,9 @@ describe 'hooksLog()', () ->
   ]
 
   before ->
-   sinon.stub loggerStub, 'log', ->
-   sinon.stub loggerStub, 'debug', ->
-   sinon.stub loggerStub, 'hook', ->
+   sinon.stub(loggerStub, 'log').callsFake( -> )
+   sinon.stub(loggerStub, 'debug').callsFake( -> )
+   sinon.stub(loggerStub, 'hook').callsFake( -> )
 
   after ->
     loggerStub.log.restore()

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -51,7 +51,7 @@ describe 'Hooks worker client', ->
     runner.hooks.configuration = {options: {}}
 
     for level in logLevels
-      sinon.stub loggerStub, level, (msg1, msg2) ->
+      sinon.stub(loggerStub, level).callsFake (msg1, msg2) ->
         text = msg1
         text += " " + msg2 if msg2
 
@@ -65,8 +65,8 @@ describe 'Hooks worker client', ->
 
   describe "when methods dealing with connection to the handler are stubbed", ->
     beforeEach ->
-      sinon.stub HooksWorkerClient.prototype, 'disconnectFromHandler', ->
-      sinon.stub HooksWorkerClient.prototype, 'connectToHandler', (cb) ->
+      sinon.stub(HooksWorkerClient.prototype, 'disconnectFromHandler').callsFake( -> )
+      sinon.stub(HooksWorkerClient.prototype, 'connectToHandler').callsFake (cb) ->
         cb()
 
     afterEach ->
@@ -153,20 +153,21 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=ruby option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: 'ruby'
             hookfiles: "somefile.rb"
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
       afterEach ->
@@ -198,7 +199,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=ruby option is given and the worker is not installed', ->
       beforeEach ->
-        sinon.stub whichStub, 'which', (command) -> false
+        sinon.stub(whichStub, 'which').callsFake (command) -> false
 
         runner.hooks['configuration'] =
           options:
@@ -217,20 +218,21 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=python option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: 'python'
             hookfiles: "somefile.py"
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
       afterEach ->
@@ -262,7 +264,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=python option is given and the worker is not installed', ->
       beforeEach ->
-        sinon.stub whichStub, 'which', (command) -> false
+        sinon.stub(whichStub, 'which').callsFake (command) -> false
 
         runner.hooks['configuration'] =
           options:
@@ -280,20 +282,21 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=php option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: 'php'
             hookfiles: "somefile.py"
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
       afterEach ->
@@ -325,7 +328,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=php option is given and the worker is not installed', ->
       beforeEach ->
-        sinon.stub whichStub, 'which', (command) -> false
+        sinon.stub(whichStub, 'which').callsFake (command) -> false
 
         runner.hooks['configuration'] =
           options:
@@ -343,7 +346,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=go option is given and the worker is not installed', ->
       beforeEach ->
-        sinon.stub whichStub, 'which', (command) -> false
+        sinon.stub(whichStub, 'which').callsFake (command) -> false
 
         runner.hooks['configuration'] =
           options:
@@ -360,20 +363,21 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=go option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: 'go'
             hookfiles: "gobinary"
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
       afterEach ->
@@ -406,20 +410,21 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=perl option is given and the worker is installed', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: 'perl'
             hookfiles: "somefile.py"
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
       afterEach ->
@@ -451,7 +456,7 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=perl option is given and the worker is not installed', ->
       beforeEach ->
-        sinon.stub whichStub, 'which', (command) -> false
+        sinon.stub(whichStub, 'which').callsFake (command) -> false
 
         runner.hooks['configuration'] =
           options:
@@ -469,21 +474,22 @@ describe 'Hooks worker client', ->
 
     describe 'when --language=./any/other-command is given', ->
       beforeEach ->
-        sinon.stub crossSpawnStub, 'spawn', ->
+        sinon.stub(crossSpawnStub, 'spawn').callsFake( ->
           emitter = new EventEmitter
           emitter.stdout = new EventEmitter
           emitter.stderr = new EventEmitter
           emitter
+        )
 
         runner.hooks['configuration'] =
           options:
             language: './my-fancy-command'
             hookfiles: "someotherfile"
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
-        sinon.stub whichStub, 'which', -> true
+        sinon.stub(whichStub, 'which').callsFake( -> true)
 
       afterEach ->
         crossSpawnStub.spawn.restore()
@@ -520,12 +526,12 @@ describe 'Hooks worker client', ->
             language: 'ruby'
             hookfiles: "somefile.rb"
 
-        sinon.stub HooksWorkerClient.prototype, 'spawnHandler' , (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'spawnHandler' ).callsFake (callback) ->
           callback()
 
-        sinon.stub whichStub, 'which', (command) -> true
+        sinon.stub(whichStub, 'which').callsFake (command) -> true
 
-        sinon.stub HooksWorkerClient.prototype, 'terminateHandler', (callback) ->
+        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake (callback) ->
           callback()
 
 

--- a/test/unit/interactive-config-test.coffee
+++ b/test/unit/interactive-config-test.coffee
@@ -21,7 +21,7 @@ describe 'interactiveConfig', () ->
     describe 'when I call it ', () ->
 
       it 'should run inquirer', (done) ->
-        sinon.stub inquirerStub, 'prompt', (questions) -> {then: (cb) -> cb()}
+        sinon.stub(inquirerStub, 'prompt').callsFake (questions) -> {then: (cb) -> cb()}
 
         interactiveConfig.prompt {}, () ->
           assert.isTrue inquirerStub.prompt.called

--- a/test/unit/reporters/html-reporter-test.coffee
+++ b/test/unit/reporters/html-reporter-test.coffee
@@ -43,7 +43,7 @@ describe 'HtmlReporter', () ->
 
     describe 'when file exists', () ->
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return true
         sinon.stub loggerStub, 'info'
 
@@ -57,7 +57,7 @@ describe 'HtmlReporter', () ->
     describe 'when file does not exist', () ->
 
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return false
         sinon.stub fsStub, 'unlinkSync'
 
@@ -79,7 +79,7 @@ describe 'HtmlReporter', () ->
       stats.tests = 1
 
     beforeEach () ->
-      sinon.stub fsStub, 'writeFile', (path, data, callback) ->
+      sinon.stub(fsStub, 'writeFile').callsFake (path, data, callback) ->
         callback()
 
     afterEach () ->

--- a/test/unit/reporters/markdown-reporter-test.coffee
+++ b/test/unit/reporters/markdown-reporter-test.coffee
@@ -44,7 +44,7 @@ describe 'MarkdownReporter', () ->
 
     describe 'when file exists', () ->
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return true
         sinon.stub loggerStub, 'info'
 
@@ -58,7 +58,7 @@ describe 'MarkdownReporter', () ->
     describe 'when file does not exist', () ->
 
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return false
         sinon.stub fsStub, 'unlinkSync'
 

--- a/test/unit/reporters/x-unit-reporter-test.coffee
+++ b/test/unit/reporters/x-unit-reporter-test.coffee
@@ -25,9 +25,9 @@ describe 'XUnitReporter', () ->
 
     describe 'when file exists', () ->
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return true
-        sinon.stub fsStub, 'unlinkSync', (path) ->
+        sinon.stub(fsStub, 'unlinkSync').callsFake (path) ->
           return true
         sinon.stub loggerStub, 'info'
 
@@ -44,7 +44,7 @@ describe 'XUnitReporter', () ->
     describe 'when file does not exist', () ->
 
       before () ->
-        sinon.stub fsStub, 'existsSync', (path) ->
+        sinon.stub(fsStub, 'existsSync').callsFake (path) ->
           return false
         sinon.stub fsStub, 'unlinkSync'
 

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -849,7 +849,7 @@ describe 'TransactionRunner', ->
       spies = {}
       for name in spyNames
         spies[name] = (data, hooksCallback) -> hooksCallback()
-        sinon.stub spies, name, (data, hooksCallback) -> hooksCallback()
+        sinon.stub(spies, name).callsFake (data, hooksCallback) -> hooksCallback()
 
       hooks.beforeAll spies.beforeAllSpy
       hooks.beforeEach spies.beforeEachSpy
@@ -1662,7 +1662,7 @@ describe 'TransactionRunner', ->
 
         beforeEach ->
           # coffeelint: disable=no_empty_functions
-          sinon.stub configuration.emitter, 'emit', ->
+          sinon.stub(configuration.emitter, 'emit').callsFake( -> )
           # coffeelint: enable=no_empty_functions
 
         afterEach ->


### PR DESCRIPTION
#### :rocket: Why this change?

Sinon has deprecated the `sinon.stub(obj, 'meth', fn)` notation and replaced it with `sinon.stub(obj, 'meth').callsFake(fn)`. [See the migration guide.](http://sinonjs.org/releases/v2.0.0/migrating-to-2.0/#stubcallsfake-replaces-stubobj-meth-fn)

#### :memo: Related issues and Pull Requests

This is a follow-up to https://github.com/apiaryio/dredd/commit/31fe7b549221fc848e89f5682818d2c25393bd56.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
