### PR TITLE
Fix jenkins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ $ npm install -g dredd
 
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/
-[Jenkins]: http://jenkins-ci.org/
+[Jenkins]: https://jenkins.io/


### PR DESCRIPTION
#### :rocket: Why this change?

Jenkins link was opening too slowly. The change will avoid redirect and thus open faster.
