### PR TITLE
Print reporter errors, but do not treat them as fatal

### DIFF
--- a/src/dredd.coffee
+++ b/src/dredd.coffee
@@ -214,24 +214,19 @@ class Dredd
 
   # start the runner
   emitStart: (callback) ->
-    # dredd can have registered more than one reporter
+    # more than one reporter is supported
     reporterCount = @configuration.emitter.listeners('start').length
 
-    # atomic state shared between reporters
-    reporterErrorOccurred = false
+    # when event 'start' is emitted, function in callback is executed for each
+    # reporter registered by listeners
+    @configuration.emitter.emit('start', @configuration.data, (reporterError) =>
+      logger.error(reporterError.message) if reporterError
 
-    # when event start is emitted, function in callback is executed for each registered reporter by listeners
-    @configuration.emitter.emit 'start', @configuration.data, (reporterError) =>
+      # last called reporter callback function starts the runner
       reporterCount--
-
-      # if any error in one of reporters occurres, callback is called and other reporters are not executed
-      if reporterError and reporterErrorOccurred is false
-        reporterErrorOccurred = true
-        return callback(reporterError, @stats)
-
-      # # last called reporter callback function starts the runner
-      if reporterCount is 0 and reporterErrorOccurred is false
-        callback null, @stats
+      if reporterCount is 0
+        callback(null, @stats)
+    )
 
   startRunner: (callback) ->
     # run all transactions

--- a/src/reporters/apiary-reporter.coffee
+++ b/src/reporters/apiary-reporter.coffee
@@ -192,6 +192,7 @@ class ApiaryReporter
       try
         parsedBody = JSON.parse(resBody)
       catch err
+        @serverError = true
         err = new Error("""\
           Apiary reporter failed to parse Apiary API response body: \
           #{err.message}\n#{resBody}\
@@ -227,6 +228,7 @@ class ApiaryReporter
       logger.debug('Request details:', JSON.stringify({options, body}, null, 2))
       request(options, handleRequest)
     catch error
+      @serverError = true
       logger.debug('Requesting Apiary API errored:', error)
       return callback(error)
 

--- a/test/integration/cli/api-blueprint-cli-test.coffee
+++ b/test/integration/cli/api-blueprint-cli-test.coffee
@@ -5,9 +5,9 @@
 
 describe 'CLI - API Blueprint Document', ->
 
-  describe 'When loaded from file', ->
+  describe 'when loaded from file', ->
 
-    describe 'When successfully loaded', ->
+    describe 'when successfully loaded', ->
       runtimeInfo = undefined
       args = ['./test/fixtures/single-get.apib', "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"]
 
@@ -25,7 +25,7 @@ describe 'CLI - API Blueprint Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When API Blueprint is loaded with errors', ->
+    describe 'when API Blueprint is loaded with errors', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/error-blueprint.apib'
@@ -43,7 +43,7 @@ describe 'CLI - API Blueprint Document', ->
       it 'should print error message to stderr', ->
         assert.include runtimeInfo.dredd.stderr, 'Error when processing API description'
 
-    describe 'When API Blueprint is loaded with warnings', ->
+    describe 'when API Blueprint is loaded with warnings', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/warning-blueprint.apib'

--- a/test/integration/cli/api-description-cli-test.coffee
+++ b/test/integration/cli/api-description-cli-test.coffee
@@ -10,9 +10,9 @@ NON_EXISTENT_PORT = DEFAULT_SERVER_PORT + 1
 
 describe 'CLI - API Description Document', ->
 
-  describe 'When loaded from file', ->
+  describe 'when loaded from file', ->
 
-    describe 'When loaded by glob pattern', ->
+    describe 'when loaded by glob pattern', ->
       runtimeInfo = undefined
       args = ['./test/fixtures/single-g*t.apib', "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"]
 
@@ -30,7 +30,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When file not found', ->
+    describe 'when file not found', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/__non-existent__.apib'
@@ -48,7 +48,7 @@ describe 'CLI - API Description Document', ->
       it 'should print error message to stderr', ->
         assert.include runtimeInfo.dredd.stderr, 'not found'
 
-    describe 'When given path exists, but can\'t be read', ->
+    describe 'when given path exists, but can\'t be read', ->
       runtimeInfo = undefined
       args = [
         os.homedir(),
@@ -67,9 +67,9 @@ describe 'CLI - API Description Document', ->
         assert.include runtimeInfo.dredd.stderr, 'Error when reading file'
 
 
-  describe 'When loaded from URL', ->
+  describe 'when loaded from URL', ->
 
-    describe 'When successfully loaded from URL', ->
+    describe 'when successfully loaded from URL', ->
       runtimeInfo = undefined
       args = [
         "http://127.0.0.1:#{DEFAULT_SERVER_PORT}/single-get.apib"
@@ -96,7 +96,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When URL points to non-existent server', ->
+    describe 'when URL points to non-existent server', ->
       runtimeInfo = undefined
       args = [
         "http://127.0.0.1:#{NON_EXISTENT_PORT}/single-get.apib"
@@ -118,7 +118,7 @@ describe 'CLI - API Description Document', ->
         assert.include runtimeInfo.dredd.stderr, 'Is the provided URL correct?'
         assert.include runtimeInfo.dredd.stderr, "http://127.0.0.1:#{NON_EXISTENT_PORT}/single-get.apib"
 
-    describe 'When URL points to non-existent resource', ->
+    describe 'when URL points to non-existent resource', ->
       runtimeInfo = undefined
       args = [
         "http://127.0.0.1:#{DEFAULT_SERVER_PORT}/__non-existent__.apib"
@@ -144,9 +144,9 @@ describe 'CLI - API Description Document', ->
         assert.include runtimeInfo.dredd.stderr, "http://127.0.0.1:#{DEFAULT_SERVER_PORT}/__non-existent__.apib"
 
 
-  describe 'When loaded by -p/--path', ->
+  describe 'when loaded by -p/--path', ->
 
-    describe 'When loaded from file', ->
+    describe 'when loaded from file', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/single-get.apib'
@@ -170,7 +170,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When loaded from URL', ->
+    describe 'when loaded from URL', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/single-get-uri-template.apib'
@@ -200,7 +200,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When used multiple times', ->
+    describe 'when used multiple times', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/single-get.apib'
@@ -227,7 +227,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When loaded by glob pattern', ->
+    describe 'when loaded by glob pattern', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/single-get.apib'
@@ -251,7 +251,7 @@ describe 'CLI - API Description Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When additional file not found', ->
+    describe 'when additional file not found', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/single-get.apib'

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -274,12 +274,12 @@ describe 'CLI - Reporters', ->
       assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output1__.xml"
       assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output2__.xml"
 
-  describe 'When -o/--output is used to specify output file but directory is not existent', ->
+  describe 'when -o/--output is used to specify output file but directory is not existent', ->
     dreddCommandInfo = undefined
     args = [
       './test/fixtures/single-get.apib'
       "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
-      '--reporter=junit'
+      '--reporter=xunit'
       '--output=./__test_directory/__test_file_output__.xml'
     ]
 
@@ -298,3 +298,35 @@ describe 'CLI - Reporters', ->
 
     it 'should create given file', ->
       assert.isOk fs.existsSync "#{process.cwd()}/__test_directory/__test_file_output__.xml"
+
+  describe('when the \'apiary\' reporter fails', ->
+    apiaryApiUrl = undefined
+    dreddCommandInfo = undefined
+    args = [
+      './test/fixtures/single-get.apib'
+      "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"
+      '--reporter=apiary'
+    ]
+
+    beforeEach((done) ->
+      apiaryApiUrl = process.env.APIARY_API_URL
+
+      nonExistentPort = DEFAULT_SERVER_PORT + 42
+      process.env.APIARY_API_URL = "http://127.0.0.1:#{nonExistentPort}"
+
+      runDreddCommand(args, (err, info) ->
+        dreddCommandInfo = info
+        done(err)
+      )
+    )
+    afterEach( ->
+      process.env.APIARY_API_URL = apiaryApiUrl
+    )
+
+    it('ends successfully', ->
+      assert.equal(dreddCommandInfo.exitStatus, 0)
+    )
+    it('prints error about Apiary API connection issues', ->
+      assert.include(dreddCommandInfo.stderr, 'Apiary reporter could not connect to Apiary API')
+    )
+  )

--- a/test/integration/cli/reporters-cli-test.coffee
+++ b/test/integration/cli/reporters-cli-test.coffee
@@ -27,7 +27,7 @@ describe 'CLI - Reporters', ->
     server.close(done)
 
 
-  describe 'When -r/--reporter is provided to use additional reporters', ->
+  describe 'when -r/--reporter is provided to use additional reporters', ->
     dreddCommandInfo = undefined
     args = [
       './test/fixtures/single-get.apib'
@@ -45,7 +45,7 @@ describe 'CLI - Reporters', ->
       assert.include dreddCommandInfo.stdout, '/\\_/\\'
 
 
-  describe 'When apiary reporter is used', ->
+  describe 'when apiary reporter is used', ->
     apiary = undefined
     apiaryRuntimeInfo = undefined
 
@@ -71,7 +71,7 @@ describe 'CLI - Reporters', ->
     afterEach (done) ->
       apiary.close(done)
 
-    describe 'When Dredd successfully performs requests to Apiary', ->
+    describe 'when Dredd successfully performs requests to Apiary', ->
       dreddCommandInfo = undefined
       stepRequest = undefined
       args = [
@@ -106,7 +106,7 @@ describe 'CLI - Reporters', ->
         assert.nestedProperty stepRequest.body, 'resultData.result.headers.validator'
         assert.nestedProperty stepRequest.body, 'resultData.result.statusCode.validator'
 
-    describe 'When hooks file uses hooks.log function for logging', ->
+    describe 'when hooks file uses hooks.log function for logging', ->
       dreddCommandInfo = undefined
       updateRequest = undefined
       stepRequest = undefined
@@ -172,7 +172,7 @@ describe 'CLI - Reporters', ->
           assert.isNumber stepRequest.body.startedAt
           assert.operator stepRequest.body.startedAt, '<=', updateRequest.body.logs[2].timestamp
 
-    describe 'When hooks file uses hooks.log function for logging and hooks are in sandbox mode', ->
+    describe 'when hooks file uses hooks.log function for logging and hooks are in sandbox mode', ->
       dreddCommandInfo = undefined
       updateRequest = undefined
       stepRequest = undefined
@@ -230,7 +230,7 @@ describe 'CLI - Reporters', ->
           assert.isNumber stepRequest.body.startedAt
           assert.operator stepRequest.body.startedAt, '<=', updateRequest.body.logs[1].timestamp
 
-  describe 'When -o/--output is used to specify output file', ->
+  describe 'when -o/--output is used to specify output file', ->
     dreddCommandInfo = undefined
     args = [
       './test/fixtures/single-get.apib'
@@ -250,7 +250,7 @@ describe 'CLI - Reporters', ->
     it 'should create given file', ->
       assert.isOk fs.existsSync "#{process.cwd()}/__test_file_output__.xml"
 
-  describe 'When -o/--output is used multiple times to specify output files', ->
+  describe 'when -o/--output is used multiple times to specify output files', ->
     dreddCommandInfo = undefined
     args = [
       './test/fixtures/single-get.apib'

--- a/test/integration/cli/server-process-cli-test.coffee
+++ b/test/integration/cli/server-process-cli-test.coffee
@@ -9,7 +9,7 @@ NON_EXISTENT_PORT = DEFAULT_SERVER_PORT + 1
 
 describe 'CLI - Server Process', ->
 
-  describe 'When specified by URL', ->
+  describe 'when specified by URL', ->
     server = undefined
     serverRuntimeInfo = undefined
 
@@ -30,7 +30,7 @@ describe 'CLI - Server Process', ->
       server.close(done)
 
 
-    describe 'When is running', ->
+    describe 'when is running', ->
       dreddCommandInfo = undefined
       args = ['./test/fixtures/single-get.apib', "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"]
 
@@ -44,7 +44,7 @@ describe 'CLI - Server Process', ->
       it 'should exit with status 0', ->
         assert.equal dreddCommandInfo.exitStatus, 0
 
-    describe 'When is not running', ->
+    describe 'when is not running', ->
       dreddCommandInfo = undefined
       args = ['./test/fixtures/apiary.apib', "http://127.0.0.1:#{NON_EXISTENT_PORT}"]
 
@@ -64,12 +64,12 @@ describe 'CLI - Server Process', ->
         assert.equal dreddCommandInfo.exitStatus, 1
 
 
-  describe 'When specified by -g/--server', ->
+  describe 'when specified by -g/--server', ->
 
     afterEach (done) ->
       killAll('test/fixtures/scripts/', done)
 
-    describe 'When works as expected', ->
+    describe 'when works as expected', ->
       dreddCommandInfo = undefined
       args = [
         './test/fixtures/single-get.apib'
@@ -90,7 +90,7 @@ describe 'CLI - Server Process', ->
       it 'should exit with status 0', ->
         assert.equal dreddCommandInfo.exitStatus, 0
 
-    describe 'When it fails to start', ->
+    describe 'when it fails to start', ->
       dreddCommandInfo = undefined
       args = [
         './test/fixtures/single-get.apib'
@@ -162,7 +162,7 @@ describe 'CLI - Server Process', ->
           it 'should exit with status 1', ->
             assert.equal dreddCommandInfo.exitStatus, 1
 
-    describe 'When didn\'t terminate and had to be killed by Dredd', ->
+    describe 'when didn\'t terminate and had to be killed by Dredd', ->
       dreddCommandInfo = undefined
       args = [
         './test/fixtures/single-get.apib'

--- a/test/integration/cli/swagger-cli-test.coffee
+++ b/test/integration/cli/swagger-cli-test.coffee
@@ -6,9 +6,9 @@ fs = require 'fs'
 
 describe 'CLI - Swagger Document', ->
 
-  describe 'When loaded from file', ->
+  describe 'when loaded from file', ->
 
-    describe 'When successfully loaded', ->
+    describe 'when successfully loaded', ->
       runtimeInfo = undefined
       args = ['./test/fixtures/single-get.yaml', "http://127.0.0.1:#{DEFAULT_SERVER_PORT}"]
 
@@ -26,7 +26,7 @@ describe 'CLI - Swagger Document', ->
       it 'should exit with status 0', ->
         assert.equal runtimeInfo.dredd.exitStatus, 0
 
-    describe 'When Swagger is loaded with errors', ->
+    describe 'when Swagger is loaded with errors', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/error-swagger.yaml'
@@ -44,7 +44,7 @@ describe 'CLI - Swagger Document', ->
       it 'should print error message to stderr', ->
         assert.include runtimeInfo.dredd.stderr, 'Error when processing API description'
 
-    describe 'When Swagger is loaded with warnings', ->
+    describe 'when Swagger is loaded with warnings', ->
       runtimeInfo = undefined
       args = [
         './test/fixtures/warning-swagger.yaml'

--- a/test/unit/dredd-test.coffee
+++ b/test/unit/dredd-test.coffee
@@ -601,8 +601,10 @@ describe 'Dredd class', ->
       PORT = 9876
       dredd = null
       apiaryServer = null
+      errorLogger = undefined
 
       beforeEach ->
+        errorLogger = sinon.spy(loggerStub, 'error')
         configuration =
           server: 'http://127.0.0.1:3000/'
           options:
@@ -617,13 +619,20 @@ describe 'Dredd class', ->
 
         dredd = new Dredd(configuration)
 
-      it 'should call the callback with error', (done) ->
+      afterEach ->
+        loggerStub.error.restore()
+
+      it 'should call the callback without the error', (done) ->
         callback = sinon.spy (error) ->
-          assert.isNotNull error
+          assert.isNull error
           assert.isOk callback.called
           done()
-
         dredd.emitStart callback
+
+      it 'should print the error', (done) ->
+        dredd.emitStart ->
+          assert.isTrue(errorLogger.called)
+          done()
 
   describe('#logProxySettings', ->
     verboseLogger = undefined


### PR DESCRIPTION
#### :rocket: Why this change?

Failure of reporters should not interfere with testing itself.

#### :memo: Related issues and Pull Requests

- Fixes https://github.com/apiaryio/dredd/issues/683

#### :white_check_mark: What didn't I forget?

- [ ] ~To write docs~
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
