### PR TITLE
Upgrade dredd-transactions to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coffee-script": "^1.12.5",
     "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
-    "dredd-transactions": "^4.3.4",
+    "dredd-transactions": "^4.4.0",
     "file": "^0.2.2",
     "gavel": "^1.1.1",
     "glob": "^7.0.5",

--- a/test/fixtures/swagger-multiple-responses.js
+++ b/test/fixtures/swagger-multiple-responses.js
@@ -1,8 +1,11 @@
-
 var hooks = require('hooks');
 
-
 hooks.before('/honey > GET > 500 > application/json', function (transaction, done) {
+  transaction.skip = false;
+  done();
+});
+
+hooks.before('/honey > GET > 500 > application/xml', function (transaction, done) {
   transaction.skip = false;
   done();
 });

--- a/test/fixtures/warning-swagger.yaml
+++ b/test/fixtures/warning-swagger.yaml
@@ -2,6 +2,10 @@ swagger: '2.0'
 info:
   title: Machines API
   version: '1.0'
+host: api.example.com
+schemes:
+- https
+- http
 paths:
   '/machines':
     x-summary: Machines Collection

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -562,8 +562,8 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 3 transactions', ->
-      assert.equal(matches.length, 3)
+    it('recognizes all 6 transactions', ->
+      assert.equal(matches.length, 6)
     )
     it('the transaction #1 is skipped', ->
       assert.equal(matches[0][1], 'skip')
@@ -571,8 +571,17 @@ describe 'Dredd class Integration', ->
     it('the transaction #2 is skipped', ->
       assert.equal(matches[1][1], 'skip')
     )
-    it('the transaction #3 is not skipped (status 200)', ->
-      assert.notEqual(matches[2][1], 'skip')
+    it('the transaction #3 is skipped', ->
+      assert.equal(matches[2][1], 'skip')
+    )
+    it('the transaction #4 is skipped', ->
+      assert.equal(matches[3][1], 'skip')
+    )
+    it('the transaction #5 is not skipped (status 200)', ->
+      assert.notEqual(matches[4][1], 'skip')
+    )
+    it('the transaction #6 is not skipped (status 200)', ->
+      assert.notEqual(matches[5][1], 'skip')
     )
   )
 
@@ -592,17 +601,26 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 3 transactions', ->
-      assert.equal(matches.length, 3)
+    it('recognizes all 6 transactions', ->
+      assert.equal(matches.length, 6)
     )
     it('the transaction #1 is skipped', ->
       assert.equal(matches[0][1], 'skip')
     )
-    it('the transaction #2 is not skipped (unskipped in hooks)', ->
-      assert.notEqual(matches[1][1], 'skip')
+    it('the transaction #2 is skipped', ->
+      assert.equal(matches[1][1], 'skip')
     )
-    it('the transaction #3 is not skipped (status 200)', ->
+    it('the transaction #3 is not skipped (unskiped in hooks)', ->
       assert.notEqual(matches[2][1], 'skip')
+    )
+    it('the transaction #4 is not skipped (status 200)', ->
+      assert.notEqual(matches[3][1], 'skip')
+    )
+    it('the transaction #5 is not skipped (status 200)', ->
+      assert.notEqual(matches[4][1], 'skip')
+    )
+    it('the transaction #6 is not skipped (unskiped in hooks)', ->
+      assert.notEqual(matches[5][1], 'skip')
     )
   )
 

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -548,48 +548,54 @@ describe 'Dredd class Integration', ->
         assert.include stderr, 'Fixed transaction name'
 
   describe('when Swagger document has multiple responses', ->
-    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
-    matches = undefined
+    reTransaction = /(\w+): (\w+) \((\d+)\) \/honey/g
+    actual = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       execCommand(
         options:
           path: './test/fixtures/multiple-responses.yaml'
       , (err) ->
         matches = []
         matches.push(groups) while groups = reTransaction.exec(stdout)
+        actual = matches.map((match) ->
+          keyMap = {'0': 'name', '1': 'action', '2': 'method', '3': 'statusCode'}
+          match.reduce((result, element, i) ->
+            Object.assign(result, "#{keyMap[i]}": element)
+          , {})
+        )
         done(err)
       )
     )
 
     it('recognizes all 6 transactions', ->
-      assert.equal(matches.length, 6)
+      assert.equal(actual.length, 6)
     )
-    it('the transaction #1 is skipped', ->
-      assert.equal(matches[0][1], 'skip')
-    )
-    it('the transaction #2 is skipped', ->
-      assert.equal(matches[1][1], 'skip')
-    )
-    it('the transaction #3 is skipped', ->
-      assert.equal(matches[2][1], 'skip')
-    )
-    it('the transaction #4 is skipped', ->
-      assert.equal(matches[3][1], 'skip')
-    )
-    it('the transaction #5 is not skipped (status 200)', ->
-      assert.notEqual(matches[4][1], 'skip')
-    )
-    it('the transaction #6 is not skipped (status 200)', ->
-      assert.notEqual(matches[5][1], 'skip')
+
+    [
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '500'}
+      {action: 'skip', statusCode: '500'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '200'}
+    ].forEach((expected, i) ->
+      context("the transaction ##{i + 1}", ->
+        it("has status code #{expected.statusCode}", ->
+          assert.equal(expected.statusCode, actual[i].statusCode)
+        )
+        it("is #{if expected.action is 'skip' then '' else 'not '}skipped by default", ->
+          assert.equal(expected.action, actual[i].action)
+        )
+      )
     )
   )
 
   describe('when Swagger document has multiple responses and hooks unskip some of them', ->
-    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
-    matches = undefined
+    reTransaction = /(\w+): (\w+) \((\d+)\) \/honey/g
+    actual = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       execCommand(
         options:
           path: './test/fixtures/multiple-responses.yaml'
@@ -597,30 +603,39 @@ describe 'Dredd class Integration', ->
       , (err) ->
         matches = []
         matches.push(groups) while groups = reTransaction.exec(stdout)
+        actual = matches.map((match) ->
+          keyMap = {'0': 'name', '1': 'action', '2': 'method', '3': 'statusCode'}
+          match.reduce((result, element, i) ->
+            Object.assign(result, "#{keyMap[i]}": element)
+          , {})
+        )
         done(err)
       )
     )
 
     it('recognizes all 6 transactions', ->
-      assert.equal(matches.length, 6)
+      assert.equal(actual.length, 6)
     )
-    it('the transaction #1 is skipped', ->
-      assert.equal(matches[0][1], 'skip')
-    )
-    it('the transaction #2 is skipped', ->
-      assert.equal(matches[1][1], 'skip')
-    )
-    it('the transaction #3 is not skipped (unskiped in hooks)', ->
-      assert.notEqual(matches[2][1], 'skip')
-    )
-    it('the transaction #4 is not skipped (status 200)', ->
-      assert.notEqual(matches[3][1], 'skip')
-    )
-    it('the transaction #5 is not skipped (status 200)', ->
-      assert.notEqual(matches[4][1], 'skip')
-    )
-    it('the transaction #6 is not skipped (unskiped in hooks)', ->
-      assert.notEqual(matches[5][1], 'skip')
+
+    [
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '400'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '500'} # Unskipped in hooks
+      {action: 'fail', statusCode: '500'} # Unskipped in hooks
+    ].forEach((expected, i) ->
+      context("the transaction ##{i + 1}", ->
+        it("has status code #{expected.statusCode}", ->
+          assert.equal(expected.statusCode, actual[i].statusCode)
+        )
+
+        defaultMessage = "is #{if expected.action is 'skip' then '' else 'not '}skipped by default"
+        unskippedMessage = 'is unskipped in hooks'
+        it("#{if expected.statusCode is '500' then unskippedMessage else defaultMessage}", ->
+          assert.equal(expected.action, actual[i].action)
+        )
+      )
     )
   )
 


### PR DESCRIPTION
#### :rocket: Why this change?
This PR introduces `dredd-transactions` with `fury-adapter-swagger` version [0.14](https://github.com/apiaryio/dredd-transactions/pull/108).

#### :memo: Related issues and Pull Requests

- Fixes https://github.com/apiaryio/dredd/issues/892

#### :white_check_mark: What didn't I forget?

- [x] To write docs - N/A
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
