### PR TITLE
Hotfix: Return correct exit code when tests fail

### DIFF
--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -332,9 +332,11 @@ class DreddCommand
   exitWithStatus: (error, stats) ->
     if error
       logger.error(error.message) if error.message
+      process.exitCode = 1
       return @_processExit(1)
 
     if (stats.failures + stats.errors) > 0
+      process.exitCode = 1
       @_processExit(1)
     else
       @_processExit(0)


### PR DESCRIPTION
#### :rocket: Why this change?

Currently, Dredd returns wrong exit code (`O`) when test(s) fail (should return `1`). This change fixes the problem.

#### :memo: Related issues and Pull Requests

Resolves https://github.com/apiaryio/dredd/issues/818.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
