### PR TITLE
Use GOPATH if GOBIN isn't set

### DIFF
--- a/src/get-go-bin.coffee
+++ b/src/get-go-bin.coffee
@@ -1,0 +1,24 @@
+path = require('path')
+childProcess = require('child_process')
+
+
+# Docs:
+# - https://golang.org/doc/code.html#GOPATH
+# - https://golang.org/cmd/go/#hdr-GOPATH_environment_variable
+getGoBin = (callback) ->
+  goBin = process.env.GOBIN
+  if goBin
+    process.nextTick( -> callback(null, goBin))
+  else
+    if process.env.GOPATH
+      process.nextTick( ->
+        callback(null, path.join(process.env.GOPATH, 'bin'))
+      )
+    else
+      childProcess.exec('go env GOPATH', (err, stdout) ->
+        return callback(err) if err
+        callback(null, path.join(stdout.trim(), 'bin'))
+      )
+
+
+module.exports = getGoBin

--- a/src/hooks-worker-client.coffee
+++ b/src/hooks-worker-client.coffee
@@ -139,21 +139,28 @@ class HooksWorkerClient
       # If the GOBIN environment variable is set, commands are installed to the
       # directory it names instead of DIR/bin. GOBIN must be an absolute path."
       # Use the gobin if provided, otherwise fall back to gopath
-      gobin = process.env.GOBIN
-      if !gobin
-        gobin = "#{process.env.GOPATH}/bin"
-
-      @handlerCommand = "#{gobin}/goodman"
-      @handlerCommandArgs = []
-      unless which.which @handlerCommand
-        msg = '''\
-          Go hooks handler command not found in $GOBIN or $GOPATH/bin
-          Install go hooks handler by running:
-          $ go get github.com/snikch/goodman/cmd/goodman
-        '''
-        return callback(new Error(msg))
-      else
-        callback()
+      {exec} = require 'child_process'
+      getGobin = (callback) ->
+        gobin = process.env.GOBIN
+        if !gobin
+          if process.env.GOPATH
+            gobin = "#{process.env.GOPATH}/bin"
+          else
+            exec "go env GOPATH", (error, stdout, stderr) -> callback "#{stdout.trim()}/bin"
+            return
+        callback gobin
+      getGobin (gobin) => 
+        @handlerCommand = "#{gobin}/goodman"
+        @handlerCommandArgs = []
+        unless which.which @handlerCommand
+          msg = '''\
+            Go hooks handler command not found in $GOBIN or $GOPATH/bin
+            Install go hooks handler by running:
+            $ go get github.com/snikch/goodman/cmd/goodman
+          '''
+          return callback(new Error(msg))
+        else
+          callback()
     else
       parsedArgs = spawnArgs(@language)
       @handlerCommand = parsedArgs.shift()

--- a/test/unit/get-go-bin-test.coffee
+++ b/test/unit/get-go-bin-test.coffee
@@ -1,5 +1,6 @@
 {assert} = require('chai')
 sinon = require('sinon')
+path = require('path')
 childProcess = require('child_process')
 
 getGoBin = require('../../src/get-go-bin')
@@ -24,7 +25,7 @@ describe('getGoBin()', ->
     callbackArgs = undefined
 
     beforeEach((done) ->
-      process.env.GOBIN = '/dummy/gobin/path'
+      process.env.GOBIN = path.join('dummy', 'gobin', 'path')
       getGoBin((args...) ->
         callbackArgs = args
         done()
@@ -32,7 +33,7 @@ describe('getGoBin()', ->
     )
 
     it('resolves as $GOBIN', ->
-      assert.deepEqual(callbackArgs, [null, '/dummy/gobin/path'])
+      assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gobin', 'path')])
     )
   )
 
@@ -40,7 +41,7 @@ describe('getGoBin()', ->
     callbackArgs = undefined
 
     beforeEach((done) ->
-      process.env.GOPATH = '/dummy/gopath/path'
+      process.env.GOPATH = path.join('dummy', 'gopath', 'path')
       getGoBin((args...) ->
         callbackArgs = args
         done()
@@ -48,7 +49,7 @@ describe('getGoBin()', ->
     )
 
     it('resolves as $GOPATH + /bin', ->
-      assert.deepEqual(callbackArgs, [null, '/dummy/gopath/path/bin'])
+      assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gopath', 'path', 'bin')])
     )
   )
 
@@ -56,8 +57,8 @@ describe('getGoBin()', ->
     callbackArgs = undefined
 
     beforeEach((done) ->
-      process.env.GOBIN = '/dummy/gobin/path'
-      process.env.GOPATH = '/dummy/gopath/path'
+      process.env.GOBIN = path.join('dummy', 'gobin', 'path')
+      process.env.GOPATH = path.join('dummy', 'gopath', 'path')
       getGoBin((args...) ->
         callbackArgs = args
         done()
@@ -65,7 +66,7 @@ describe('getGoBin()', ->
     )
 
     it('resolves as $GOBIN', ->
-      assert.deepEqual(callbackArgs, [null, '/dummy/gobin/path'])
+      assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gobin', 'path')])
     )
   )
 
@@ -74,7 +75,7 @@ describe('getGoBin()', ->
 
     beforeEach((done) ->
       sinon.stub(childProcess, 'exec').callsFake((command, callback) ->
-        callback(null, '/dummy/gopath/path')
+        callback(null, path.join('dummy', 'gopath', 'path'))
       )
       getGoBin((args...) ->
         callbackArgs = args
@@ -86,7 +87,7 @@ describe('getGoBin()', ->
     )
 
     it('calls \'go env GOPATH\' + /bin', ->
-      assert.deepEqual(callbackArgs, [null, '/dummy/gopath/path/bin'])
+      assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gopath', 'path', 'bin')])
     )
   )
 

--- a/test/unit/get-go-bin-test.coffee
+++ b/test/unit/get-go-bin-test.coffee
@@ -1,0 +1,114 @@
+{assert} = require('chai')
+sinon = require('sinon')
+childProcess = require('child_process')
+
+getGoBin = require('../../src/get-go-bin')
+
+
+describe('getGoBin()', ->
+  goBin = undefined
+  goPath = undefined
+
+  beforeEach( ->
+    goBin = process.env.GOBIN
+    delete process.env.GOBIN
+    goPath = process.env.GOPATH
+    delete process.env.GOPATH
+  )
+  afterEach( ->
+    process.env.GOBIN = goBin
+    process.env.GOPATH = goPath
+  )
+
+  describe('when $GOBIN is set', ->
+    callbackArgs = undefined
+
+    beforeEach((done) ->
+      process.env.GOBIN = '/dummy/gobin/path'
+      getGoBin((args...) ->
+        callbackArgs = args
+        done()
+      )
+    )
+
+    it('resolves as $GOBIN', ->
+      assert.deepEqual(callbackArgs, [null, '/dummy/gobin/path'])
+    )
+  )
+
+  describe('when $GOPATH is set', ->
+    callbackArgs = undefined
+
+    beforeEach((done) ->
+      process.env.GOPATH = '/dummy/gopath/path'
+      getGoBin((args...) ->
+        callbackArgs = args
+        done()
+      )
+    )
+
+    it('resolves as $GOPATH + /bin', ->
+      assert.deepEqual(callbackArgs, [null, '/dummy/gopath/path/bin'])
+    )
+  )
+
+  describe('when both $GOBIN and $GOPATH are set', ->
+    callbackArgs = undefined
+
+    beforeEach((done) ->
+      process.env.GOBIN = '/dummy/gobin/path'
+      process.env.GOPATH = '/dummy/gopath/path'
+      getGoBin((args...) ->
+        callbackArgs = args
+        done()
+      )
+    )
+
+    it('resolves as $GOBIN', ->
+      assert.deepEqual(callbackArgs, [null, '/dummy/gobin/path'])
+    )
+  )
+
+  describe('when neither $GOBIN nor $GOPATH are set', ->
+    callbackArgs = undefined
+
+    beforeEach((done) ->
+      sinon.stub(childProcess, 'exec').callsFake((command, callback) ->
+        callback(null, '/dummy/gopath/path')
+      )
+      getGoBin((args...) ->
+        callbackArgs = args
+        done()
+      )
+    )
+    afterEach( ->
+      childProcess.exec.restore()
+    )
+
+    it('calls \'go env GOPATH\' + /bin', ->
+      assert.deepEqual(callbackArgs, [null, '/dummy/gopath/path/bin'])
+    )
+  )
+
+  describe('when \'go env GOPATH\' fails', ->
+    error = new Error('Ouch!')
+    callbackArgs = undefined
+
+    beforeEach((done) ->
+      sinon.stub(childProcess, 'exec').callsFake((command, callback) ->
+        callback(error)
+      )
+      getGoBin((args...) ->
+        callbackArgs = args
+        done()
+      )
+    )
+    afterEach( ->
+      childProcess.exec.restore()
+    )
+
+    it('propagates the error', ->
+      assert.deepEqual(callbackArgs, [error])
+    )
+  )
+)

--- a/test/unit/hooks-worker-client-test.coffee
+++ b/test/unit/hooks-worker-client-test.coffee
@@ -372,12 +372,13 @@ describe 'Hooks worker client', ->
           done()
 
     describe 'when --language=go option is given and the worker is installed', ->
+      dummyPath = path.join('dummy', 'gobin', 'path')
       goBin = undefined
       goPath = undefined
       beforeEach ->
         goBin = process.env.GOBIN
         goPath = process.env.GOPATH
-        process.env.GOBIN = '/dummy/gobin/path'
+        process.env.GOBIN = dummyPath
         delete process.env.GOPATH
 
         sinon.stub(crossSpawnStub, 'spawn').callsFake( ->


### PR DESCRIPTION
#### :rocket: Why this change?

According to Go docs, the following cascade should be the correct way to determine where to look for the binaries:

- $GOBIN
- $GOPATH/bin
- $(go env GOPATH)/bin

Review from @ddelnano / @snikch appreciated. I'm also adding all the Go fans I know as reviewers, because I'm not really skilled in Go at all.

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/pull/835

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
