### PR TITLE
Added support for reporter xunit parameter

### DIFF
--- a/src/configure-reporters.coffee
+++ b/src/configure-reporters.coffee
@@ -9,7 +9,13 @@ ApiaryReporter = require './reporters/apiary-reporter'
 
 logger = require('./logger')
 
-fileReporters = ['junit', 'html', 'markdown', 'apiary']
+fileReporters = [
+  'xunit',
+  'html',
+  'markdown',
+  'apiary',
+  'junit' # deprecated
+]
 cliReporters = ['dot', 'nyan']
 
 intersection = (a, b) ->
@@ -35,7 +41,10 @@ configureReporters = (config, stats, tests, runner) ->
 
   addReporter = (reporter, emitter, stats, tests, path) ->
     switch reporter
-      when 'junit'
+      when 'xunit'
+        xUnitReporter = new XUnitReporter(emitter, stats, tests, path, config.options.details)
+      when 'junit' # deprecated
+        logger.warn('junit will be deprecated in the future. Please use `xunit` instead.')
         xUnitReporter = new XUnitReporter(emitter, stats, tests, path, config.options.details)
       when 'dot'
         dotReporter = new DotReporter(emitter, stats, tests)

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -53,7 +53,7 @@ options =
     alias: "r"
     description: """Output additional report format. This option can be used \
       multiple times to add multiple reporters. \
-      Options: junit, nyan, dot, markdown, html, apiary.\n"""
+      Options: xunit, nyan, dot, markdown, html, apiary.\n"""
     default: []
 
   output:

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -235,7 +235,7 @@ describe 'CLI - Reporters', ->
     args = [
       './test/fixtures/single-get.apib'
       "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
-      '--reporter=junit'
+      '--reporter=xunit'
       '--output=__test_file_output__.xml'
     ]
 
@@ -256,9 +256,9 @@ describe 'CLI - Reporters', ->
     args = [
       './test/fixtures/single-get.apib'
       "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
-      '--reporter=junit'
+      '--reporter=xunit'
       '--output=__test_file_output1__.xml'
-      '--reporter=junit'
+      '--reporter=xunit'
       '--output=__test_file_output2__.xml'
     ]
 

--- a/test/unit/configure-reporters-test.coffee
+++ b/test/unit/configure-reporters-test.coffee
@@ -107,7 +107,7 @@ describe 'configureReporters(config, stats, tests, onSaveCallback)', () ->
   describe 'when there are only file-based reporters', () ->
 
     before () ->
-      configuration.options.reporter = ['junit', 'markdown']
+      configuration.options.reporter = ['xunit', 'markdown']
 
     after () ->
       configuration.options.reporter = []


### PR DESCRIPTION
#### :rocket: Why this change?

`xunit` is the better parameter for reporter rather than `junit`. `junit` is still supported until it is decided to be removed (https://github.com/apiaryio/dredd/issues/888#issuecomment-337265911).

#### :memo: Related issues and Pull Requests

Resolves https://github.com/apiaryio/dredd/issues/888

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
