### PR TITLE
Fail CI build as soon as there's something failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
   - "npm -g install npm@latest"
 install: "npm install --no-optional"
 script:
-  - "npm run lint"
-  - "npm run test:coverage"
+  - "npm run lint && npm run test:coverage"
 after_success:
   - "npm run coveralls || true"
   - "npm run semantic-release || true"


### PR DESCRIPTION
#### :rocket: Why this change?

With current setup, the CI build continues to run tests even if linter fails. This is unnecessary waste of time & resources.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
