### PR TITLE
Remove commitizen

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "body-parser": "1.18.2",
     "conventional-changelog-lint": "1.1.9",
     "coveralls": "2.13.0",
-    "cz-conventional-changelog": "2.0.0",
     "drafter": "1.2.0",
     "ect": "0.5.9",
     "eslint": "4.4.1",
@@ -100,10 +99,5 @@
     "acceptance"
   ],
   "author": "Apiary Czech Republic, s.r.o. <support@apiary.io>",
-  "license": "MIT",
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
IMHO nobody uses this anyway. Semantic Release prefixes need to be enforced on CI level and reminded in Pull Requests. I think the commitizen config doesn't really help to solve any real issues and moreover it has some licensing issues.

Close https://github.com/apiaryio/dredd/issues/1049
