### PR TITLE
Resolve glob patterns before passing them to hook handlers

### DIFF
--- a/docs/hooks-new-language.md
+++ b/docs/hooks-new-language.md
@@ -28,9 +28,9 @@ If you want to write a hook handler for your language you will have to implement
     - after each transaction
     - after all transactions
 - When CLI command is executed
-    - it loads files specified as CLI server arguments
-        - it exposes API similar to those in [Ruby](hooks-ruby.md), [Python](hooks-python.md) and [Node.js](hooks-nodejs.md) to each loaded file
-        - it registers functions declared in files for later execution
+    - It loads files passed in alphabetical order with paths resolved to absolute form
+        - It exposes API similar to those in [Ruby](hooks-ruby.md), [Python](hooks-python.md) and [Node.js](hooks-nodejs.md) to each loaded file
+        - It registers functions declared in files for later execution
     - starts a TCP socket server and starts listening on `http://127.0.0.1:61321`.
 - When any data is received by the server
     - Adds every received character to a buffer

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -33,7 +33,7 @@ Dredd doesn't speak your language? [**It's very easy to write support for your l
 ## Using Hook Files
 
 To use a hook file with Dredd, use the `--hookfiles` flag in the command line.
-You can use this flag multiple times or use a [glob](http://npmjs.com/package/glob) expression for loading multiple hook files.
+You can use this flag multiple times or use a [glob](http://npmjs.com/package/glob) expression for loading multiple hook files. Dredd executes hook files in alphabetical order.
 
 Example:
 

--- a/docs/usage-cli.md
+++ b/docs/usage-cli.md
@@ -102,8 +102,7 @@ Extra header to include in every request. This option can be used multiple times
 Show usage information.<br>
 
 ### --hookfiles, -f
-Specifies a pattern to match files with before/after hooks for running tests. Files are executed in
-alphabetical order.<br>
+Specifies a pattern to match files with before/after hooks for running tests<br>
 
 ### --hooks-worker-after-connect-wait
 How long to wait between connecting to hooks worker and start of testing. [ms]<br>

--- a/docs/usage-cli.md
+++ b/docs/usage-cli.md
@@ -102,7 +102,8 @@ Extra header to include in every request. This option can be used multiple times
 Show usage information.<br>
 
 ### --hookfiles, -f
-Specifies a pattern to match files with before/after hooks for running tests<br>
+Specifies a pattern to match files with before/after hooks for running tests. Files are executed in
+alphabetical order.<br>
 
 ### --hooks-worker-after-connect-wait
 How long to wait between connecting to hooks worker and start of testing. [ms]<br>

--- a/src/add-hooks.coffee
+++ b/src/add-hooks.coffee
@@ -101,12 +101,12 @@ addHooks = (runner, transactions, callback) ->
   else
     # Expand hookfiles - sort files alphabetically and resolve their paths
     hookfiles = [].concat runner.configuration?.options?.hookfiles
-    files = hookfiles.reduce((result, item) ->
+    files = hookfiles.reduce((result, unresolvedPath) ->
       # glob.sync does not resolve paths, only glob patterns
-      input = if glob.hasMagic(item) then glob.sync(item) else [item]
+      unresolvedPaths = if glob.hasMagic(unresolvedPath) then glob.sync(unresolvedPath) else [unresolvedPath]
 
       # Gradually append sorted and resolved paths
-      result.concat input
+      result.concat unresolvedPaths
         # Create a filename / filepath map for easier sorting
         # Example:
         # [

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -6,7 +6,8 @@ options =
 
   hookfiles:
     alias: 'f'
-    description: 'Specifies a pattern to match files with before/after hooks for running tests'
+    description: """Specifies a pattern to match files with before/after hooks for running tests. \
+      Files are executed in alphabetical order."""
     default: null
 
   language:

--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -1,5 +1,7 @@
-{assert} = require('chai')
 net = require('net')
+path = require('path')
+
+{assert} = require('chai')
 {exec} = require('child_process')
 
 {isProcessRunning, killAll, createServer, runDreddCommandWithServer, runDreddCommand, DEFAULT_SERVER_PORT} = require('../helpers')
@@ -194,7 +196,10 @@ describe 'CLI', ->
         before (done) ->
           app = createServer()
           app.get '/machines', (req, res) ->
-            killAll('endless-ignore-term.+[^=]foo/bar/hooks', (err) ->
+            # path.posix|win32.normalize and path.join do not do the job in this case,
+            # hence this ingenious hack
+            normalizedPath = path.normalize('foo/bar/hooks').replace(/\\/g, '\\\\')
+            killAll("endless-ignore-term.+[^=]#{normalizedPath}", (err) ->
               done err if err
               res.json([{type: 'bulldozer', name: 'willy'}])
             )

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -137,6 +137,8 @@ describe 'addHooks(runner, transactions, callback)', () ->
 
         actual = runner.hooks.configuration.options.hookfiles
 
+        assert.notEqual actual.length, 0
+
         actual.forEach (item, index) ->
           assert.include item, expected[index]
 

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -125,6 +125,77 @@ describe 'addHooks(runner, transactions, callback)', () ->
         globStub.sync.restore()
         done()
 
+    it 'should return files alphabetically sorted', (done) ->
+      addHooks runner, transactions, (err) ->
+        return done err if err
+
+        expected = [
+          'multifile_hooks.coffee',
+          'test2_hooks.js',
+          'test_hooks.coffee'
+        ]
+
+        actual = runner.hooks.configuration.options.hookfiles
+
+        actual.forEach (item, index) ->
+          assert.include item, expected[index]
+
+        done()
+
+    it 'should return files with resolved paths', (done) ->
+      addHooks runner, transactions, (err) ->
+        return done err if err
+
+        expected = [
+          pathStub.resolve(process.cwd(), './test/fixtures/multifile/multifile_hooks.coffee'),
+          pathStub.resolve(process.cwd(), './test/fixtures/test2_hooks.js'),
+          pathStub.resolve(process.cwd(), './test/fixtures/test_hooks.coffee')
+        ]
+
+        actual = runner.hooks.configuration.options.hookfiles
+
+        assert.deepEqual actual, expected
+
+        done()
+
+    it 'should return resolved path for non existing file', (done) ->
+      runner =
+        configuration:
+          options:
+            hookfiles: 'foo/bar/hooks'
+
+      addHooks runner, transactions, (err) ->
+        return done err if err
+
+        actual = runner.hooks.configuration.options.hookfiles
+        expected = [pathStub.resolve(process.cwd(), 'foo/bar/hooks')]
+
+        assert.deepEqual actual, expected
+
+        done()
+
+    it 'should handle mixed filepaths and globs', (done) ->
+      runner =
+        configuration:
+          options:
+            hookfiles: ['foo/bar/hooks', './**/*_hooks.*']
+
+      addHooks runner, transactions, (err) ->
+        return done err if err
+
+        actual = runner.hooks.configuration.options.hookfiles
+        expected = [
+          pathStub.resolve(process.cwd(), 'foo/bar/hooks')
+          pathStub.resolve(process.cwd(), './test/fixtures/multifile/multifile_hooks.coffee')
+          pathStub.resolve(process.cwd(), './test/fixtures/test2_hooks.js')
+          pathStub.resolve(process.cwd(), './test/fixtures/test_hooks.coffee')
+        ]
+
+        assert.deepEqual actual, expected
+
+        done()
+
+
     describe 'when files are valid js/coffeescript', () ->
       runner = null
       before () ->


### PR DESCRIPTION
#### :rocket: Why this change?

Currently, Dredd provides hook file paths / globs to hook handlers in the same form (untouched) as they are passed via the CLI. Since every language has its own implementation of glob pattern resolution, it can potentially lead to problems with wrong execution order of hook files.

With the changes introduced in this pull request, Dredd will now resolve glob patterns, matched file paths resolves to their absolute form, sorts them alphabetically and then passes to hook handlers.

#### :memo: Related issues and Pull Requests

Resolves #680 and resolves #742.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
