### PR TITLE
Use "trusty" at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: "precise"
+dist: "trusty"
 language: "node_js"
 env:
   global:


### PR DESCRIPTION
#### :rocket: Why this change?

We should have been using `trusty` for a long time, but the tests has been flaky/failing - https://github.com/apiaryio/dredd/issues/828. Now I tried to address the issue and I discovered the tests are not failing anymore 🤷‍♂️ I'm not sure why exactly, but hey, let's rejoice and migrate to `trusty`!

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/issues/828

#### :white_check_mark: What didn't I forget?

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
