### PR TITLE
Introduce Travis CI build stages and pin npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 dist: "precise"
 language: "node_js"
-node_js:
-  - "4"
-  - "6"
 env:
   global:
     # GH_TOKEN and NPM_TOKEN encrypted by 'travis encrypt' utility
@@ -15,10 +12,18 @@ before_install:
   # Travis CI has only shallow clone of the repository. We need to get the 'master' branch
   # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
   - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
-  - "npm -g install npm@latest"
+  - "npm -g install npm@4"
 install: "npm install --no-optional"
-script:
-  - "npm run lint && npm run test:coverage"
-after_success:
-  - "npm run coveralls || true"
-  - "npm run semantic-release || true"
+jobs:
+  include:
+    - stage: "code/docs/commits quality checks"
+      node_js: "6"
+      script: "npm run lint"
+    - stage: "tests & code coverage"
+      node_js: "4"
+      script: "npm run test:coverage && npm run coveralls"
+    - node_js: "6"
+      script: "npm run test:coverage && npm run coveralls"
+    - stage: "semantic release"
+      node_js: "6"
+      script: "npm run semantic-release || true"


### PR DESCRIPTION
#### :rocket: Why this change?

See https://blog.travis-ci.com/2017-05-11-introducing-build-stages and https://docs.travis-ci.com/user/build-stages. Looks like a cool feature which could save some resources (if not now, then in the future). Also the stages could make the build more readable for Dredd contributors.

- [Last `master` build](https://travis-ci.org/apiaryio/dredd/builds/262662384) took 35 mins total time
- This branch built in 33 mins total time twice, so I don't think it should have any kind of performace impact

The PR also pins npm to v4 on Travis CI.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/issues/828

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
