### PR TITLE
chore: Don't use the deprecated Buffer constructor

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -104,7 +104,7 @@ function applyConfiguration(config) {
   configuration.options.method = configuration.options.method.map(method => method.toUpperCase());
 
   if (configuration.options.user) {
-    const authHeader = `Authorization:Basic ${new Buffer(configuration.options.user).toString('base64')}`;
+    const authHeader = `Authorization:Basic ${Buffer.from(configuration.options.user).toString('base64')}`;
     configuration.options.header.push(authHeader);
   }
 

--- a/test/integration/cli/cli-test.js
+++ b/test/integration/cli/cli-test.js
@@ -338,7 +338,7 @@ describe('CLI', () => {
 
       it('should have an authorization header in the request', () => assert.isOk(runtimeInfo.server.requests['/machines'][0].headers.authorization));
 
-      it('should contain a base64 encoded string of the username and password', () => assert.isOk(runtimeInfo.server.requests['/machines'][0].headers.authorization === (`Basic ${new Buffer('username:password').toString('base64')}`)));
+      it('should contain a base64 encoded string of the username and password', () => assert.isOk(runtimeInfo.server.requests['/machines'][0].headers.authorization === (`Basic ${Buffer.from('username:password').toString('base64')}`)));
     });
 
 


### PR DESCRIPTION
#### :rocket: Why this change?

The `Buffer` constructor is deprecated (it will likely start throwing warnings in Node.js 10), instead `Buffer.{from|alloc|allocUnsafe}` should be used. 

Discussion of the API change: https://medium.com/@jasnell/node-js-buffer-api-changes-3c21f1048f97
Runtime deprecation planning: nodejs/node#19079

#### :memo: Related issues and Pull Requests

This is also preparation for #975.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`