### PR TITLE
Make sure addHooks() tests don't match unexpected stuff

### DIFF
--- a/test/unit/add-hooks-test.coffee
+++ b/test/unit/add-hooks-test.coffee
@@ -115,7 +115,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
       runner =
         configuration:
           options:
-            hookfiles: './**/*_hooks.*'
+            hookfiles: './test/**/*_hooks.*'
 
     it 'should return files', (done) ->
       sinon.spy globStub, 'sync'
@@ -129,7 +129,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
       runner =
         configuration:
           options:
-            hookfiles: ['./**/*_hooks.*', '/baz/x.js', '/foo/y.js', '/bar/z.js', '/foo/a.js', '/bar/b.js', '/baz/c.js', '/foo/o.js', '/bar/p.js']
+            hookfiles: ['./test/**/*_hooks.*', '/baz/x.js', '/foo/y.js', '/bar/z.js', '/foo/a.js', '/bar/b.js', '/baz/c.js', '/foo/o.js', '/bar/p.js']
 
       addHooks runner, transactions, (err) ->
         return done err if err
@@ -194,7 +194,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
       runner =
         configuration:
           options:
-            hookfiles: ['foo/bar/hooks', './**/*_hooks.*']
+            hookfiles: ['foo/bar/hooks', './test/**/*_hooks.*']
 
       addHooks runner, transactions, (err) ->
         return done err if err
@@ -218,7 +218,7 @@ describe 'addHooks(runner, transactions, callback)', () ->
         runner =
           configuration:
             options:
-              hookfiles: './**/*_hooks.*'
+              hookfiles: './test/**/*_hooks.*'
         sinon.stub(globStub, 'sync').callsFake (pattern) ->
           ['file1.js', 'file2.coffee']
         sinon.stub(pathStub, 'resolve').callsFake (path, rel) ->


### PR DESCRIPTION
#### :rocket: Why this change?

Sometimes I happen to have extraneous stuff in the repo, such as [virtualenv](https://docs.python.org/3/library/venv.html). It can contain basically anything. The tests are so vague they can match anything 🙂 Let's make them more specific.

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
