### PR TITLE
Upgrade Dredd Transactions and fix tons of issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - "set PATH=%APPDATA%\\npm;%PATH%"
   - "npm install --no-optional"
 cache:
-  - "node_modules"
+  - "node_modules -> package.json"
   - "%APPDATA%\\npm-cache"
 build: off
 test_script:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -176,9 +176,9 @@ The [Swagger][] format allows to specify multiple responses for a single operati
 By default Dredd tests only responses with `2xx` status codes. Responses with other
 codes are marked as _skipped_ and can be activated in [hooks](hooks.md) - see [Testing non-2xx Responses with Swagger](how-to-guides.md#testing-non-2xx-responses-with-swagger).
 
-[Default responses][default-responses] are ignored by Dredd. Also, as of now,
-only `application/json` media type is supported in [`produces`][produces] and [`consumes`][consumes].
-Other media types are skipped.
+In [`produces`][produces] and [`consumes`][consumes], only JSON media types are supported. Only the first JSON media type in `produces` is effective, others are skipped. Other media types are respected only when provided with [explicit examples][response-examples].
+
+[Default response][default-responses] is ignored by Dredd unless it is the only available response. In that case, the default response is assumed to have HTTP 200 status code.
 
 ## Security
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -148,9 +148,19 @@ If body parameter has [`schema.example`][schema-example], it is used as a raw JS
 2. First value from `enum`.
 3. Dummy, generated value.
 
-## How Dredd Works With HTTP Transactions
+### Empty Response Body
 
-### Multiple Requests and Responses
+If there is no body example or schema specified for the response in your API description document, Dredd won't imply any assertions. Any server response will be considered as valid.
+
+If you want to enforce the incoming body is empty, you can use [hooks](hooks.md):
+
+```js
+:[hooks example](../test/fixtures/response/empty-body-hooks.js)
+```
+
+In case of responses with 204 or 205 status codes Dredd still behaves the same way, but it warns about violating the [RFC7231](https://tools.ietf.org/html/rfc7231) when the responses have non-empty bodies.
+
+## Choosing HTTP Transactions
 
 #### API Blueprint
 
@@ -168,13 +178,13 @@ currently supports just separated HTTP transaction pairs like this:
 
 In other words, Dredd always selects just the first response for each request.
 
-> **Note:** Improving the support for multiple requests and responses is under development. Refer to issues [#25](https://github.com/apiaryio/dredd/issues/25) and [#78](https://github.com/apiaryio/dredd/issues/78) for details. Support for URI parameters specific to a single request within one action is also limited. Solving [#227](https://github.com/apiaryio/dredd/issues/227) should unblock many related problems. Also see [Multiple Requests and Responses within One API Blueprint Action](how-to-guides.md#multiple-requests-and-responses-within-one-api-blueprint-action) guide for workarounds.
+> **Note:** Improving the support for multiple requests and responses is under development. Refer to issues [#25](https://github.com/apiaryio/dredd/issues/25) and [#78](https://github.com/apiaryio/dredd/issues/78) for details. Support for URI parameters specific to a single request within one action is also limited. Solving [#227](https://github.com/apiaryio/dredd/issues/227) should unblock many related problems. Also see [Multiple Requests and Responses](how-to-guides.md#multiple-requests-and-responses) guide for workarounds.
 
 #### Swagger
 
 The [Swagger][] format allows to specify multiple responses for a single operation.
 By default Dredd tests only responses with `2xx` status codes. Responses with other
-codes are marked as _skipped_ and can be activated in [hooks](hooks.md) - see [Testing non-2xx Responses with Swagger](how-to-guides.md#testing-non-2xx-responses-with-swagger).
+codes are marked as _skipped_ and can be activated in [hooks](hooks.md) - see the [Multiple Requests and Responses](how-to-guides.md#multiple-requests-and-responses) how-to guide.
 
 In [`produces`][produces] and [`consumes`][consumes], only JSON media types are supported. Only the first JSON media type in `produces` is effective, others are skipped. Other media types are respected only when provided with [explicit examples][response-examples].
 

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -505,30 +505,22 @@ Most of the authentication schemes use HTTP header for carrying the authenticati
 
 ## Sending Multipart Requests
 
-API Blueprint format supports `multipart/form-data` media type and so does Dredd. In the example below, Dredd will automatically add `LF` to all lines in request body:
+```apiblueprint
+:[API Blueprint example](../test/fixtures/request/multipart-form-data.apib)
+```
+
+```yaml
+:[Swagger example](../test/fixtures/request/multipart-form-data.yaml)
+```
+
+## Sending Form Data
 
 ```apiblueprint
-# POST /images
+:[API Blueprint example](../test/fixtures/request/application-x-www-form-urlencoded.apib)
+```
 
-+ Request (multipart/form-data;boundary=---BOUNDARY)
-    + Headers
-
-            Authorization: qwertyqwerty
-
-    + Body
-
-            ---BOUNDARY
-            Content-Disposition: form-data; name="json"
-
-
-            {"name": "test"}
-            ---BOUNDARY
-            Content-Disposition: form-data; name="image"; filename="filename.jpg"
-            Content-Type: image/jpeg
-
-            data
-            ---BOUNDARY--
-
+```yaml
+:[Swagger example](../test/fixtures/request/application-x-www-form-urlencoded.yaml)
 ```
 
 ## Multiple Requests and Responses within One API Blueprint Action

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -523,9 +523,11 @@ Most of the authentication schemes use HTTP header for carrying the authenticati
 :[Swagger example](../test/fixtures/request/application-x-www-form-urlencoded.yaml)
 ```
 
-## Multiple Requests and Responses within One API Blueprint Action
+## Multiple Requests and Responses
 
 > **Note:** For details on this topic see also [How Dredd Works With HTTP Transactions](how-it-works.md#how-dredd-works-with-http-transactions).
+
+### API Blueprint
 
 To test multiple requests and responses within one action in Dredd, you need to cluster them into pairs:
 
@@ -572,7 +574,7 @@ info: Resource > Update Resource > Example 2
 
 In case you need to perform particular request with different URI parameters and standard inheritance of URI parameters isn't working for you, try [modifying transaction before its execution](hooks-nodejs.md#modifying-transaction-request-body-prior-to-execution) in hooks.
 
-## Testing non-2xx Responses with Swagger
+### Swagger
 
 When using [Swagger][] format, by default Dredd tests only responses with `2xx` status codes. Responses with other codes are marked as _skipped_ and can be activated in [hooks](hooks.md):
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coffee-script": "^1.12.5",
     "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
-    "dredd-transactions": "4.3.4",
+    "dredd-transactions": "4.6.1",
     "file": "^0.2.2",
     "gavel": "^1.1.1",
     "glob": "^7.0.5",

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -303,11 +303,10 @@ class TransactionRunner
 
     # The data models as used here must conform to Gavel.js
     # as defined in `http-response.coffee`
-    expected =
-      headers: flattenHeaders response['headers']
-      body: response['body']
-      statusCode: response['status']
-    expected['bodySchema'] = response['schema'] if response['schema']
+    expected = {headers: flattenHeaders(response['headers'])}
+    expected.body = response.body if response.body
+    expected.statusCode = response.status if response.status
+    expected.bodySchema = response.schema if response.schema
 
     # Backward compatible transaction name hack. Transaction names will be
     # replaced by Canonical Transaction Paths: https://github.com/apiaryio/dredd/issues/227

--- a/src/transaction-runner.coffee
+++ b/src/transaction-runner.coffee
@@ -635,8 +635,8 @@ class TransactionRunner
         # Warn about empty responses
         if (
           ( # expected is as string, actual is as integer :facepalm:
-            test.expected.statusCode.toString() in ['204', '205'] or
-            test.actual.statusCode.toString() in ['204', '205']
+            test.expected.statusCode?.toString() in ['204', '205'] or
+            test.actual.statusCode?.toString() in ['204', '205']
           ) and (test.expected.body or test.actual.body)
         )
           logger.warn("""\

--- a/test/fixtures/regression-893.yaml
+++ b/test/fixtures/regression-893.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - application/json; charset=utf-8
+paths:
+  /resource:
+    get:
+      responses:
+        default:
+          description: Representation

--- a/test/fixtures/regression-897-body.yaml
+++ b/test/fixtures/regression-897-body.yaml
@@ -1,0 +1,22 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - application/json; charset=utf-8
+  - text/csv; charset=utf-8
+paths:
+  /resource:
+    get:
+      responses:
+        200:
+          description: Representation
+  /resource.csv:
+    get:
+      responses:
+        200:
+          description: Representation
+          examples:
+            "text/csv; charset=utf-8": ""

--- a/test/fixtures/regression-897-schema.yaml
+++ b/test/fixtures/regression-897-schema.yaml
@@ -1,0 +1,22 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - application/json; charset=utf-8
+  - text/csv; charset=utf-8
+paths:
+  /resource:
+    get:
+      responses:
+        200:
+          description: Representation
+  /resource.csv:
+    get:
+      responses:
+        200:
+          description: Representation
+          examples:
+            "text/csv; charset=utf-8": "name,color\nHonza,green\n"

--- a/test/fixtures/request/application-x-www-form-urlencoded.yaml
+++ b/test/fixtures/request/application-x-www-form-urlencoded.yaml
@@ -1,0 +1,23 @@
+swagger: '2.0'
+info:
+  title: "Testing 'application/x-www-form-urlencoded' Request API"
+  version: '1.0'
+consumes:
+  - application/x-www-form-urlencoded
+produces:
+  - application/json; charset=utf-8
+paths:
+  '/data':
+    post:
+      parameters:
+        - name: test
+          in: formData
+          type: string
+          required: true
+          x-example: "42"
+      responses:
+        200:
+          description: 'Test OK'
+          examples:
+            application/json; charset=utf-8:
+              test: 'OK'

--- a/test/fixtures/request/multipart-form-data.apib
+++ b/test/fixtures/request/multipart-form-data.apib
@@ -4,21 +4,22 @@ FORMAT: 1A
 
 # POST /data
 
-+ Request (multipart/form-data;boundary=---BOUNDARY)
++ Request (multipart/form-data; boundary=CUSTOM-BOUNDARY)
 
     + Body
 
-            ---BOUNDARY
+            --CUSTOM-BOUNDARY
             Content-Disposition: form-data; name="text"
             Content-Type: text/plain
 
             test equals to 42
-            ---BOUNDARY
-            Content-Disposition: form-data; name="json"; filename="filename.json"
+            --CUSTOM-BOUNDARY
+            Content-Disposition: form-data; name="json"
             Content-Type: application/json
 
             {"test": 42}
-            ---BOUNDARY--
+
+            --CUSTOM-BOUNDARY--
 
 + Response 200 (application/json; charset=utf-8)
 

--- a/test/fixtures/request/multipart-form-data.yaml
+++ b/test/fixtures/request/multipart-form-data.yaml
@@ -1,0 +1,28 @@
+swagger: '2.0'
+info:
+  title: "Testing 'multipart/form-data' Request API"
+  version: '1.0'
+consumes:
+  - multipart/form-data; boundary=CUSTOM-BOUNDARY
+produces:
+  - application/json; charset=utf-8
+paths:
+  '/data':
+    post:
+      parameters:
+        - name: text
+          in: formData
+          type: string
+          required: true
+          x-example: "test equals to 42"
+        - name: json
+          in: formData
+          type: string
+          required: true
+          x-example: '{"test": 42}'
+      responses:
+        200:
+          description: 'Test OK'
+          examples:
+            application/json; charset=utf-8:
+              test: 'OK'

--- a/test/fixtures/response/204-205-body.apib
+++ b/test/fixtures/response/204-205-body.apib
@@ -1,0 +1,29 @@
+FORMAT: 1A
+
+# My API
+
+## Resource 204 without Body [/204-without-body]
+### Retrieve Representation [GET]
+
++ Response 204
+
+## Resource 205 without Body [/205-without-body]
+### Retrieve Representation [GET]
+
++ Response 205
+
+## Resource 204 with Body [/204-with-body]
+### Retrieve Representation [GET]
+
++ Response 204 (text/plain; charset=utf-8)
+    + Body
+
+            test
+
+## Resource 205 with Body [/205-with-body]
+### Retrieve Representation [GET]
+
++ Response 205 (text/plain; charset=utf-8)
+    + Body
+
+            test

--- a/test/fixtures/response/204-205-body.yaml
+++ b/test/fixtures/response/204-205-body.yaml
@@ -1,0 +1,33 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - text/plain; charset=utf-8
+paths:
+  /204-without-body:
+    get:
+      responses:
+        204:
+          description: Representation
+  /205-without-body:
+    get:
+      responses:
+        205:
+          description: Representation
+  /204-with-body:
+    get:
+      responses:
+        204:
+          description: Representation
+          examples:
+            "text/plain; charset=utf-8": "test\n"
+  /205-with-body:
+    get:
+      responses:
+        205:
+          description: Representation
+          examples:
+            "text/plain; charset=utf-8": "test\n"

--- a/test/fixtures/response/empty-body-empty-schema.apib
+++ b/test/fixtures/response/empty-body-empty-schema.apib
@@ -1,0 +1,19 @@
+FORMAT: 1A
+
+# My API
+
+## Resource [/resource.json]
+
+### Retrieve Representation [GET]
+
++ Response 200 (application/json; charset=utf-8)
+
+## Resource [/resource.csv]
+
+### Retrieve Representation [GET]
+
++ Response 200 (text/csv; charset=utf-8)
+    + Body
+
+        ```
+        ```

--- a/test/fixtures/response/empty-body-empty-schema.yaml
+++ b/test/fixtures/response/empty-body-empty-schema.yaml
@@ -1,0 +1,22 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - application/json; charset=utf-8
+  - text/csv; charset=utf-8
+paths:
+  /resource.json:
+    get:
+      responses:
+        200:
+          description: Representation
+  /resource.csv:
+    get:
+      responses:
+        200:
+          description: Representation
+          examples:
+            "text/csv; charset=utf-8": ""

--- a/test/fixtures/response/empty-body-hooks.js
+++ b/test/fixtures/response/empty-body-hooks.js
@@ -1,0 +1,9 @@
+var hooks = require('hooks');
+
+
+hooks.beforeEachValidation(function (transaction, done) {
+  if (transaction.real.body) {
+    transaction.fail = 'The response body must be empty';
+  }
+  done();
+});

--- a/test/fixtures/response/empty-body.apib
+++ b/test/fixtures/response/empty-body.apib
@@ -1,0 +1,16 @@
+FORMAT: 1A
+
+# My API
+
+## Resource [/resource]
+
+### Retrieve Representation [GET]
+
++ Response 200 (application/json; charset=utf-8)
+    + Schema
+
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"]
+            }

--- a/test/fixtures/response/empty-body.yaml
+++ b/test/fixtures/response/empty-body.yaml
@@ -1,0 +1,19 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Colors API
+schemes:
+  - http
+produces:
+  - application/json; charset=utf-8
+paths:
+  /resource:
+    get:
+      responses:
+        200:
+          description: Representation
+          schema:
+            type: object
+            properties:
+              name: {type: string}
+            required: [name]

--- a/test/fixtures/swagger-multiple-responses.js
+++ b/test/fixtures/swagger-multiple-responses.js
@@ -1,8 +1,11 @@
-
 var hooks = require('hooks');
 
-
 hooks.before('/honey > GET > 500 > application/json', function (transaction, done) {
+  transaction.skip = false;
+  done();
+});
+
+hooks.before('/honey > GET > 500 > application/xml', function (transaction, done) {
   transaction.skip = false;
   done();
 });

--- a/test/fixtures/swagger-multiple-responses.js
+++ b/test/fixtures/swagger-multiple-responses.js
@@ -4,8 +4,3 @@ hooks.before('/honey > GET > 500 > application/json', function (transaction, don
   transaction.skip = false;
   done();
 });
-
-hooks.before('/honey > GET > 500 > application/xml', function (transaction, done) {
-  transaction.skip = false;
-  done();
-});

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -562,8 +562,8 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 3 transactions', ->
-      assert.equal(matches.length, 3)
+    it('recognizes all 6 transactions', ->
+      assert.equal(matches.length, 6)
     )
     it('the transaction #1 is skipped', ->
       assert.equal(matches[0][1], 'skip')
@@ -571,8 +571,17 @@ describe 'Dredd class Integration', ->
     it('the transaction #2 is skipped', ->
       assert.equal(matches[1][1], 'skip')
     )
-    it('the transaction #3 is not skipped (status 200)', ->
-      assert.notEqual(matches[2][1], 'skip')
+    it('the transaction #3 is skipped', ->
+      assert.equal(matches[2][1], 'skip')
+    )
+    it('the transaction #4 is skipped', ->
+      assert.equal(matches[3][1], 'skip')
+    )
+    it('the transaction #5 is not skipped (status 200)', ->
+      assert.notEqual(matches[4][1], 'skip')
+    )
+    it('the transaction #6 is not skipped (status 200)', ->
+      assert.notEqual(matches[5][1], 'skip')
     )
   )
 
@@ -592,17 +601,26 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 3 transactions', ->
-      assert.equal(matches.length, 3)
+    it('recognizes all 6 transactions', ->
+      assert.equal(matches.length, 6)
     )
     it('the transaction #1 is skipped', ->
       assert.equal(matches[0][1], 'skip')
     )
-    it('the transaction #2 is not skipped (unskipped in hooks)', ->
-      assert.notEqual(matches[1][1], 'skip')
+    it('the transaction #2 is skipped', ->
+      assert.equal(matches[1][1], 'skip')
     )
-    it('the transaction #3 is not skipped (status 200)', ->
+    it('the transaction #3 is not skipped (unskiped in hooks)', ->
       assert.notEqual(matches[2][1], 'skip')
+    )
+    it('the transaction #4 is not skipped (status 200)', ->
+      assert.notEqual(matches[3][1], 'skip')
+    )
+    it('the transaction #5 is not skipped (status 200)', ->
+      assert.notEqual(matches[4][1], 'skip')
+    )
+    it('the transaction #6 is not skipped (unskiped in hooks)', ->
+      assert.notEqual(matches[5][1], 'skip')
     )
   )
 

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -568,16 +568,13 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 6 transactions', ->
-      assert.equal(actual.length, 6)
+    it('recognizes all 3 transactions', ->
+      assert.equal(actual.length, 3)
     )
 
     [
       {action: 'skip', statusCode: '400'}
-      {action: 'skip', statusCode: '400'}
       {action: 'skip', statusCode: '500'}
-      {action: 'skip', statusCode: '500'}
-      {action: 'fail', statusCode: '200'}
       {action: 'fail', statusCode: '200'}
     ].forEach((expected, i) ->
       context("the transaction ##{i + 1}", ->
@@ -613,16 +610,13 @@ describe 'Dredd class Integration', ->
       )
     )
 
-    it('recognizes all 6 transactions', ->
-      assert.equal(actual.length, 6)
+    it('recognizes all 3 transactions', ->
+      assert.equal(actual.length, 3)
     )
 
     [
       {action: 'skip', statusCode: '400'}
-      {action: 'skip', statusCode: '400'}
       {action: 'fail', statusCode: '200'}
-      {action: 'fail', statusCode: '200'}
-      {action: 'fail', statusCode: '500'} # Unskipped in hooks
       {action: 'fail', statusCode: '500'} # Unskipped in hooks
     ].forEach((expected, i) ->
       context("the transaction ##{i + 1}", ->

--- a/test/integration/dredd-test.coffee
+++ b/test/integration/dredd-test.coffee
@@ -548,48 +548,54 @@ describe 'Dredd class Integration', ->
         assert.include stderr, 'Fixed transaction name'
 
   describe('when Swagger document has multiple responses', ->
-    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
-    matches = undefined
+    reTransaction = /(\w+): (\w+) \((\d+)\) \/honey/g
+    actual = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       execCommand(
         options:
           path: './test/fixtures/multiple-responses.yaml'
       , (err) ->
         matches = []
         matches.push(groups) while groups = reTransaction.exec(stdout)
+        actual = matches.map((match) ->
+          keyMap = {'0': 'name', '1': 'action', '2': 'method', '3': 'statusCode'}
+          match.reduce((result, element, i) ->
+            Object.assign(result, "#{keyMap[i]}": element)
+          , {})
+        )
         done(err)
       )
     )
 
     it('recognizes all 6 transactions', ->
-      assert.equal(matches.length, 6)
+      assert.equal(actual.length, 6)
     )
-    it('the transaction #1 is skipped', ->
-      assert.equal(matches[0][1], 'skip')
-    )
-    it('the transaction #2 is skipped', ->
-      assert.equal(matches[1][1], 'skip')
-    )
-    it('the transaction #3 is skipped', ->
-      assert.equal(matches[2][1], 'skip')
-    )
-    it('the transaction #4 is skipped', ->
-      assert.equal(matches[3][1], 'skip')
-    )
-    it('the transaction #5 is not skipped (status 200)', ->
-      assert.notEqual(matches[4][1], 'skip')
-    )
-    it('the transaction #6 is not skipped (status 200)', ->
-      assert.notEqual(matches[5][1], 'skip')
+
+    [
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '500'}
+      {action: 'skip', statusCode: '500'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '200'}
+    ].forEach((expected, i) ->
+      context("the transaction ##{i + 1}", ->
+        it("has status code #{expected.statusCode}", ->
+          assert.equal(expected.statusCode, actual[i].statusCode)
+        )
+        it("is #{if expected.action is 'skip' then '' else 'not '}skipped by default", ->
+          assert.equal(expected.action, actual[i].action)
+        )
+      )
     )
   )
 
   describe('when Swagger document has multiple responses and hooks unskip some of them', ->
-    reTransaction = /(\w+): (\w+) \(\d+\) \/honey/g
-    matches = undefined
+    reTransaction = /(\w+): (\w+) \((\d+)\) \/honey/g
+    actual = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       execCommand(
         options:
           path: './test/fixtures/multiple-responses.yaml'
@@ -597,30 +603,39 @@ describe 'Dredd class Integration', ->
       , (err) ->
         matches = []
         matches.push(groups) while groups = reTransaction.exec(stdout)
+        actual = matches.map((match) ->
+          keyMap = {'0': 'name', '1': 'action', '2': 'method', '3': 'statusCode'}
+          match.reduce((result, element, i) ->
+            Object.assign(result, "#{keyMap[i]}": element)
+          , {})
+        )
         done(err)
       )
     )
 
     it('recognizes all 6 transactions', ->
-      assert.equal(matches.length, 6)
+      assert.equal(actual.length, 6)
     )
-    it('the transaction #1 is skipped', ->
-      assert.equal(matches[0][1], 'skip')
-    )
-    it('the transaction #2 is skipped', ->
-      assert.equal(matches[1][1], 'skip')
-    )
-    it('the transaction #3 is not skipped (unskiped in hooks)', ->
-      assert.notEqual(matches[2][1], 'skip')
-    )
-    it('the transaction #4 is not skipped (status 200)', ->
-      assert.notEqual(matches[3][1], 'skip')
-    )
-    it('the transaction #5 is not skipped (status 200)', ->
-      assert.notEqual(matches[4][1], 'skip')
-    )
-    it('the transaction #6 is not skipped (unskiped in hooks)', ->
-      assert.notEqual(matches[5][1], 'skip')
+
+    [
+      {action: 'skip', statusCode: '400'}
+      {action: 'skip', statusCode: '400'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '200'}
+      {action: 'fail', statusCode: '500'} # Unskipped in hooks
+      {action: 'fail', statusCode: '500'} # Unskipped in hooks
+    ].forEach((expected, i) ->
+      context("the transaction ##{i + 1}", ->
+        it("has status code #{expected.statusCode}", ->
+          assert.equal(expected.statusCode, actual[i].statusCode)
+        )
+
+        defaultMessage = "is #{if expected.action is 'skip' then '' else 'not '}skipped by default"
+        unskippedMessage = 'is unskipped in hooks'
+        it("#{if expected.statusCode is '500' then unskippedMessage else defaultMessage}", ->
+          assert.equal(expected.action, actual[i].action)
+        )
+      )
     )
   )
 

--- a/test/integration/regressions/regression-152-test.coffee
+++ b/test/integration/regressions/regression-152-test.coffee
@@ -8,7 +8,7 @@ describe('Regression: Issue #152', ->
   describe('Modify transaction object inside beforeAll combined with beforeEach helper', ->
     runtimeInfo = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer()
       app.get('/machines', (req, res) ->
         res.json([{type: 'bulldozer', name: 'willy'}])

--- a/test/integration/regressions/regression-615-test.coffee
+++ b/test/integration/regressions/regression-615-test.coffee
@@ -7,7 +7,7 @@ Dredd = require('../../../src/dredd')
 describe('Regression: Issue #615', ->
   runtimeInfo = undefined
 
-  beforeEach((done) ->
+  before((done) ->
     app = createServer()
     app.all('/honey', (req, res) ->
       res.status(200).type('text/plain').send('')

--- a/test/integration/regressions/regression-893-897-test.coffee
+++ b/test/integration/regressions/regression-893-897-test.coffee
@@ -8,7 +8,7 @@ describe('Regression: Issue #893 and #897', ->
   describe('when the response has no explicit status code', ->
     runtimeInfo = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer()
       app.get('/resource', (req, res) ->
         res.json({name: 'Honza', color: 'green'})
@@ -35,7 +35,7 @@ describe('Regression: Issue #893 and #897', ->
   describe('when the response has no explicit schema and it has empty body', ->
     runtimeInfo = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer()
       app.get('/resource', (req, res) ->
         res.json({name: 'Honza', color: 'green'})
@@ -65,7 +65,7 @@ describe('Regression: Issue #893 and #897', ->
   describe('when the response has no explicit schema', ->
     runtimeInfo = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer()
       app.get('/resource', (req, res) ->
         res.json({name: 'Honza', color: 'green'})

--- a/test/integration/regressions/regression-893-897-test.coffee
+++ b/test/integration/regressions/regression-893-897-test.coffee
@@ -1,0 +1,94 @@
+{assert} = require('chai')
+
+Dredd = require('../../../src/dredd')
+{runDreddWithServer, createServer} = require('../helpers')
+
+
+describe('Regression: Issue #893 and #897', ->
+  describe('when the response has no explicit status code', ->
+    runtimeInfo = undefined
+
+    beforeEach((done) ->
+      app = createServer()
+      app.get('/resource', (req, res) ->
+        res.json({name: 'Honza', color: 'green'})
+      )
+
+      dredd = new Dredd({options: {path: './test/fixtures/regression-893.yaml'}})
+      runDreddWithServer(dredd, app, (args...) ->
+        [err, runtimeInfo] = args
+        done(err)
+      )
+    )
+
+    it('outputs no failures or errors', ->
+      assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0)
+    )
+    it('results in exactly one test', ->
+      assert.equal(runtimeInfo.dredd.stats.tests, 1)
+    )
+    it('results in one passing test (HTTP 200 is assumed)', ->
+      assert.equal(runtimeInfo.dredd.stats.passes, 1)
+    )
+  )
+
+  describe('when the response has no explicit schema and it has empty body', ->
+    runtimeInfo = undefined
+
+    beforeEach((done) ->
+      app = createServer()
+      app.get('/resource', (req, res) ->
+        res.json({name: 'Honza', color: 'green'})
+      )
+      app.get('/resource.csv', (req, res) ->
+        res.type('text/csv').send('name,color\nHonza,green\n')
+      )
+
+      dredd = new Dredd({options: {path: './test/fixtures/regression-897-body.yaml'}})
+      runDreddWithServer(dredd, app, (args...) ->
+        [err, runtimeInfo] = args
+        done(err)
+      )
+    )
+
+    it('outputs no failures or errors', ->
+      assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0)
+    )
+    it('results in exactly two tests', ->
+      assert.equal(runtimeInfo.dredd.stats.tests, 2)
+    )
+    it('results in two passing tests (body is not validated)', ->
+      assert.equal(runtimeInfo.dredd.stats.passes, 2)
+    )
+  )
+
+  describe('when the response has no explicit schema', ->
+    runtimeInfo = undefined
+
+    beforeEach((done) ->
+      app = createServer()
+      app.get('/resource', (req, res) ->
+        res.json({name: 'Honza', color: 'green'})
+      )
+      app.get('/resource.csv', (req, res) ->
+        res.type('text/csv').send('name,color\nHonza,green\n')
+      )
+
+      dredd = new Dredd({options: {path: './test/fixtures/regression-897-schema.yaml'}})
+      runDreddWithServer(dredd, app, (args...) ->
+        [err, runtimeInfo] = args
+        done(err)
+      )
+    )
+
+    it('outputs no failures or errors', ->
+      assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0)
+    )
+    it('results in exactly two tests', ->
+      assert.equal(runtimeInfo.dredd.stats.tests, 2)
+    )
+    it('results in two passing tests', ->
+      assert.equal(runtimeInfo.dredd.stats.passes, 2)
+    )
+  )
+)

--- a/test/integration/request-test.coffee
+++ b/test/integration/request-test.coffee
@@ -41,85 +41,105 @@ describe('Sending \'application/json\' request', ->
 )
 
 
-describe('Sending \'multipart/form-data\' request', ->
-  runtimeInfo = undefined
-  contentType = 'multipart/form-data'
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/request/multipart-form-data.apib'
+    supportsContentTypes: true,
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/request/multipart-form-data.yaml'
+    supportsContentTypes: false,
+].forEach((apiDescription) ->
+  describe("Sending 'multipart/form-data' request described in #{apiDescription.name}", ->
+    runtimeInfo = undefined
+    contentType = 'multipart/form-data'
 
-  beforeEach((done) ->
-    path = './test/fixtures/request/multipart-form-data.apib'
+    beforeEach((done) ->
+      app = createServer({bodyParser: bodyParser.text({type: contentType})})
+      app.post('/data', (req, res) ->
+        res.json({test: 'OK'})
+      )
+      dredd = new Dredd({options: {path: apiDescription.path}})
 
-    app = createServer({bodyParser: bodyParser.text({type: contentType})})
-    app.post('/data', (req, res) ->
-      res.json({test: 'OK'})
+      runDreddWithServer(dredd, app, (err, info) ->
+        runtimeInfo = info
+        done(err)
+      )
     )
-    dredd = new Dredd({options: {path}})
 
-    runDreddWithServer(dredd, app, (err, info) ->
-      runtimeInfo = info
-      done(err)
+    it('results in one request being delivered to the server', ->
+      assert.isTrue(runtimeInfo.server.requestedOnce)
     )
-  )
+    it('the request has the expected Content-Type', ->
+      assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data')
+    )
+    it('the request has the expected format', ->
+      lines = [
+        '--CUSTOM-BOUNDARY'
+        'Content-Disposition: form-data; name="text"'
+        'Content-Type: text/plain'
+        ''
+        'test equals to 42'
+        '--CUSTOM-BOUNDARY'
+        'Content-Disposition: form-data; name="json"'
+        'Content-Type: application/json'
+        ''
+        '{"test": 42}'
+        ''
+        '--CUSTOM-BOUNDARY--'
+        ''
+      ]
+      if not apiDescription.supportsContentTypes
+        lines = lines.filter((line) -> not line.match(/^Content-Type:/))
 
-  it('results in one request being delivered to the server', ->
-    assert.isTrue(runtimeInfo.server.requestedOnce)
-  )
-  it('the request has the expected Content-Type', ->
-    assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data')
-  )
-  it('the request has the expected format', ->
-    assert.equal(runtimeInfo.server.lastRequest.body, [
-      '---BOUNDARY'
-      'Content-Disposition: form-data; name="text"'
-      'Content-Type: text/plain'
-      ''
-      'test equals to 42'
-      '---BOUNDARY'
-      'Content-Disposition: form-data; name="json"; filename="filename.json"'
-      'Content-Type: application/json'
-      ''
-      '{"test": 42}'
-      '---BOUNDARY--'
-      ''
-    ].join('\r\n'))
-  )
-  it('results in one passing test', ->
-    assert.equal(runtimeInfo.dredd.stats.tests, 1)
-    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+      assert.equal(runtimeInfo.server.lastRequest.body, lines.join('\r\n'))
+    )
+    it('results in one passing test', ->
+      assert.equal(runtimeInfo.dredd.stats.tests, 1)
+      assert.equal(runtimeInfo.dredd.stats.passes, 1)
+    )
   )
 )
 
 
-describe('Sending \'application/x-www-form-urlencoded\' request', ->
-  runtimeInfo = undefined
-  contentType = 'application/x-www-form-urlencoded'
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/request/application-x-www-form-urlencoded.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/request/application-x-www-form-urlencoded.yaml'
+].forEach((apiDescription) ->
+  describe("Sending 'application/x-www-form-urlencoded' request described in #{apiDescription.name}", ->
+    runtimeInfo = undefined
+    contentType = 'application/x-www-form-urlencoded'
 
-  beforeEach((done) ->
-    path = './test/fixtures/request/application-x-www-form-urlencoded.apib'
+    beforeEach((done) ->
+      app = createServer({bodyParser: bodyParser.text({type: contentType})})
+      app.post('/data', (req, res) ->
+        res.json({test: 'OK'})
+      )
+      dredd = new Dredd({options: {path: apiDescription.path}})
 
-    app = createServer({bodyParser: bodyParser.text({type: contentType})})
-    app.post('/data', (req, res) ->
-      res.json({test: 'OK'})
+      runDreddWithServer(dredd, app, (err, info) ->
+        runtimeInfo = info
+        done(err)
+      )
     )
-    dredd = new Dredd({options: {path}})
 
-    runDreddWithServer(dredd, app, (err, info) ->
-      runtimeInfo = info
-      done(err)
+    it('results in one request being delivered to the server', ->
+      assert.isTrue(runtimeInfo.server.requestedOnce)
     )
-  )
-
-  it('results in one request being delivered to the server', ->
-    assert.isTrue(runtimeInfo.server.requestedOnce)
-  )
-  it('the request has the expected Content-Type', ->
-    assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType)
-  )
-  it('the request has the expected format', ->
-    assert.equal(runtimeInfo.server.lastRequest.body, 'test=42\n')
-  )
-  it('results in one passing test', ->
-    assert.equal(runtimeInfo.dredd.stats.tests, 1)
-    assert.equal(runtimeInfo.dredd.stats.passes, 1)
+    it('the request has the expected Content-Type', ->
+      assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType)
+    )
+    it('the request has the expected format', ->
+      # API Blueprint adds extra \n at the end: https://github.com/apiaryio/dredd/issues/67
+      assert.equal(runtimeInfo.server.lastRequest.body.trim(), 'test=42')
+    )
+    it('results in one passing test', ->
+      assert.equal(runtimeInfo.dredd.stats.tests, 1)
+      assert.equal(runtimeInfo.dredd.stats.passes, 1)
+    )
   )
 )
 

--- a/test/integration/request-test.coffee
+++ b/test/integration/request-test.coffee
@@ -9,7 +9,7 @@ describe('Sending \'application/json\' request', ->
   runtimeInfo = undefined
   contentType = 'application/json'
 
-  beforeEach((done) ->
+  before((done) ->
     app = createServer({bodyParser: bodyParser.text({type: contentType})})
     app.post('/data', (req, res) ->
       res.json({test: 'OK'})
@@ -54,7 +54,7 @@ describe('Sending \'application/json\' request', ->
     runtimeInfo = undefined
     contentType = 'multipart/form-data'
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer({bodyParser: bodyParser.text({type: contentType})})
       app.post('/data', (req, res) ->
         res.json({test: 'OK'})
@@ -113,7 +113,7 @@ describe('Sending \'application/json\' request', ->
     runtimeInfo = undefined
     contentType = 'application/x-www-form-urlencoded'
 
-    beforeEach((done) ->
+    before((done) ->
       app = createServer({bodyParser: bodyParser.text({type: contentType})})
       app.post('/data', (req, res) ->
         res.json({test: 'OK'})
@@ -148,7 +148,7 @@ describe('Sending \'text/plain\' request', ->
   runtimeInfo = undefined
   contentType = 'text/plain'
 
-  beforeEach((done) ->
+  before((done) ->
     path = './test/fixtures/request/text-plain.apib'
 
     app = createServer({bodyParser: bodyParser.text({type: contentType})})

--- a/test/integration/response-test.coffee
+++ b/test/integration/response-test.coffee
@@ -1,0 +1,341 @@
+{assert} = require('chai')
+
+{runDreddWithServer, createServer} = require('./helpers')
+Dredd = require('../../src/dredd')
+
+
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/response/empty-body-empty-schema.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/response/empty-body-empty-schema.yaml'
+].forEach((apiDescription) ->
+  describe("Specifying neither response body nor schema in the #{apiDescription.name}", ->
+    describe('when the server returns non-empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.json({test: 'OK'})
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send('test,OK\n')
+        )
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as valid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, passes: 2})
+      )
+    )
+
+    describe('when the server returns empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.type('json').send()
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send()
+        )
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as valid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, passes: 2})
+      )
+    )
+  )
+)
+
+
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/response/empty-body.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/response/empty-body.yaml'
+].forEach((apiDescription) ->
+  describe("Specifying no response body in the #{apiDescription.name}, but specifying a schema", ->
+    describe('when the server returns a response not valid according to the schema', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource', (req, res) ->
+          res.json({name: 123})
+        )
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the response as invalid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 1, failures: 1})
+      )
+      it('prints JSON Schema validation error', ->
+        assert.include(runtimeInfo.dredd.logging, 'At \'/name\' Invalid type: number (expected string)')
+      )
+    )
+
+    describe('when the server returns a response valid according to the schema', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource', (req, res) ->
+          res.json({name: "test"})
+        )
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the response as valid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 1, passes: 1})
+      )
+    )
+  )
+)
+
+
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/response/empty-body-empty-schema.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/response/empty-body-empty-schema.yaml'
+].forEach((apiDescription) ->
+  describe("Specifying no response body in the #{apiDescription.name} and having hooks ensuring empty response", ->
+    describe('when the server returns a non-empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.json({test: 'OK'})
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send('test,OK\n')
+        )
+        dredd = new Dredd(
+          options:
+            path: apiDescription.path
+            hookfiles: './test/fixtures/response/empty-body-hooks.js'
+        )
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as invalid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, failures: 2})
+      )
+      it('prints the error message from hooks', ->
+        assert.include(runtimeInfo.dredd.logging, 'The response body must be empty')
+      )
+    )
+
+    describe('when the server returns an empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.send()
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send()
+        )
+        dredd = new Dredd(
+          options:
+            path: apiDescription.path
+            hookfiles: './test/fixtures/response/empty-body-hooks.js'
+        )
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as valid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, passes: 2})
+      )
+    )
+  )
+)
+
+
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/response/empty-body-empty-schema.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/response/empty-body-empty-schema.yaml'
+].forEach((apiDescription) ->
+  describe("Specifying no response body in the #{apiDescription.name} and having hooks ensuring empty response", ->
+    describe('when the server returns non-empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.json({test: 'OK'})
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send('test,OK\n')
+        )
+        dredd = new Dredd(
+          options:
+            path: apiDescription.path
+            hookfiles: './test/fixtures/response/empty-body-hooks.js'
+        )
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as invalid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, failures: 2})
+      )
+      it('prints the error message from hooks', ->
+        assert.include(runtimeInfo.dredd.logging, 'The response body must be empty')
+      )
+    )
+
+    describe('when the server returns empty responses', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        app = createServer()
+        app.get('/resource.json', (req, res) ->
+          res.send()
+        )
+        app.get('/resource.csv', (req, res) ->
+          res.type('text/csv').send()
+        )
+        dredd = new Dredd(
+          options:
+            path: apiDescription.path
+            hookfiles: './test/fixtures/response/empty-body-hooks.js'
+        )
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates the responses as valid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 2, passes: 2})
+      )
+    )
+  )
+)
+
+
+[
+    name: 'API Blueprint'
+    path: './test/fixtures/response/204-205-body.apib'
+  ,
+    name: 'Swagger'
+    path: './test/fixtures/response/204-205-body.yaml'
+].forEach((apiDescription) ->
+  describe("Working with HTTP 204 and 205 responses in the #{apiDescription.name}", ->
+    describe('when the actual response is non-empty', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        # It's not trivial to create an actual server sending HTTP 204 or 205
+        # with non-empty body, because it's against specs. That's why we're
+        # returning HTTP 200 here and in the assertions we're making sure
+        # the failures are there only because of non-matching status codes.
+        app = createServer()
+        app.get('*', (req, res) ->
+          res.type('text/plain').send('test\n')
+        )
+
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates all the responses as invalid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 4, failures: 4})
+      )
+      it('prints four warnings for each of the responses', ->
+        assert.equal(runtimeInfo.dredd.logging.match(
+          /HTTP 204 and 205 responses must not include a message body/g
+        ).length, 4)
+      )
+      it('prints four failures for each non-matching status code', ->
+        assert.equal(runtimeInfo.dredd.logging.match(
+          /fail: statusCode: Status code is not/g
+        ).length, 4)
+      )
+      it('does not print any failures regarding response bodies', ->
+        assert.isNull(runtimeInfo.dredd.logging.match(/fail: body:/g))
+      )
+    )
+
+    describe('when the actual response is empty', ->
+      runtimeInfo = undefined
+
+      beforeEach((done) ->
+        # It's not trivial to create an actual server sending HTTP 204 or 205
+        # sending a Content-Type header, because it's against specs. That's
+        # why we're returning HTTP 200 here and in the assertions we're making
+        # sure the extra failures are there only because of non-matching status
+        # codes.
+        app = createServer()
+        app.get('*', (req, res) ->
+          res.type('text/plain').send()
+        )
+
+        dredd = new Dredd({options: {path: apiDescription.path}})
+        runDreddWithServer(dredd, app, (err, info) ->
+          runtimeInfo = info
+          done(err)
+        )
+      )
+
+      it('evaluates all the responses as invalid', ->
+        assert.deepInclude(runtimeInfo.dredd.stats, {tests: 4, failures: 4})
+      )
+      it('prints two warnings for each of the non-empty expectations', ->
+        assert.equal(runtimeInfo.dredd.logging.match(
+          /HTTP 204 and 205 responses must not include a message body/g
+        ).length, 2)
+      )
+      it('prints two failures for each non-matching body (and status code)', ->
+        assert.equal(runtimeInfo.dredd.logging.match(
+          /fail: body: Real and expected data does not match.\nstatusCode: Status code is not/g
+        ).length, 2)
+      )
+      it('prints two failures for each non-matching status code', ->
+        assert.equal(runtimeInfo.dredd.logging.match(
+          /fail: statusCode: Status code is not/g
+        ).length, 2)
+      )
+    )
+  )
+)

--- a/test/integration/response-test.coffee
+++ b/test/integration/response-test.coffee
@@ -15,7 +15,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns non-empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.json({test: 'OK'})
@@ -38,7 +38,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.type('json').send()
@@ -72,7 +72,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns a response not valid according to the schema', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource', (req, res) ->
           res.json({name: 123})
@@ -95,7 +95,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns a response valid according to the schema', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource', (req, res) ->
           res.json({name: "test"})
@@ -126,7 +126,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns a non-empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.json({test: 'OK'})
@@ -156,7 +156,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns an empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.send()
@@ -194,7 +194,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns non-empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.json({test: 'OK'})
@@ -224,7 +224,7 @@ Dredd = require('../../src/dredd')
     describe('when the server returns empty responses', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         app = createServer()
         app.get('/resource.json', (req, res) ->
           res.send()
@@ -262,7 +262,7 @@ Dredd = require('../../src/dredd')
     describe('when the actual response is non-empty', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         # It's not trivial to create an actual server sending HTTP 204 or 205
         # with non-empty body, because it's against specs. That's why we're
         # returning HTTP 200 here and in the assertions we're making sure
@@ -300,7 +300,7 @@ Dredd = require('../../src/dredd')
     describe('when the actual response is empty', ->
       runtimeInfo = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         # It's not trivial to create an actual server sending HTTP 204 or 205
         # sending a Content-Type header, because it's against specs. That's
         # why we're returning HTTP 200 here and in the assertions we're making

--- a/test/unit/transaction-runner-test.coffee
+++ b/test/unit/transaction-runner-test.coffee
@@ -96,7 +96,7 @@ describe 'TransactionRunner', ->
 
         assert.isOk runner.multiBlueprint
 
-  describe 'configureTransaction(transaction, callback)', ->
+  describe 'configureTransaction(transaction)', ->
     beforeEach ->
       transaction =
         name: "Machines API > Group Machine > Machine > Delete Message > Bogus example name"
@@ -181,7 +181,7 @@ describe 'TransactionRunner', ->
 
       ].forEach(({description, input, expected}) ->
         context("#{description}: '#{input.serverUrl}' + '#{input.requestPath}'", ->
-          beforeEach((done) ->
+          beforeEach( ->
             transaction.request.uri = input.requestPath
             transaction.origin.filename = filename
 
@@ -190,10 +190,7 @@ describe 'TransactionRunner', ->
             runner.configuration.data[filename] ?= {}
             runner.configuration.data[filename].mediaType = 'text/vnd.apiblueprint'
 
-            runner.configureTransaction(transaction, (args...) ->
-              [err, configuredTransaction] = args
-              done(err)
-            )
+            configuredTransaction = runner.configureTransaction(transaction)
           )
 
           it("the transaction gets configured with fullPath '#{expected.fullPath}' and has expected host, port, and protocol", ->
@@ -214,7 +211,7 @@ describe 'TransactionRunner', ->
 
       ['100', '400', 199, 300].forEach((status) ->
         context('status code: ' + JSON.stringify(status), ->
-          beforeEach((done) ->
+          beforeEach( ->
             transaction.response.status = status
             transaction.origin.filename = filename
 
@@ -222,10 +219,7 @@ describe 'TransactionRunner', ->
             runner.configuration.data[filename] ?= {}
             runner.configuration.data[filename].mediaType = 'application/swagger+json'
 
-            runner.configureTransaction(transaction, (args...) ->
-              [err, configuredTransaction] = args
-              done(err)
-            )
+            configuredTransaction = runner.configureTransaction(transaction)
           )
 
           it('skips the transaction by default', ->
@@ -241,7 +235,7 @@ describe 'TransactionRunner', ->
 
       ['200', 299].forEach((status) ->
         context('status code: ' + JSON.stringify(status), ->
-          beforeEach((done) ->
+          beforeEach( ->
             transaction.response.status = status
             transaction.origin.filename = filename
 
@@ -249,10 +243,7 @@ describe 'TransactionRunner', ->
             runner.configuration.data[filename] ?= {}
             runner.configuration.data[filename].mediaType = 'application/swagger+json'
 
-            runner.configureTransaction(transaction, (args...) ->
-              [err, configuredTransaction] = args
-              done(err)
-            )
+            configuredTransaction = runner.configureTransaction(transaction)
           )
 
           it('does not skip the transaction by default', ->
@@ -266,7 +257,7 @@ describe 'TransactionRunner', ->
       filename = 'api-description.yml'
       configuredTransaction = undefined
 
-      beforeEach((done) ->
+      beforeEach( ->
         transaction.response.status = 400
         transaction.origin.filename = filename
 
@@ -274,10 +265,7 @@ describe 'TransactionRunner', ->
         runner.configuration.data[filename] ?= {}
         runner.configuration.data[filename].mediaType = 'text/plain'
 
-        runner.configureTransaction(transaction, (args...) ->
-          [err, configuredTransaction] = args
-          done(err)
-        )
+        configuredTransaction = runner.configureTransaction(transaction)
       )
 
       it('does not skip the transaction by default', ->
@@ -286,25 +274,22 @@ describe 'TransactionRunner', ->
     )
 
     describe 'when processing multiple API description documents', ->
-      it 'should include api name in the transaction name', (done) ->
+      it 'should include api name in the transaction name', ->
         runner.multiBlueprint = true
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.include configuredTransaction.name, 'Machines API'
-          done()
+        configuredTransaction = runner.configureTransaction transaction
+        assert.include configuredTransaction.name, 'Machines API'
 
     describe 'when processing only single API description document', ->
-      it 'should not include api name in the transaction name', (done) ->
+      it 'should not include api name in the transaction name', ->
         runner.multiBlueprint = false
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.notInclude configuredTransaction.name, 'Machines API'
-          done()
+        configuredTransaction = runner.configureTransaction transaction
+        assert.notInclude configuredTransaction.name, 'Machines API'
 
     describe 'when request does not have User-Agent', ->
 
-      it 'should add the Dredd User-Agent', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.isOk configuredTransaction.request.headers['User-Agent']
-          done()
+      it 'should add the Dredd User-Agent', ->
+        configuredTransaction = runner.configureTransaction transaction
+        assert.isOk configuredTransaction.request.headers['User-Agent']
 
     describe 'when an additional header has a colon', ->
       beforeEach ->
@@ -312,22 +297,20 @@ describe 'TransactionRunner', ->
         conf.options.header = ["MyCustomDate:Wed, 10 Sep 2014 12:34:26 GMT"]
         runner = new Runner(conf)
 
-      it 'should include the entire value in the header', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.equal configuredTransaction.request.headers['MyCustomDate'], 'Wed, 10 Sep 2014 12:34:26 GMT'
-          done()
+      it 'should include the entire value in the header', ->
+        configuredTransaction = runner.configureTransaction transaction
+        assert.equal configuredTransaction.request.headers['MyCustomDate'], 'Wed, 10 Sep 2014 12:34:26 GMT'
 
     describe 'when configuring a transaction', ->
 
-      it 'should callback with a properly configured transaction', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.equal configuredTransaction.name, 'Group Machine > Machine > Delete Message > Bogus example name'
-          assert.equal configuredTransaction.id, 'POST (202) /machines'
-          assert.isOk configuredTransaction.host
-          assert.isOk configuredTransaction.request
-          assert.isOk configuredTransaction.expected
-          assert.strictEqual transaction.origin, configuredTransaction.origin
-          done()
+      it 'should callback with a properly configured transaction', ->
+        configuredTransaction = runner.configureTransaction transaction
+        assert.equal configuredTransaction.name, 'Group Machine > Machine > Delete Message > Bogus example name'
+        assert.equal configuredTransaction.id, 'POST (202) /machines'
+        assert.isOk configuredTransaction.host
+        assert.isOk configuredTransaction.request
+        assert.isOk configuredTransaction.expected
+        assert.strictEqual transaction.origin, configuredTransaction.origin
 
     describe 'when endpoint URL contains PORT and path', ->
       beforeEach ->
@@ -335,21 +318,19 @@ describe 'TransactionRunner', ->
         configurationWithPath.server = 'https://hostname.tld:9876/my/path/to/api/'
         runner = new Runner(configurationWithPath)
 
-      it 'should join the endpoint path with transaction uriTemplate together', (done) ->
-        runner.configureTransaction transaction, (err, configuredTransaction) ->
-          assert.equal configuredTransaction.id, 'POST (202) /machines'
-          assert.strictEqual configuredTransaction.host, 'hostname.tld'
-          assert.equal configuredTransaction.port, 9876
-          assert.strictEqual configuredTransaction.protocol, 'https:'
-          assert.strictEqual configuredTransaction.fullPath, '/my/path/to/api' + '/machines'
-          done()
+      it 'should join the endpoint path with transaction uriTemplate together', ->
+        configuredTransaction = runner.configureTransaction transaction
+        assert.equal configuredTransaction.id, 'POST (202) /machines'
+        assert.strictEqual configuredTransaction.host, 'hostname.tld'
+        assert.equal configuredTransaction.port, 9876
+        assert.strictEqual configuredTransaction.protocol, 'https:'
+        assert.strictEqual configuredTransaction.fullPath, '/my/path/to/api' + '/machines'
 
-       it 'should keep trailing slash in url if present', (done) ->
-         transaction.request.uri = '/machines/'
-         runner.configureTransaction transaction, (err, configuredTransaction) ->
-           assert.equal configuredTransaction.id, 'POST (202) /machines/'
-           assert.strictEqual configuredTransaction.fullPath, '/my/path/to/api' + '/machines/'
-           done()
+      it 'should keep trailing slash in url if present', ->
+        transaction.request.uri = '/machines/'
+        configuredTransaction = runner.configureTransaction transaction
+        assert.equal configuredTransaction.id, 'POST (202) /machines/'
+        assert.strictEqual configuredTransaction.fullPath, '/my/path/to/api' + '/machines/'
 
   describe 'executeTransaction(transaction, callback)', ->
 


### PR DESCRIPTION
#### :rocket: Why this change?

- Solitary default responses in Swagger are now treated as HTTP 200 #893
- Fixes how Dredd handles empty bodies and empty schemas #556, #897
- Pins peer dependencies #905
- In Swagger, JSON media types with parameters (such as charset) are now recognized as JSON #553, #883
- Fixed handling of multipart/form-data in Swagger #711

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/pull/896 (deprecates)
- Fixes #893, fixes #556, fixes #897, fixes #905, fixes #711, fixes #553
- Related https://github.com/apiaryio/dredd/issues/883, https://github.com/apiaryio/dredd-transactions/pull/119

#### :white_check_mark: What didn't I forget?

- [x] Incorporate https://github.com/apiaryio/dredd/pull/896
- [x] To write docs for empty bodies and empty schemas
- [x] To write docs on how to assert empty bodies, assertions from body/schema
- [x] To write docs for solitary default responses
- [x] To write docs for `multipart/form-data` handling
- [x] To write docs for which produces media types are (not) ignored, how to create non-JSON media types
- [x] To write tests for solitary default responses (in Dredd Transactions)
- [x] To write tests for empty bodies and empty schemas
- [x] Test HTTP 204, 205
- [x] To write tests for `application/json; charset=utf-8` (in Dredd Transactions)
- [x] To write tests for `multipart/form-data` handling
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
