### PR TITLE
chore: update inquirer to version 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.0.5",
     "html": "^1.0.0",
     "htmlencode": "0.0.4",
-    "inquirer": "^1.1.0",
+    "inquirer": "^3.3.0",
     "js-yaml": "^3.8.3",
     "markdown-it": "^8.3.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
#### :rocket: Why this change?

The old `inquirer` version pulls down a lot of old dependencies and prevents deduplication.

#### :memo: Related issues and Pull Requests

Fixes #768

#### :white_check_mark: What didn't I forget?

Tested `dread init` manually with a couple of variations, everything works fine.

- [X] To write docs - N/A
- [X] To write tests - N/A
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`