### PR TITLE
Return correct exit code when server fails to start

### DIFF
--- a/src/child-process.coffee
+++ b/src/child-process.coffee
@@ -118,6 +118,7 @@ terminate = (childProcess, options = {}, callback) ->
 spawn = (args...) ->
   childProcess = crossSpawn.spawn.apply(null, args)
 
+  childProcess.spawned = true
   childProcess.terminated = false
   killedIntentionally = false
   terminatedIntentionally = false
@@ -139,6 +140,10 @@ spawn = (args...) ->
     terminate(childProcess, options, (err) ->
       childProcess.emit('error', err) if err
     )
+
+  childProcess.on('error', (err) ->
+    if err.syscall and err.syscall.indexOf('spawn') >= 0 then childProcess.spawned = false
+  )
 
   childProcess.on('exit', (exitStatus, signal) ->
     childProcess.terminated = true

--- a/src/dredd-command.coffee
+++ b/src/dredd-command.coffee
@@ -53,7 +53,7 @@ class DreddCommand
 
   # Gracefully terminate server
   stopServer: (callback) ->
-    unless @serverProcess?
+    if not @serverProcess or not @serverProcess.spawned
       logger.verbose('No backend server process to terminate.')
       return callback()
     if @serverProcess.terminated
@@ -219,9 +219,9 @@ class DreddCommand
       @serverProcess.on 'exit', =>
         logger.info('Backend server process exited')
 
-      @serverProcess.on 'error', (error) =>
-        logger.error('Command to start backend server process failed, exiting Dredd', error)
-        @_processExit(2)
+      @serverProcess.on 'error', (err) =>
+        logger.error('Command to start backend server process failed, exiting Dredd', err)
+        @_processExit(1)
 
       # Ensure server is not running when dredd exits prematurely somewhere
       process.on 'beforeExit', =>
@@ -332,11 +332,9 @@ class DreddCommand
   exitWithStatus: (error, stats) ->
     if error
       logger.error(error.message) if error.message
-      process.exitCode = 1
       return @_processExit(1)
 
     if (stats.failures + stats.errors) > 0
-      process.exitCode = 1
       @_processExit(1)
     else
       @_processExit(0)

--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -90,6 +90,26 @@ describe 'CLI - Server Process', ->
       it 'should exit with status 0', ->
         assert.equal dreddCommandInfo.exitStatus, 0
 
+    describe 'When it fails to start', ->
+      dreddCommandInfo = undefined
+      args = [
+        './test/fixtures/single-get.apib'
+        "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
+        "--server=/foo/bar/baz"
+        '--server-wait=1'
+      ]
+
+      beforeEach (done) ->
+        runDreddCommand args, (err, info) ->
+          dreddCommandInfo = info
+          done(err)
+
+      it 'should inform about starting server with custom command', ->
+        assert.include dreddCommandInfo.stdout, 'Starting backend server process with command'
+      it 'should report problem with server process spawn', ->
+        assert.include dreddCommandInfo.stderr, 'Command to start backend server process failed, exiting Dredd'
+      it 'should exit with status 1', ->
+        assert.equal dreddCommandInfo.exitStatus, 1
 
     for scenario in [
         description: 'When crashes before requests'


### PR DESCRIPTION
#### :rocket: Why this change?
This PR fixes the issue with wrong CLI exit code when running Dredd with incorrect argument to `--server` command (reported in https://github.com/apiaryio/dredd/issues/818).

#### :memo: Related issues and Pull Requests
Closes #838

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
