### PR TITLE
Test exit status when there's a connection error to the server

### DIFF
--- a/test/fixtures/scripts/dummy-server-connection-error.coffee
+++ b/test/fixtures/scripts/dummy-server-connection-error.coffee
@@ -1,0 +1,2 @@
+console.log("Dummy server listening on port #{process.argv[2]}!")
+setInterval(( -> ), 100)

--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -111,6 +111,11 @@ describe 'CLI - Server Process', ->
         apiDescriptionDocument: './test/fixtures/apiary.apib'
         server: "#{COFFEE_BIN} test/fixtures/scripts/dummy-server-kill.coffee #{DEFAULT_SERVER_PORT}"
         expectServerBoot: true
+      ,
+        description: 'When is not able to communicate over HTTP'
+        apiDescriptionDocument: './test/fixtures/single-get.apib'
+        server: "#{COFFEE_BIN} test/fixtures/scripts/dummy-server-connection-error.coffee #{DEFAULT_SERVER_PORT}"
+        expectServerBoot: true
     ]
       do (scenario) ->
         describe scenario.description, ->


### PR DESCRIPTION
#### :rocket: Why this change?

Addressing https://github.com/apiaryio/dredd/pull/851#discussion_r132434000.

#### :memo: Related issues and Pull Requests

- #818
- https://github.com/apiaryio/dredd/pull/851

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
