### PR TITLE
docs: fix inconsistencies in hook socket message docs

### DIFF
--- a/docs/hooks-new-language.md
+++ b/docs/hooks-new-language.md
@@ -59,17 +59,14 @@ On Linux or macOS, Dredd uses the `SIGTERM` signal to tell the hook handler proc
 - transaction (object)
     - uuid: `234567-asdfghjkl` (string) - Id used for event unique identification on both server and client sides
     - event: `event` (enum) - Event type
-        - beforeAll (string)
-        - beforeEach (string)
-        - before (string)
-        - beforeEachValidation (string)
-        - beforeValidation (string)
-        - after (string)
-        - afterEach (string)
-        - afterAll (string)
+        - beforeAll (string) - Signals the hook handler to run the `beforeAll` hooks
+        - beforeEach (string) - Signals the hook handler to run the `beforeEach` and `before` hooks
+        - beforeEachValidation (string) - Signals the hook handler to run the `beforeEachValidation` and `beforeValidation` hooks
+        - afterEach (string) - Signals the hook handler to run the `after` and `afterValidation` hooks
+        - afterAll (string) - Signals the hook handler to run the `afterAll` hooks
     - data (enum) - Data passed as a argument to the function
-        - (object)
-        - (array)
+        - (object) - Single Transaction object
+        - (array) - An array of Transaction objects, containing all transactions in the API description. Sent for `beforeAll` and `afterAll` events
 
 ## Configuration Options
 


### PR DESCRIPTION
#### :rocket: Why this change?

CLOSES #271 

Also adresses my question of #834, what the array of transaction objects contains.

#### :memo: Related issues and Pull Requests

#271, #834

#### :white_check_mark: What didn't I forget?

- [X] To write docs
- [X] ~To write tests~ N/A
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
