### PR TITLE
Add status codes to test ID and Dredd output

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -7,7 +7,7 @@ Documentation of various data structures in both [Gavel.js][] and Dredd. [MSON n
 
 Transaction object is passed as a first argument to [hook functions](hooks.md) and is one of the main public interfaces in Dredd.
 
-- id: `GET /greetings` - identifier for this transaction
+- id: `GET (200) /greetings` - identifier for this transaction
 - name: `./api-description.apib > My API > Greetings > Hello, world! > Retrieve Message > Example 2` (string) - reference to the transaction definition in the original API description document (see also [Dredd Transactions][])
 - origin (object) - reference to the transaction definition in the original API description document (see also [Dredd Transactions][])
     - filename: `./api-description.apib` (string)

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -324,7 +324,7 @@ class TransactionRunner
 
     configuredTransaction =
       name: transaction.name
-      id: request.method + ' ' + request.uri
+      id: request.method + ' (' + expected.statusCode + ') ' + request.uri
       host: @parsedUrl.hostname
       port: @parsedUrl.port
       request: request

--- a/test/integration/cli/cli-test.coffee
+++ b/test/integration/cli/cli-test.coffee
@@ -480,7 +480,7 @@ describe 'CLI', ->
         )
 
       it 'should notify skipping to the stdout', ->
-        assert.include runtimeInfo.dredd.stdout, 'skip: GET /machines'
+        assert.include runtimeInfo.dredd.stdout, 'skip: GET (200) /machines'
 
       it 'should hit the only transaction', ->
         assert.deepEqual runtimeInfo.server.requestCounts, {'/message': 1}

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -548,7 +548,7 @@ describe 'Dredd class Integration', ->
         assert.include stderr, 'Fixed transaction name'
 
   describe('when Swagger document has multiple responses', ->
-    reTransaction = /(\w+): (\w+) \/honey/g
+    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
     matches = undefined
 
     beforeEach((done) ->
@@ -577,7 +577,7 @@ describe 'Dredd class Integration', ->
   )
 
   describe('when Swagger document has multiple responses and hooks unskip some of them', ->
-    reTransaction = /(\w+): (\w+) \/honey/g
+    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
     matches = undefined
 
     beforeEach((done) ->

--- a/test/integration/regressions/regression-319-354-test.coffee
+++ b/test/integration/regressions/regression-319-354-test.coffee
@@ -237,7 +237,7 @@ describe 'Regression: Issues #319 and #354', ->
 
     describe 'Attributes defined in resource are referenced from payload [GET /bricks/XYZ42]', ->
       it 'fails on missing required property and invalid type', ->
-        assert.include results.failures[0], 'GET /bricks/XYZ42'
+        assert.include results.failures[0], 'GET (200) /bricks/XYZ42'
         assert.include results.failures[1], 'Missing required property: name'
         assert.include results.failures[1], 'Invalid type: number'
       it 'has no request body', ->
@@ -251,7 +251,7 @@ describe 'Regression: Issues #319 and #354', ->
 
     describe 'Attributes defined in resource are referenced from action [POST /bricks]', ->
       it 'fails on missing required property and invalid type', ->
-        assert.include results.failures[2], 'POST /bricks'
+        assert.include results.failures[2], 'POST (200) /bricks'
         assert.include results.failures[3], 'Missing required property: name'
         assert.include results.failures[3], 'Invalid type: number'
       it 'has correct request body', ->
@@ -265,7 +265,7 @@ describe 'Regression: Issues #319 and #354', ->
 
     describe 'Attributes defined as data structure are referenced from payload [GET /customers]', ->
       it 'fails on invalid type', ->
-        assert.include results.failures[4], 'GET /customers'
+        assert.include results.failures[4], 'GET (200) /customers'
         assert.include results.failures[5], 'Invalid type: object'
       it 'has no request body', ->
         assert.isUndefined results.bodies[6]
@@ -278,7 +278,7 @@ describe 'Regression: Issues #319 and #354', ->
 
     describe 'Attributes defined as data structure are referenced from action [POST /customers]', ->
       it 'fails on invalid types', ->
-        assert.include results.failures[6], 'POST /customers'
+        assert.include results.failures[6], 'POST (200) /customers'
         assert.include results.failures[7], 'Invalid type: null'
         assert.include results.failures[7], 'Invalid type: string'
       it 'has correct request body', ->

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -322,7 +322,7 @@ describe 'TransactionRunner', ->
       it 'should callback with a properly configured transaction', (done) ->
         runner.configureTransaction transaction, (err, configuredTransaction) ->
           assert.equal configuredTransaction.name, 'Group Machine > Machine > Delete Message > Bogus example name'
-          assert.equal configuredTransaction.id, 'POST /machines'
+          assert.equal configuredTransaction.id, 'POST (202) /machines'
           assert.isOk configuredTransaction.host
           assert.isOk configuredTransaction.request
           assert.isOk configuredTransaction.expected
@@ -337,7 +337,7 @@ describe 'TransactionRunner', ->
 
       it 'should join the endpoint path with transaction uriTemplate together', (done) ->
         runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.equal configuredTransaction.id, 'POST /machines'
+          assert.equal configuredTransaction.id, 'POST (202) /machines'
           assert.strictEqual configuredTransaction.host, 'hostname.tld'
           assert.equal configuredTransaction.port, 9876
           assert.strictEqual configuredTransaction.protocol, 'https:'
@@ -347,7 +347,7 @@ describe 'TransactionRunner', ->
        it 'should keep trailing slash in url if present', (done) ->
          transaction.request.uri = '/machines/'
          runner.configureTransaction transaction, (err, configuredTransaction) ->
-           assert.equal configuredTransaction.id, 'POST /machines/'
+           assert.equal configuredTransaction.id, 'POST (202) /machines/'
            assert.strictEqual configuredTransaction.fullPath, '/my/path/to/api' + '/machines/'
            done()
 
@@ -356,7 +356,7 @@ describe 'TransactionRunner', ->
     beforeEach ->
       transaction =
         name: 'Group Machine > Machine > Delete Message > Bogus example name'
-        id: 'POST /machines'
+        id: 'POST (202) /machines'
         host: '127.0.0.1'
         port: '3000'
         request:


### PR DESCRIPTION
#### :rocket: Why this change?

The primary reason for this change is that test IDs are non-unique and that makes test output hard to understand. This PR adds the `(###)` to the transaction ID so that a 200 is distinctly different from a 204, 401, 404, etc... 

```
info: Successfully connected to hooks handler. Waiting 0.1s to start testing.
pass: POST (204) /channelmapper/v1/channel duration: 25ms
skip: POST (401) /channelmapper/v1/channel
skip: POST (404) /channelmapper/v1/channel
pass: GET (200) /v1/channel/9cd4342be duration: 25ms
skip: GET (401) /v1/channel/9cd4342be
pass: GET (404) /v1/channel/9cd4342be duration: 16ms

complete: 3 passing, 0 failing, 0 errors, 3 skipped, 6 total

```



#### :memo: Related issues and Pull Requests
* Closes https://github.com/apiaryio/dredd/issues/866


#### :white_check_mark: What didn't I forget?

- [✔] To write docs
- [✔] To write tests
- [✔] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`