### PR TITLE
Non obvious link added to the docs for swagger

### DIFF
--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -535,6 +535,9 @@ API Blueprint format supports `multipart/form-data` media type and so does Dredd
 
 > **Note:** For details on this topic see also [How Dredd Works With HTTP Transactions](how-it-works.md#how-dredd-works-with-http-transactions).
 
+> **Note:** For details multiple requests in swagger format see [Testing Non-2xx Responses with swagger](how-to-guides.md#testing-non-2xx-responses-with-swagger).
+
+
 To test multiple requests and responses within one action in Dredd, you need to cluster them into pairs:
 
 ```apiblueprint


### PR DESCRIPTION
#### :rocket: Why this change?

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
