### PR TITLE
Update docs to reflect actual data

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -31,7 +31,7 @@ Transaction object is passed as a first argument to [hook functions](hooks.md) a
     - statusCode: `200` (string)
     - headers (object) - keys are HTTP header names, values are HTTP header contents
     - body (string)
-    - schema (object) - JSON Schema of the response body
+    - bodySchema (object) - JSON Schema of the response body
 - real (object) - the HTTP response Dredd gets from the tested server (present only in `after` hooks)
     - statusCode: `200` (string)
     - headers (object) - keys are HTTP header names, values are HTTP header contents

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "nock": "^9.0.13",
     "ps-node": "^0.1.5",
-    "semantic-release": "^7.0.1",
+    "semantic-release": "^7.0.2",
     "sinon": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
#### :rocket: Why this change?
Seems like the docs are out of sync with the transaction data structure.

#### :memo: Related issues and Pull Requests
https://github.com/snikch/goodman/pull/37

#### :white_check_mark: What didn't I forget?
I still haven't completed verified this is the case since the bug report does not have much detail but skimming the dredd source code I see [this](https://github.com/apiaryio/dredd/blob/acecae523d71b71f47cc66e8587d83e5104ebded/src/transaction-runner.coffee#L310).

- [ ] To write docs
- [ ] To write tests
- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
