### PR TITLE
Fix moved link

### DIFF
--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -119,7 +119,7 @@ This validation result is returned not only when validating against [JSON Schema
 <a name="textdiff-validation-result"></a>
 ## TextDiff Validation Result (string)
 
-Block of text which looks extremely similar to the standard GNU diff/patch format. Result of the [`patch_toText()` function of the `google-diff-match-patch` library](https://code.google.com/archive/p/google-diff-match-patch/wikis/API.wiki).
+Block of text which looks extremely similar to the standard GNU diff/patch format. Result of the [`patch_toText()` function of the `google-diff-match-patch` library](https://github.com/google/diff-match-patch/wiki/API#patch_totextpatches--text).
 
 <a name="gavel-error"></a>
 ## Gavel Error (object)


### PR DESCRIPTION
#### :rocket: Why this change?

The original docs has moved.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
