### PR TITLE
Make sure Semantic Release works with build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ jobs:
       script: "npm run test:coverage && npm run coveralls"
     - stage: "semantic release"
       node_js: "6"
-      script: "npm run semantic-release || true"
+      # https://github.com/semantic-release/semantic-release/issues/390
+      script: "TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release || true"


### PR DESCRIPTION
#### :rocket: Why this change?

In https://github.com/apiaryio/dredd/pull/849 Travis CI stages were introduced. This has broken automatic releasing: https://github.com/semantic-release/semantic-release/issues/390

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/849
- https://github.com/semantic-release/semantic-release/issues/390

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
