### PR TITLE
Pin CoffeeScript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "caseless": "^0.12.0",
     "chai": "^4.0.2",
     "clone": "^2.1.1",
-    "coffee-script": "^1.12.5",
+    "coffee-script": "1.12.6",
     "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
     "dredd-transactions": "5.0.0",


### PR DESCRIPTION
#### :rocket: Why this change?

Prevents https://github.com/jashkenas/coffeescript/issues/4806. I raised the patch number to be aligned with what was previously in Dredd Transactions.

#### :white_check_mark: What didn't I forget?

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
