### PR TITLE
CoffeeScript on NPM has moved to "coffeescript"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "caseless": "0.12.0",
     "chai": "4.0.2",
     "clone": "2.1.1",
-    "coffee-script": "1.12.6",
+    "coffeescript": "1.12.6",
     "cross-spawn": "5.0.1",
     "dredd-transactions": "5.0.4",
     "file": "0.2.2",

--- a/src/add-hooks.js
+++ b/src/add-hooks.js
@@ -1,4 +1,4 @@
-require('coffee-script/register');
+require('coffeescript/register');
 
 const async = require('async');
 const clone = require('clone');

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---compilers=coffee:coffee-script/register
+--compilers=coffee:coffeescript/register
 --reporter=test/reporter.js
 --timeout=120000
 --recursive


### PR DESCRIPTION
#### :rocket: Why this change?

It just remove a warning at dredd installation : `warning dredd > coffee-script@1.12.6: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)`
