### PR TITLE
fix: throw error when any additional path doesn't exist

### DIFF
--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -126,6 +126,12 @@ class Dredd
       glob globToExpand, (err, match) =>
         return globCallback(err) if err
         @configuration.files = @configuration.files.concat match
+        if match.length == 0
+          err = new Error("""\
+            API description document(s) not found on path: \
+            '#{globToExpand}'\
+          """)
+          return globCallback(err)
         globCallback()
 
     , (err) =>

--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -137,13 +137,6 @@ class Dredd
     , (err) =>
       return callback(err, @stats) if err
 
-      if @configDataIsEmpty and @configuration.files.length == 0
-        err = new Error("""\
-          API description document (or documents) not found on path: \
-          '#{@configuration.options.path}'\
-        """)
-        return callback(err, @stats)
-
       # remove duplicate filenames
       @configuration.files = removeDuplicates @configuration.files
       callback(null, @stats)

--- a/test/integration/cli/api-description-cli-test.coffee
+++ b/test/integration/cli/api-description-cli-test.coffee
@@ -268,7 +268,9 @@ describe 'CLI - API Description Document', ->
           runtimeInfo = info
           done(err)
 
-      it 'should request /machines', ->
-        assert.deepEqual runtimeInfo.server.requestCounts, {'/machines': 1}
-      it 'should exit with status 0', ->
-        assert.equal runtimeInfo.dredd.exitStatus, 0
+      it 'should not request server', ->
+        assert.isFalse runtimeInfo.server.requested
+      it 'should exit with status 1', ->
+        assert.equal runtimeInfo.dredd.exitStatus, 1
+      it 'should print error message to stderr', ->
+        assert.include runtimeInfo.dredd.stderr, 'not found'

--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -211,6 +211,37 @@ describe 'addHooks(runner, transactions, callback)', () ->
 
         done()
 
+    describe 'when the hook file(s) doesn\'t exist', () ->
+      describe 'for all hook files', () ->
+        it 'should return an error', (done) ->
+          runner =
+            configuration:
+              options:
+                hookfiles: './**/*_hooks.balony'
+          addHooks runner, transactions, (error) ->
+            assert.isOk error
+            done()
+          
+      describe 'for some hook files', () ->
+        it 'should return an error', (done) ->
+          runner =
+            configuration:
+              options:
+                hookfiles: ['./**/*_hooks.coffee', './**/*_hooks.balony']
+          addHooks runner, transactions, (error) ->
+            assert.isOk error
+            done()
+          
+      describe 'for a single hook file', () ->
+        it 'should return an error', (done) ->
+          runner =
+            configuration:
+              options:
+                hookfiles: './test/fixtures/balony_hooks.balony'
+          addHooks runner, transactions, (error) ->
+            assert.isOk error
+            done()
+          
 
     describe 'when files are valid js/coffeescript', () ->
       runner = null

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -113,7 +113,7 @@ describe 'Dredd class', ->
           server: 'http://127.0.0.1:3000/'
           options:
             silent: true
-            path: ['./test/fixtures/multifile/*.apib', './test/fixtures/multifile/*.apib' ,'./test/fixtures/multifile/*.balony']
+            path: ['./test/fixtures/multifile/*.apib', './test/fixtures/multifile/*.apib']
         dredd = new Dredd(configuration)
 
       beforeEach ->
@@ -134,7 +134,6 @@ describe 'Dredd class', ->
         dredd.run (error) ->
           return done error if error
           assert.notInclude dredd.configuration.files, './test/fixtures/multifile/*.apib'
-          assert.notInclude dredd.configuration.files, './test/fixtures/multifile/*.balony'
           done()
 
       it 'should load file contents on paths to config', (done) ->
@@ -154,6 +153,28 @@ describe 'Dredd class', ->
           assert.property dredd.configuration.data['./test/fixtures/multifile/greeting.apib'], 'annotations'
           assert.property dredd.configuration.data['./test/fixtures/multifile/greeting.apib'], 'filename'
           assert.property dredd.configuration.data['./test/fixtures/multifile/greeting.apib'], 'raw'
+          done()
+
+
+    describe 'when a glob pattern does not match any files and another does', ->
+      before ->
+        configuration =
+          server: 'http://127.0.0.1:3000/'
+          options:
+            silent: true
+            path: ['./test/fixtures/multifile/*.balony', './test/fixtures/multifile/*.apib']
+        dredd = new Dredd(configuration)
+
+      beforeEach ->
+        sinon.stub(dredd.runner, 'executeTransaction').callsFake (transaction, hooks, callback) ->
+          callback()
+
+      afterEach ->
+        dredd.runner.executeTransaction.restore()
+
+      it 'should return error', (done) ->
+        dredd.run (error) ->
+          assert.isOk error
           done()
 
 


### PR DESCRIPTION
#### :rocket: Why this change?

It seems that dredd doesn't show an error when there is a path that doesn't exist which is not the expected behavior.

#### :memo: Related issues and Pull Requests

Fixes https://github.com/apiaryio/dredd/issues/378

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
