### PR TITLE
Fix typo on the installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ In case of compilation errors, Dredd automatically uses a less performant soluti
 The installation process features compilation of some C++ components, which may take some time ([learn more about this][C++11 vs JS]). You can simplify and speed up the process using `npm install -g dredd --no-optional` if you are:
 
 - using Dredd exclusively with [Swagger][],
-- using Dredd with small [API Bluepint][] files,
+- using Dredd with small [API Blueprint][] files,
 - using Dredd on Windows or other environments with complicated C++11 compiler setup.
 
 The `--no-optional` option avoids any compilation attempts when installing Dredd, but causes slower reading of the API Blueprint files, especially the large ones.


### PR DESCRIPTION
#### :rocket: Why this change?

The typo breaks a link.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
