### PR TITLE
fix: Update cross-spawn to 6.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chai": "4.1.2",
     "clone": "2.1.1",
     "coffeescript": "1.12.7",
-    "cross-spawn": "5.1.0",
+    "cross-spawn": "6.0.5",
     "dredd-transactions": "6.0.1",
     "file": "0.2.2",
     "fs-extra": "5.0.0",


### PR DESCRIPTION
#### :rocket: Why this change?

This release removed use of the deprecated Buffer constructor and will prevent a warning on Node.js 10.

#### :memo: Related issues and Pull Requests

- See #979 for removal of the use of the constructor in dredd itself
- moxystudio/node-cross-spawn#94 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
