### PR TITLE
Pin Travis to 'precise' until we explicitly migrate to 'trusty'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: "precise"
 language: "node_js"
 node_js:
   - "4"


### PR DESCRIPTION
#### :rocket: Why this change?

See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming. Dredd test suite has some issues running on `trusty`. We have to investigate and fix those before upgrading.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
