### PR TITLE
Refactor: make some parts more decaffeinate-friendly

### DIFF
--- a/src/reporters/x-unit-reporter.coffee
+++ b/src/reporters/x-unit-reporter.coffee
@@ -26,7 +26,7 @@ class XUnitReporter extends EventEmitter
       fs.unlinkSync(filePath)
     filePath
 
-  configureEmitter: (emitter) =>
+  configureEmitter: (emitter) ->
     emitter.on 'start', (rawBlueprint, callback) =>
       appendLine @path, toTag('testsuite', {
         name: 'Dredd Tests'
@@ -89,7 +89,7 @@ class XUnitReporter extends EventEmitter
       appendLine @path, toTag('testcase', attrs, false, toTag('failure', null, false, cdata(errorMessage)))
 
   updateSuiteStats = (path, stats, callback) ->
-    fs.readFile path, (err, data) ->
+    fs.readFile path, (err, data) =>
       if !err
         data = data.toString()
         position = data.toString().indexOf('\n')

--- a/test/integration/child-process-test.coffee
+++ b/test/integration/child-process-test.coffee
@@ -281,7 +281,7 @@ describe('Babysitting Child Processes', ->
 
       beforeEach((done) ->
         runChildProcess('test/fixtures/scripts/exit-0.coffee', (childProcess) ->
-          ; # do nothing
+          true
         , (err, info) ->
           processInfo = info
           done(err)
@@ -313,7 +313,7 @@ describe('Babysitting Child Processes', ->
 
       beforeEach((done) ->
         runChildProcess('test/fixtures/scripts/exit-3.coffee', (childProcess) ->
-          ; # do nothing
+          true
         , (err, info) ->
           processInfo = info
           done(err)

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -1525,7 +1525,7 @@ describe 'TransactionRunner', ->
         runner.hooks.beforeHooks =
           'Group Machine > Machine > Delete Message > Bogus example name' : [
             (transaction) ->
-              loggerStub.info "first",
+              loggerStub.info "first"
             (transaction, cb) ->
               loggerStub.info "second"
               cb()


### PR DESCRIPTION
#### :rocket: Why this change?
To make sure that, if one day you'll be willing to use `decaffeinate`, it will convert the code with no complains.

#### :memo: Related issues and Pull Requests
#705 
#### :white_check_mark: What didn't I forget?
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
