### PR TITLE
Add watch script for auto recompile

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "conventional-changelog-lint --from=master && coffeelint src",
     "build": "coffee -b -c -o lib/ src/",
+    "build:watch": "coffee -b -w -o lib/ src/",
     "docs:lint": "sphinx-build -nW -b linkcheck docs docs/_build/",
     "docs:build": "sphinx-build -nW -b html docs docs/_build/",
     "docs:serve": "sphinx-autobuild docs docs/_build/",


### PR DESCRIPTION
#### :rocket: Why this change?
This PR adds `build:watch` script to `package.json` to enable incremental compilation as requested in https://github.com/apiaryio/dredd/issues/867.

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/issues/867

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
