### PR TITLE
Support setting Request encoding for response

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -27,6 +27,7 @@ Transaction object is passed as a first argument to [hook functions](hooks.md) a
     - headers (object) - keys are HTTP header names, values are HTTP header contents
     - uri: `/message` (string) - request URI as it was written in API description
     - method: `POST` (string)
+    - encoding: `utf8` (object) - response encoding
 - expected (object) - the HTTP response Dredd expects to get from the tested server
     - statusCode: `200` (string)
     - headers (object) - keys are HTTP header names, values are HTTP header contents

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pretest": "npm run build",
     "test": "mocha \"test/**/*-test.coffee\"",
     "test:coverage": "scripts/coverage.sh",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
+    "prepublish": "check-node-version --npm \">=4\" || npm run prepare",
     "coveralls": "scripts/coveralls.sh",
     "semantic-release": "scripts/semantic-release.sh"
   },
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "body-parser": "^1.17.1",
+    "check-node-version": "^2.1.0",
     "coffee-coverage": "^2.0.1",
     "coffeelint": "^1.15.7",
     "conventional-changelog-lint": "^1.1.9",

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -456,6 +456,7 @@ class TransactionRunner
     options.method = transaction.request.method
     options.headers = transaction.request.headers
     options.body = transaction.request.body
+    options.encoding = transaction.request.encoding
     options.proxy = false
     options.followRedirect = false
     return options


### PR DESCRIPTION
Mostly useful for Node.js hooks that want to deal with binary data.

#### :rocket: Why this change?

Request keeps on messing up higher bytes in some binary data I want to test in a hook.

#### :memo: Related issues and Pull Requests

[Epic: empty responses and binary files](https://github.com/apiaryio/dredd/issues?q=label%3A%22Epic%3A%20empty%20responses%20and%20binary%20files%22)
#617, #87

#### :white_check_mark: What didn't I forget?

- [X] To write docs
- [ ] To write tests
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
