### PR TITLE
Fix internal links in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,10 +236,21 @@ def process_refs(app, doctree, docname):
         for node in doctree.traverse(nodes.reference):
             uri = node.get('refuri')
             if to_reference(uri, basedoc=docname) == reference:
-                fixed_uri = '/{}.html'.format(referenced_docname)
-                if anchor:
-                    fixed_uri += '#{}'.format(anchor)
-                node['refuri'] = fixed_uri
+                node['refuri'] = to_uri(app, referenced_docname, anchor)
+
+def to_uri(app, docname, anchor=None):
+    uri = ''
+
+    if IS_READTHEDOCS:
+        language = app.config.language or 'en'
+        version_name = os.environ.get('READTHEDOCS_VERSION')
+        uri = '/{}/{}'.format(language, version_name)
+
+    uri += '/{}.html'.format(docname)
+    if anchor:
+        uri += '#{}'.format(anchor)
+
+    return uri
 
 def to_reference(uri, basedoc=None):
     """


### PR DESCRIPTION
#### :rocket: Why this change?

Local links do not work on current version of the docs. This fix is tested on https://dredd.readthedocs.io/en/honzajavorek-fix-local-links/ and it looks like it resolves the problem.

#### :memo: Related issues and Pull Requests

Fixes https://github.com/apiaryio/dredd/issues/825.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
