### PR TITLE
Add example of modifying multipart request body

### DIFF
--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -189,6 +189,30 @@ before("Machines > Machines collection > Get Machines", function (transaction) {
 });
 ```
 
+### Modifying Multipart Transaction Request Body Prior to Execution
+
+Dependencies:
+- [multi-part](https://www.npmjs.com/package/multi-part)
+- [stream-to-string](https://www.npmjs.com/package/stream-to-string)
+
+```javascript
+const hooks = require('hooks');
+const fs = require('fs');
+const Multipart = require('multi-part');
+const streamToString = require('stream-to-string');
+
+var before = hooks.before;
+
+before("Machines > Machines collection > Create Machines", async function (transaction, done) {
+    const form = new Multipart();
+    form.append('title', 'Foo');
+    form.append('photo', fs.createReadStream('./bar.jpg'));
+    transaction.request.body = await streamToString(form.getStream());
+    transaction.request.headers['Content-Type'] = form.getHeaders()['content-type'];
+    done();
+});
+```
+
 ### Adding or Changing URI Query Parameters to All Requests
 
 ```javascript


### PR DESCRIPTION
#### :rocket: Why this change?

Shows an example for multi-part formdata requests modification on before hooks.

#### :memo: Related issues and Pull Requests

Closes https://github.com/apiaryio/dredd/pull/1015, an awesome contribution by @sajjad-shirazy. The commit here keeps his authorship. I'm only fixing commit message length, as otherwise the commit message linter gets upset 🙄 