### PR TITLE
Update coffeescript to the latest of the 1.x.x series

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "caseless": "0.12.0",
     "chai": "4.0.2",
     "clone": "2.1.1",
-    "coffeescript": "1.12.6",
+    "coffeescript": "1.12.7",
     "cross-spawn": "5.0.1",
     "dredd-transactions": "6.0.1",
     "file": "0.2.2",


### PR DESCRIPTION
#### :rocket: Why this change?

Let's support the latest old CoffeeScript in the Dredd hooks. In the future, CoffeeScript should be removed from dependencies completely in favor of a different ways how to use transpiled languages in the hooks.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
