### PR TITLE
chore: remove the unused dependency colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "chai": "^4.0.2",
     "clone": "^2.1.1",
     "coffee-script": "1.12.6",
-    "colors": "^1.1.2",
     "cross-spawn": "^5.0.1",
     "dredd-transactions": "5.0.3",
     "file": "^0.2.2",


### PR DESCRIPTION
#### :rocket: Why this change?

Looks like the only use of `colors` was removed in 91a4d585691fcc0a04fde06a491be9bbdc1dd073. Let's have one less dependency 🎉 

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
