### PR TITLE
docs: add example of modifying multipart transaction request body prior to execution

### DIFF
--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -188,6 +188,25 @@ before("Machines > Machines collection > Get Machines", function (transaction) {
   transaction.request.body = JSON.stringify(requestBody);
 });
 ```
+### Modifying Multipart Transaction Request Body Prior to Execution
+
+```javascript
+const hooks = require('hooks');
+const Multipart = require('multi-part');
+const fs = require('fs');
+const streamToString = require('stream-to-string');
+
+var before = hooks.before;
+
+before("Machines > Machines collection > POST Machines", async function (transaction, done) {
+    const form = new Multipart();
+    form.append('title', 'Paykan Jvanan Gojeii');
+    form.append('photo', fs.createReadStream('./peykan.jpg'));
+    transaction.request.body = await streamToString(form.getStream());
+    transaction.request.headers['Content-Type'] = form.getHeaders()['content-type'];
+    done();
+});
+```
 
 ### Adding or Changing URI Query Parameters to All Requests
 


### PR DESCRIPTION
#### :rocket: Why this change?
shows an example for multi-part formdata requests modification on before hooks
#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
