### PR TITLE
Update Semantic Release (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "nock": "^9.0.13",
     "ps-node": "^0.1.5",
-    "semantic-release": "^7.0.1",
+    "semantic-release": "^7.0.2",
     "sinon": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
#### :rocket: Why this change?

Because of this bug in Semantic Release: https://github.com/semantic-release/semantic-release/issues/411#issuecomment-322964177

#### :memo: Related issues and Pull Requests

- https://github.com/semantic-release/semantic-release/issues/411

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
