### PR TITLE
Fix several links, use Swagger 2.0 specs as a reference

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -221,7 +221,7 @@ Any `id` HTML attributes generated for headings or manual `<a name="section"></a
 
 #### Redirects
 
-Redirects are documented in the `docs/redirects.yml` file. They need to be manually set in the [ReadTheDocs administration](https://readthedocs.org/dashboard/dredd-docs-sphinx-test/redirects/). It's up to Dredd maintainers to keep the list in sync with reality.
+Redirects are documented in the `docs/redirects.yml` file. They need to be manually set in the [ReadTheDocs administration](https://readthedocs.org/dashboard/dredd/redirects/). It's up to Dredd maintainers to keep the list in sync with reality.
 
 You can use the [rtd-redirects](https://github.com/honzajavorek/rtd-redirects) tool to programmatically upload the redirects from `docs/redirects.yml` to ReadTheDocs admin interface.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ npm install -g dredd
 [API Blueprint]: https://apiblueprint.org/
 [API Blueprint tutorial]: https://apiblueprint.org/documentation/tutorial.html
 [API Blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 
 [Documentation]: https://dredd.readthedocs.io/en/latest/
 [Changelog]: https://github.com/apiaryio/dredd/releases

--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -8,7 +8,7 @@ $ dredd apiary.apib http://127.0.0.1:30000 --hookfiles=./hooks*.js
 
 ## API Reference
 
-- For `before`, `after`, `beforeValidation`, `beforeEach`, `afterEach` and `beforeEachValidation` a [Transaction Object](https://dredd.readthedocs.io/en/latest/hooks/#transaction-object-structure) is passed as the first argument to the hook function.
+- For `before`, `after`, `beforeValidation`, `beforeEach`, `afterEach` and `beforeEachValidation` a [Transaction Object](hooks.md#transaction-object-structure) is passed as the first argument to the hook function.
 - An array of Transaction Objects is passed to `beforeAll` and `afterAll`.
 - The second argument is an optional callback function for async execution.
 - Any modifications on the `transaction` object are propagated to the actual HTTP transactions.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -217,7 +217,7 @@ Dredd intentionally **does not support HTTP(S) proxies for testing**. Proxy can 
 [Apiary]: https://apiary.io/
 [Semantic Versioning]: http://semver.org/
 [API Blueprint]: https://apiblueprint.org/
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 [Gavel.js]: https://github.com/apiaryio/gavel.js
 [Gavel]: https://relishapp.com/apiary/gavel/docs
 [MSON]: https://github.com/apiaryio/mson
@@ -244,15 +244,15 @@ Dredd intentionally **does not support HTTP(S) proxies for testing**. Proxy can 
 [action-section]: https://apiblueprint.org/documentation/specification.html#def-action-section
 [body-schema-attributes]: https://apiblueprint.org/documentation/specification.html#relation-of-body-schema-and-attributes-sections
 
-[produces]: http://swagger.io/specification/#swaggerProduces
-[consumes]: http://swagger.io/specification/#swaggerConsumes
-[response-headers]: http://swagger.io/specification/#responseHeaders
-[schema]: http://swagger.io/specification/#parameterSchema
-[response-schema]: http://swagger.io/specification/#responseSchema
-[response-examples]: http://swagger.io/specification/#responseExamples
-[parameters]: http://swagger.io/specification/#parameterObject
-[operation-parameters]: http://swagger.io/specification/#operationParameters
-[paths-parameters]: http://swagger.io/specification/#pathItemParameters
-[swagger-parameters]: http://swagger.io/specification/#swaggerParameters
-[default-responses]: http://swagger.io/specification/#responsesDefault
-[schema-example]: http://swagger.io/specification/#schemaExample
+[produces]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-swaggerProduces
+[consumes]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-swaggerConsumes
+[response-headers]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-responseHeaders
+[schema]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-parameterSchema
+[response-schema]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-responseSchema
+[response-examples]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-responseExamples
+[parameters]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-parameterObject
+[operation-parameters]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-operationParameters
+[paths-parameters]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-pathItemParameters
+[swagger-parameters]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-swaggerParameters
+[default-responses]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-responsesDefault
+[schema-example]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-schemaExample

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -752,10 +752,10 @@ If your hooks crash, Dredd will send an error to reporters, alongside with curre
 
 [Apiary]: https://apiary.io/
 [API Blueprint]: https://apiblueprint.org/
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/
-[vendor extension property]: http://swagger.io/specification/#vendorExtensions
+[vendor extension property]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-vendorExtensions
 
 [MSON]: https://apiblueprint.org/documentation/mson/specification.html
 [JSON Schema]: http://json-schema.org/

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ Dredd supports writing [hooks](hooks.md) — a glue code for each test setup and
 
 
 [API Blueprint]: https://apiblueprint.org/
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 
 [GitHub Repository]: https://github.com/apiaryio/dredd
 [Bug Tracker]: https://github.com/apiaryio/dredd/issues?q=is%3Aopen

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,7 @@ There are still [several known limitations][Windows Issues] when using Dredd on 
 
 
 [API Blueprint]: https://apiblueprint.org/
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 
 [CoffeeScript]: http://coffeescript.org/
 [CI]: how-to-guides.md#continuous-integration

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,5 +133,5 @@ For more complex example applications, please refer to:
 
 
 [API Blueprint]: https://apiblueprint.org/
-[Swagger]: http://swagger.io/
+[Swagger]: https://swagger.io/
 [Express.js]: http://expressjs.com/starter/hello-world.html

--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -1,6 +1,6 @@
 # This file is a documentation of which redirects need to be manually set
-# on the https://readthedocs.org/dashboard/dredd-docs-sphinx-test/redirects/
-# page. It's up to Dredd maintainers to keep this list in sync with reality.
+# on the https://readthedocs.org/dashboard/dredd/redirects/ page. It's up
+# to Dredd maintainers to keep this list in sync with reality.
 #
 # You can use https://github.com/honzajavorek/rtd-redirects to programmatically
 # upload the redirects to ReadTheDocs admin interface.


### PR DESCRIPTION
#### :rocket: Why this change?

https://swagger.io/specification/ now features the new 3.0 specification, but Dredd only supports Swagger 2.0. All links to supported Swagger features should now link to the old spec, which is still available on GitHub.

With this change, also other minor fixes were made in several links. All has been locally checked with `npm run docs:build` and `npm run docs:lint`.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/issues/828
- #775 

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
