### PR TITLE
Limit stack depth to avoid maximum call stack exceeded issues

### DIFF
--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -148,7 +148,7 @@ class TransactionRunner
           runHookCallback()
 
       async.timesSeries hooks.length, runHookWithData, ->
-        callback()
+        process.nextTick(() -> callback())
 
     else
       callback()
@@ -334,7 +334,7 @@ class TransactionRunner
       protocol: @parsedUrl.protocol
       skip: skip
 
-    return callback(null, configuredTransaction)
+    return process.nextTick(() -> callback(null, configuredTransaction))
 
   parseServerUrl: (serverUrl) ->
     unless serverUrl.match(/^https?:\/\//i)


### PR DESCRIPTION
#### :rocket: Why this change?

It might be helpful for people suffering from maximum call stack exceeded issues eg #225 

#### :memo: Related issues and Pull Requests

#225 could be fixed, I haven't tested but it at least solves my issues.

#### :white_check_mark: What didn't I forget?

Tests break as many assume synchronous returns.
If someone else wants to pick it up and run with it they are welcome to.