### PR TITLE
Clean up Windows docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,19 +92,12 @@ The installation process features compilation of some C++ components, which may 
 
 The `--no-optional` option avoids any compilation attempts when installing Dredd, but causes slower reading of the API Blueprint files, especially the large ones.
 
-### Windows Support
-
-There are still [several known limitations][Windows Issues] when using Dredd on Windows, but the intention is to support it without any compromises. If you find any new issues, please [file them in the bug tracker][New Issue].
-
 
 [API Blueprint]: https://apiblueprint.org/
 [Swagger]: https://swagger.io/
 
 [CoffeeScript]: http://coffeescript.org/
 [CI]: how-to-guides.md#continuous-integration
-
-[Windows Issues]: https://github.com/apiaryio/dredd/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AWindows%20
-[New Issue]: https://github.com/apiaryio/dredd/issues/new
 
 [Homebrew]: https://brew.sh/
 [Node.js]: https://nodejs.org/en/

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,8 +10,6 @@ $ npm install -g dredd
 
 If you're not familiar with the Node.js ecosystem or you bump into any issues, follow the [installation guide](installation.md).
 
-**Note:** While Dredd seems to work on Windows for many users, it's not officially supported on the platform yet. See [details](installation.md#windows-support).
-
 ## Document Your API
 
 First, let's design the API we are about to build and test. That means you will need to create an API description file, which will document how your API should look like. Dredd supports two formats of API description documents:


### PR DESCRIPTION
#### :rocket: Why this change?

The sections are either misleading or not relevant anymore.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
