### PR TITLE
Add Rust to the list

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -26,6 +26,7 @@ You can interact with your server implementation in following languages:
 - [PHP](hooks-php.md)
 - [Python](hooks-python.md)
 - [Ruby](hooks-ruby.md)
+- [Rust](hooks-rust.md)
 
 Dredd doesn't speak your language? [**It's very easy to write support for your language.**](hooks-new-language.md) Your contribution is more than welcome!
 


### PR DESCRIPTION
#### :rocket: Why this change?

Rust is supported for a long time already, but it's missing in this particular list.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
