### PR TITLE
fix: Hook files are not always executed in alphabetical order (#890)

### DIFF
--- a/src/add-hooks.coffee
+++ b/src/add-hooks.coffee
@@ -115,7 +115,11 @@ addHooks = (runner, transactions, callback) ->
         # ]
         .map((filepath) -> basename: basename(filepath), path: filepath)
         # Sort 'em up
-        .sort((a, b) -> a.basename > b.basename)
+        .sort((a, b) -> switch
+          when a.basename < b.basename then -1
+          when a.basename > b.basename then 1
+          else 0
+        )
         # Resolve paths to absolute form. Take into account user defined current
         # working directory, fallback to process.cwd() otherwise
         .map((item) -> path.resolve(customConfigCwd or process.cwd(), item.path))

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -126,13 +126,27 @@ describe 'addHooks(runner, transactions, callback)', () ->
         done()
 
     it 'should return files alphabetically sorted', (done) ->
+      runner =
+        configuration:
+          options:
+            hookfiles: ['./**/*_hooks.*', '/baz/x.js', '/foo/y.js', '/bar/z.js', '/foo/a.js', '/bar/b.js', '/baz/c.js', '/foo/o.js', '/bar/p.js']
+
       addHooks runner, transactions, (err) ->
         return done err if err
 
+        # We need >10 files to prove that sorting is ok
         expected = [
+          'a.js',
+          'b.js',
+          'c.js',
           'multifile_hooks.coffee',
+          'o.js',
+          'p.js',
           'test2_hooks.js',
-          'test_hooks.coffee'
+          'test_hooks.coffee',
+          'x.js',
+          'y.js',
+          'z.js',
         ]
 
         actual = runner.hooks.configuration.options.hookfiles


### PR DESCRIPTION
Just a simple mistake with the compare function.

I'm not sure if adding extra hook files for testing is actually helpful?  On my machine they are the smallest number of files needed to trigger the bug but now the bug is fixed they are kind of messy.