### PR TITLE
fix: Update request

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "optimist": "0.6.1",
     "pitboss-ng": "0.3.3",
     "proxyquire": "2.0.0",
-    "request": "2.83.0",
+    "request": "2.86.0",
     "spawn-args": "0.2.0",
     "uuid": "3.2.1",
     "which": "1.3.0",


### PR DESCRIPTION
#### :rocket: Why this change?

There has been a security report for `stringstream` which is a dependency of the current `request` version: https://nodesecurity.io/advisories/664. 

The issue will probably not affect this issue, but it's nice to remove vulnerable packages from the tree.

npm audit report:
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Out-of-bounds Read                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ stringstream                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ No patch available                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ dredd [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ dredd > request > stringstream                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/664                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
