### PR TITLE
Fix reference to the OpenAPI Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ documentation.
 ### Supported API Description Formats
 
 - [API Blueprint][]
-- [Swagger][]
+- [OpenAPI (fka Swagger)](https://github.com/OAI/OpenAPI-Specification)
 
 ### Supported Hooks Languages
 


### PR DESCRIPTION
#### :rocket: Why this change?
The specification format formerly known as Swagger is now the OpenAPI Specification

#### :memo: Related issues and Pull Requests
None

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [ ] To write tests
- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`

Since this is a docs-only fix, no tests or linting required.