### PR TITLE
Update to dredd-transactions 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clone": "2.1.1",
     "coffeescript": "1.12.7",
     "cross-spawn": "6.0.5",
-    "dredd-transactions": "6.1.0",
+    "dredd-transactions": "6.1.1",
     "file": "0.2.2",
     "fs-extra": "5.0.0",
     "gavel": "1.1.1",


### PR DESCRIPTION
This brings fury-adapter-swagger 0.18.3 over to Dredd (https://github.com/apiaryio/fury-adapter-swagger/pull/172)