### PR TITLE
docs: correct typo in tcp message event afterEach

### DIFF
--- a/docs/hooks-new-language.md
+++ b/docs/hooks-new-language.md
@@ -62,7 +62,7 @@ On Linux or macOS, Dredd uses the `SIGTERM` signal to tell the hook handler proc
         - beforeAll (string) - Signals the hook handler to run the `beforeAll` hooks
         - beforeEach (string) - Signals the hook handler to run the `beforeEach` and `before` hooks
         - beforeEachValidation (string) - Signals the hook handler to run the `beforeEachValidation` and `beforeValidation` hooks
-        - afterEach (string) - Signals the hook handler to run the `after` and `afterValidation` hooks
+        - afterEach (string) - Signals the hook handler to run the `after` and `afterEach` hooks
         - afterAll (string) - Signals the hook handler to run the `afterAll` hooks
     - data (enum) - Data passed as a argument to the function
         - (object) - Single Transaction object


### PR DESCRIPTION
#### :rocket: Why this change?
Correct typo which could confuse the reader.
#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
