### PR TITLE
Fix broken master

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coffee-script": "^1.12.5",
     "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
-    "dredd-transactions": "^4.3.4",
+    "dredd-transactions": "4.3.4",
     "file": "^0.2.2",
     "gavel": "^1.1.1",
     "glob": "^7.0.5",

--- a/test/fixtures/warning-swagger.yaml
+++ b/test/fixtures/warning-swagger.yaml
@@ -2,6 +2,10 @@ swagger: '2.0'
 info:
   title: Machines API
   version: '1.0'
+host: api.example.com
+schemes:
+- https
+- http
 paths:
   '/machines':
     x-summary: Machines Collection


### PR DESCRIPTION
#### :rocket: Why this change?
Currently, tests on `master` branch do not pass due to two issues - first, `dredd-transactions` got implicitly bumped to version `4.4.0` (which introduces a breaking change due to upgrade of `fury-adapter-swagger` to version `0.14.2`) and second, `warning-swagger.yaml` test fixture was not producing a warning anymore.

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
