### PR TITLE
fix(reporters): Use correct context after faulty CoffeeScript conversion

### DIFF
--- a/src/reporters/html-reporter.js
+++ b/src/reporters/html-reporter.js
@@ -35,9 +35,7 @@ HtmlReporter.prototype.sanitizedPath = function (path) {
 };
 
 HtmlReporter.prototype.configureEmitter = function (emitter) {
-  function title(str) {
-    return `${Array(this.level).join('#')} ${str}`;
-  }
+  const title = str => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (rawBlueprint, callback) => {
     this.level++;

--- a/src/reporters/markdown-reporter.js
+++ b/src/reporters/markdown-reporter.js
@@ -34,9 +34,7 @@ MarkdownReporter.prototype.sanitizedPath = function (path) {
 };
 
 MarkdownReporter.prototype.configureEmitter = function (emitter) {
-  function title(str) {
-    return `${Array(this.level).join('#')} ${str}`;
-  }
+  const title = str => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (rawBlueprint, callback) => {
     this.level++;


### PR DESCRIPTION
#### :rocket: Why this change?

Both the html and markdown reporters are currently broken with `TypeError: Cannot read property 'level' of undefined at title`.

This is caused by a faulty coffeescript conversion where a fat arrow function was converted to a regular function without taking into effect that `@level`/`this.level` would then be broken.
Using an arrow functions brings back the old behavior.

#### :memo: Related issues and Pull Requests

-

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`