### PR TITLE
Remove some more usage of coffeescript

### DIFF
--- a/docs/usage-js.md
+++ b/docs/usage-js.md
@@ -24,7 +24,7 @@ numbers accumulated throughout the Dredd run.
 
 ### Configuration Object for Dredd Class
 
-Let's have a look at an example configuration first. (Please also see [options source](https://github.com/apiaryio/dredd/blob/master/src/options.coffee) to read detailed information about the `options` attributes).
+Let's have a look at an example configuration first. (Please also see [options source](https://github.com/apiaryio/dredd/blob/master/src/options.js) to read detailed information about the `options` attributes).
 
 ```javascript
 {

--- a/scripts/semantic-release.sh
+++ b/scripts/semantic-release.sh
@@ -6,8 +6,8 @@ SEMANTIC_RELEASE=./node_modules/.bin/semantic-release
 
 
 add_stable_dist_tag() {
-  PACKAGE_NAME=$(coffee -e 'console.log(require("./package.json").name)')
-  PACKAGE_VERSION=$(coffee -e 'console.log(require("./package.json").version)')
+  PACKAGE_NAME=$(node -e 'console.log(require("./package.json").name)')
+  PACKAGE_VERSION=$(node -e 'console.log(require("./package.json").version)')
 
   npm dist-tag add "$PACKAGE_NAME@$PACKAGE_VERSION" stable
   return $?

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---compilers=coffee:coffeescript/register
 --reporter=test/reporter.js
 --timeout=120000
 --recursive


### PR DESCRIPTION
#### :rocket: Why this change?

Slowly getting rid of some of the remaining references to coffeescript. This is just the first PR but the desired end result should be that it's only used for coffeescript hooks and nothing else. 

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [X] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`