### PR TITLE
Add test case for CLI exit code regression

### DIFF
--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -92,6 +92,11 @@ describe 'CLI - Server Process', ->
 
 
     for scenario in [
+        description: 'When it fails to start'
+        apiDescriptionDocument: './test/fixtures/single-get.apib'
+        server: "/foo/bar/baz"
+        expectServerBoot: false
+      ,
         description: 'When crashes before requests'
         apiDescriptionDocument: './test/fixtures/single-get.apib'
         server: "#{COFFEE_BIN} test/fixtures/scripts/exit-3.coffee"


### PR DESCRIPTION
#### :rocket: Why this change?
This PR adds a test case for a regression fixed in https://github.com/apiaryio/dredd/pull/819.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
