### PR TITLE
Skip flaky CLI test

### DIFF
--- a/test/integration/cli/cli-test.js
+++ b/test/integration/cli/cli-test.js
@@ -163,7 +163,7 @@ describe('CLI', () => {
 
         after(done => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+        xit('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
 
         it('should return message announcing the fact', () => {
           if (process.platform === 'win32') {


### PR DESCRIPTION
#### :rocket: Why this change?
_"...when using language hook handler and spawning the server and handler is killed before execution should return with status 1"_ test is currently killing our builds on Windows, let's skip it until it is fixed.

#### :memo: Related issues and Pull Requests
https://github.com/apiaryio/dredd/issues/1030

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
