### PR TITLE
Modify multipart body and calculate Content-Length in the right order

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -675,8 +675,10 @@ class TransactionRunner
 
   isMultipart: (headers) ->
     contentType = caseless(headers).get('Content-Type')
-    return false unless contentType
-    return contentType.indexOf('multipart') > -1
+    if contentType
+      contentType.indexOf('multipart') > -1
+    else
+      false
 
   # Finds newlines not preceeded by carriage returns and replaces them by
   # newlines preceeded by carriage returns.

--- a/test/fixtures/request/application-json.apib
+++ b/test/fixtures/request/application-json.apib
@@ -1,0 +1,17 @@
+FORMAT: 1A
+
+# Testing 'application/json' Request API
+
+# POST /data
+
++ Request (application/json)
+
+    + Body
+
+            {"test": 42}
+
++ Response 200 (application/json; charset=utf-8)
+
+    + Body
+
+            {"test": "OK"}

--- a/test/fixtures/request/application-x-www-form-urlencoded.apib
+++ b/test/fixtures/request/application-x-www-form-urlencoded.apib
@@ -1,0 +1,17 @@
+FORMAT: 1A
+
+# Testing 'application/x-www-form-urlencoded' Request API
+
+# POST /data
+
++ Request (application/x-www-form-urlencoded)
+
+    + Body
+
+            test=42
+
++ Response 200 (application/json; charset=utf-8)
+
+    + Body
+
+            {"test": "OK"}

--- a/test/fixtures/request/multipart-form-data.apib
+++ b/test/fixtures/request/multipart-form-data.apib
@@ -1,0 +1,27 @@
+FORMAT: 1A
+
+# Testing 'multipart/form-data' Request API
+
+# POST /data
+
++ Request (multipart/form-data;boundary=---BOUNDARY)
+
+    + Body
+
+            ---BOUNDARY
+            Content-Disposition: form-data; name="text"
+            Content-Type: text/plain
+
+            test equals to 42
+            ---BOUNDARY
+            Content-Disposition: form-data; name="json"; filename="filename.json"
+            Content-Type: application/json
+
+            {"test": 42}
+            ---BOUNDARY--
+
++ Response 200 (application/json; charset=utf-8)
+
+    + Body
+
+            {"test": "OK"}

--- a/test/fixtures/request/text-plain.apib
+++ b/test/fixtures/request/text-plain.apib
@@ -1,0 +1,17 @@
+FORMAT: 1A
+
+# Testing 'text/plain' Request API
+
+# POST /data
+
++ Request (text/plain)
+
+    + Body
+
+            test equals to 42
+
++ Response 200 (application/json; charset=utf-8)
+
+    + Body
+
+            {"test": "OK"}

--- a/test/integration/helpers.coffee
+++ b/test/integration/helpers.coffee
@@ -90,6 +90,7 @@ getSSLCredentials = ->
 #     - *endpointUrl*: 0 (number, default) - number of requests to the endpoint
 createServer = (options = {}) ->
   protocol = options.protocol or 'http'
+  bodyParserInstance = options.bodyParser or bodyParser.json({size: '5mb'})
 
   serverRuntimeInfo =
     requestedOnce: false
@@ -99,10 +100,11 @@ createServer = (options = {}) ->
     requestCounts: {}
 
   app = express()
-  app.use(bodyParser.json({size: '5mb'}))
+  app.use(bodyParserInstance)
   app.use((req, res, next) ->
     recordServerRequest(serverRuntimeInfo, req)
-    res.type('json').status(200) # sensible defaults, can be overriden
+    res.type('json')
+    res.status(200) # sensible defaults, can be overriden
     next()
   )
   app = https.createServer(getSSLCredentials(), app) if protocol is 'https'

--- a/test/integration/helpers.coffee
+++ b/test/integration/helpers.coffee
@@ -103,8 +103,7 @@ createServer = (options = {}) ->
   app.use(bodyParserInstance)
   app.use((req, res, next) ->
     recordServerRequest(serverRuntimeInfo, req)
-    res.type('json')
-    res.status(200) # sensible defaults, can be overriden
+    res.type('json').status(200) # sensible defaults, can be overriden
     next()
   )
   app = https.createServer(getSSLCredentials(), app) if protocol is 'https'

--- a/test/integration/request-test.coffee
+++ b/test/integration/request-test.coffee
@@ -1,0 +1,159 @@
+{assert} = require('chai')
+bodyParser = require('body-parser')
+
+{runDreddWithServer, createServer} = require('./helpers')
+Dredd = require('../../src/dredd')
+
+
+describe('Sending \'application/json\' request', ->
+  runtimeInfo = undefined
+  contentType = 'application/json'
+
+  beforeEach((done) ->
+    app = createServer({bodyParser: bodyParser.text({type: contentType})})
+    app.post('/data', (req, res) ->
+      res.json({test: 'OK'})
+    )
+
+    path = './test/fixtures/request/application-json.apib'
+    dredd = new Dredd({options: {path}})
+
+    runDreddWithServer(dredd, app, (err, info) ->
+      runtimeInfo = info
+      done(err)
+    )
+  )
+
+  it('results in one request being delivered to the server', ->
+    assert.isTrue(runtimeInfo.server.requestedOnce)
+  )
+  it('the request has the expected Content-Type', ->
+    assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType)
+  )
+  it('the request has the expected format', ->
+    body = runtimeInfo.server.lastRequest.body
+    assert.deepEqual(JSON.parse(body), {test: 42})
+  )
+  it('results in one passing test', ->
+    assert.equal(runtimeInfo.dredd.stats.tests, 1)
+    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+  )
+)
+
+
+describe('Sending \'multipart/form-data\' request', ->
+  runtimeInfo = undefined
+  contentType = 'multipart/form-data'
+
+  beforeEach((done) ->
+    path = './test/fixtures/request/multipart-form-data.apib'
+
+    app = createServer({bodyParser: bodyParser.text({type: contentType})})
+    app.post('/data', (req, res) ->
+      res.json({test: 'OK'})
+    )
+    dredd = new Dredd({options: {path}})
+
+    runDreddWithServer(dredd, app, (err, info) ->
+      runtimeInfo = info
+      done(err)
+    )
+  )
+
+  it('results in one request being delivered to the server', ->
+    assert.isTrue(runtimeInfo.server.requestedOnce)
+  )
+  it('the request has the expected Content-Type', ->
+    assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data')
+  )
+  it('the request has the expected format', ->
+    assert.equal(runtimeInfo.server.lastRequest.body, [
+      '---BOUNDARY'
+      'Content-Disposition: form-data; name="text"'
+      'Content-Type: text/plain'
+      ''
+      'test equals to 42'
+      '---BOUNDARY'
+      'Content-Disposition: form-data; name="json"; filename="filename.json"'
+      'Content-Type: application/json'
+      ''
+      '{"test": 42}'
+      '---BOUNDARY--'
+      ''
+    ].join('\r\n'))
+  )
+  it('results in one passing test', ->
+    assert.equal(runtimeInfo.dredd.stats.tests, 1)
+    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+  )
+)
+
+
+describe('Sending \'application/x-www-form-urlencoded\' request', ->
+  runtimeInfo = undefined
+  contentType = 'application/x-www-form-urlencoded'
+
+  beforeEach((done) ->
+    path = './test/fixtures/request/application-x-www-form-urlencoded.apib'
+
+    app = createServer({bodyParser: bodyParser.text({type: contentType})})
+    app.post('/data', (req, res) ->
+      res.json({test: 'OK'})
+    )
+    dredd = new Dredd({options: {path}})
+
+    runDreddWithServer(dredd, app, (err, info) ->
+      runtimeInfo = info
+      done(err)
+    )
+  )
+
+  it('results in one request being delivered to the server', ->
+    assert.isTrue(runtimeInfo.server.requestedOnce)
+  )
+  it('the request has the expected Content-Type', ->
+    assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType)
+  )
+  it('the request has the expected format', ->
+    assert.equal(runtimeInfo.server.lastRequest.body, 'test=42\n')
+  )
+  it('results in one passing test', ->
+    assert.equal(runtimeInfo.dredd.stats.tests, 1)
+    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+  )
+)
+
+
+describe('Sending \'text/plain\' request', ->
+  runtimeInfo = undefined
+  contentType = 'text/plain'
+
+  beforeEach((done) ->
+    path = './test/fixtures/request/text-plain.apib'
+
+    app = createServer({bodyParser: bodyParser.text({type: contentType})})
+    app.post('/data', (req, res) ->
+      res.json({test: 'OK'})
+    )
+    dredd = new Dredd({options: {path}})
+
+    runDreddWithServer(dredd, app, (err, info) ->
+      runtimeInfo = info
+      done(err)
+    )
+  )
+
+  it('results in one request being delivered to the server', ->
+    assert.isTrue(runtimeInfo.server.requestedOnce)
+  )
+  it('the request has the expected Content-Type', ->
+    assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType)
+  )
+  it('the request has the expected format', ->
+    assert.equal(runtimeInfo.server.lastRequest.body, 'test equals to 42\n')
+  )
+  it('results in one passing test', ->
+    assert.equal(runtimeInfo.dredd.stats.tests, 1)
+    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+  )
+)


### PR DESCRIPTION
#### :rocket: Why this change?

Current implementation of multipart request bodies is broken. See https://github.com/apiaryio/dredd/issues/786.

In https://github.com/apiaryio/dredd/pull/734 Dredd's custom implementation of HTTP requesting was replaced with the `request` library. There is some special handling of multipart requests, solving https://github.com/apiaryio/api-blueprint/issues/401, which modifies the body payload and also modifies the `Content-Length` header accordingly. This wasn't updated with introduction of the `request` library. That resulted in the `Content-Length` being sent with incorrect number, causing the server under test to hang, waiting for more bytes.

My changes makes the code dealing with https://github.com/apiaryio/api-blueprint/issues/401 a lot simpler and more functional (no side effects). It removes any modifications to `Content-Length` and instead it changes the order in which the body gets modified and the header gets calculated.

#### :memo: Related issues and Pull Request

- https://github.com/apiaryio/dredd/pull/734
- https://github.com/apiaryio/api-blueprint/issues/401
- https://github.com/apiaryio/dredd/issues/74
- https://github.com/apiaryio/dredd/pull/118

Fixes https://github.com/apiaryio/dredd/issues/786.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
