### PR TITLE
Add "python" error for Windows users

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,9 +76,9 @@ When using `git config`, make sure you have the port specified even
 when it's the standard `:80`. Also check out
 [how to set up Dredd to correctly work with proxies][Dredd Proxy].
 
-### Why I'm Seeing `node-gyp` Errors?
+### Why I'm Seeing `node-gyp` or `python` Errors?
 
-The installation process features compilation of some C++ components, which may not be successful. In that case, errors related to `node-gyp` are printed. However, if `dredd --version` works for you when the installation is done, feel free to ignore the errors.
+The installation process features compilation of some C++ components, which may not be successful. In that case, errors related to `node-gyp` or `python` are printed. However, if `dredd --version` works for you when the installation is done, feel free to ignore the errors.
 
 In case of compilation errors, Dredd automatically uses a less performant solution written in pure JavaScript. Next time when installing Dredd, you can use `npm install -g dredd --no-optional` to skip the compilation step ([learn more about this][C++11 vs JS]).
 


### PR DESCRIPTION
#### :rocket: Why this change?

Because on Windows there's no node-gyp error, there's python error.

![pasted image at 2017_10_20 10_42 am](https://user-images.githubusercontent.com/283441/31812656-fa29747c-b583-11e7-8d66-9e984ce5bdfc.png)

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
