### PR TITLE
Generate request body for "format: uuid"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clone": "^2.1.1",
     "coffee-script": "1.12.6",
     "cross-spawn": "^5.0.1",
-    "dredd-transactions": "5.0.3",
+    "dredd-transactions": "5.0.4",
     "file": "^0.2.2",
     "fs-extra": "5.0.0",
     "gavel": "^1.1.1",


### PR DESCRIPTION
#### :rocket: Why this change?

The request body is not generated when ```format: uuid``` is present and there is no error message as of why. This has been fixed by https://github.com/apiaryio/fury-adapter-swagger/pull/156 (thanks, @kylef!).

#### :memo: Related issues and Pull Requests

Releases https://github.com/apiaryio/fury-adapter-swagger/pull/156
Fixes https://github.com/apiaryio/dredd/issues/941

#### :white_check_mark: What didn't I forget?

- [ ] ~~To write docs~~
- [ ] To write tests - I didn't write tests as the bug was in a dependency and should be tested there
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
