### PR TITLE
fix: update Gavel

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dredd-transactions": "6.1.3",
     "file": "0.2.2",
     "fs-extra": "5.0.0",
-    "gavel": "1.1.1",
+    "gavel": "^2.1.2",
     "glob": "7.1.2",
     "html": "1.0.0",
     "htmlencode": "0.0.4",


### PR DESCRIPTION
This updates Gavel to most recent release 2.1.2 which does not make use of the `git+https` protocol, since it not supported for old Git versions, and therefore blocking the use of Dredd on ci servers with old Git versions (Git 2.1.2 affected, but Git 2.3 is good)

Gavels update is a Major release, which is breaking because it stopped supporting Node 4. But since this project requires at least Node 6, we should be good.

More details found in https://github.com/apiaryio/gavel.js/pull/102
