### PR TITLE
Make sure Semantic Release works with build stages (sequel)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,4 @@ jobs:
       script: "npm run test:coverage && npm run coveralls"
     - stage: "semantic release"
       node_js: "6"
-      # https://github.com/semantic-release/semantic-release/issues/390
-      script: "TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release || true"
+      script: " npm run semantic-release || true"

--- a/scripts/semantic-release.sh
+++ b/scripts/semantic-release.sh
@@ -14,6 +14,15 @@ add_stable_dist_tag() {
 }
 
 
+# Semantic Release has built-in workaround for waiting until all parallel
+# builds finish on Travis CI. However, Travis CI introduced "build stages"
+# to tackle exactly this problem. When using the build stages, the built-in
+# workaround makes Semantic Release unusable, so we need to trick it.
+#
+# Tracked as https://github.com/semantic-release/semantic-release/issues/390
+export TRAVIS_JOB_NUMBER="WORKAROUND.1"
+
+
 $SEMANTIC_RELEASE pre && \
   npm publish && \
   add_stable_dist_tag && \

--- a/scripts/semantic-release.sh
+++ b/scripts/semantic-release.sh
@@ -20,7 +20,9 @@ add_stable_dist_tag() {
 # workaround makes Semantic Release unusable, so we need to trick it.
 #
 # Tracked as https://github.com/semantic-release/semantic-release/issues/390
+# Related https://github.com/travis-ci/travis-ci/issues/8239
 export TRAVIS_JOB_NUMBER="WORKAROUND.1"
+export TRAVIS_TEST_RESULT="0"
 
 
 $SEMANTIC_RELEASE pre && \


### PR DESCRIPTION
#### :rocket: Why this change?

Sequel to https://github.com/apiaryio/dredd/pull/854, inspired by Hollywood™

Works around [this line of code](https://github.com/semantic-release/travis-deploy-once/blob/54effadf0f3c3b90500b495218f05cf80e95b446/src.js#L12). The stage will never start without the previous stages being passing, so the check is pointless now.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/854
- https://github.com/semantic-release/semantic-release/issues/390#issuecomment-321769702

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
