### PR TITLE
Fix flaky cli-test.js test case on Windows, round two

### DIFF
--- a/src/child-process.js
+++ b/src/child-process.js
@@ -1,5 +1,7 @@
 const crossSpawn = require('cross-spawn');
 
+const { ignorePipeErrors } = require('./common');
+
 const ASCII_CTRL_C = 3;
 const IS_WINDOWS = process.platform === 'win32';
 const TERM_FIRST_CHECK_TIMEOUT_MS = 1;
@@ -124,6 +126,12 @@ function terminate(childProcess, options = {}, callback) {
 
 const spawn = function (...args) {
   const childProcess = crossSpawn.spawn.apply(null, args);
+
+  // On Windows, killing stdin / stdout / stderr pipes intentionally
+  // on either side can result `uncaughtException` causing
+  // dredd main process exiting with exitCode 7 instead of 1. This _fix_
+  // remedies the issue.
+  ignorePipeErrors(childProcess);
 
   childProcess.spawned = true;
   childProcess.terminated = false;

--- a/src/child-process.js
+++ b/src/child-process.js
@@ -127,10 +127,6 @@ function terminate(childProcess, options = {}, callback) {
 const spawn = function (...args) {
   const childProcess = crossSpawn.spawn.apply(null, args);
 
-  // On Windows, killing stdin / stdout / stderr pipes intentionally
-  // on either side can result `uncaughtException` causing
-  // dredd main process exiting with exitCode 7 instead of 1. This _fix_
-  // remedies the issue.
   ignorePipeErrors(childProcess);
 
   childProcess.spawned = true;

--- a/src/child-process.js
+++ b/src/child-process.js
@@ -1,6 +1,6 @@
 const crossSpawn = require('cross-spawn');
 
-const { ignorePipeErrors } = require('./common');
+const ignorePipeErrors = require('./ignore-pipe-errors');
 
 const ASCII_CTRL_C = 3;
 const IS_WINDOWS = process.platform === 'win32';

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,7 @@
+function ignorePipeErrors(proc) {
+  proc.stdin.on('error', () => {});
+  proc.stdout.on('error', () => {});
+  proc.stderr.on('error', () => {});
+}
+
+module.exports = { ignorePipeErrors };

--- a/src/dredd-command.js
+++ b/src/dredd-command.js
@@ -32,11 +32,6 @@ class DreddCommand {
     if (!this.custom.argv || !Array.isArray(this.custom.argv)) {
       this.custom.argv = [];
     }
-
-    // Fixes https://github.com/apiaryio/dredd/issues/1030
-    process.stdin.on('error', (err) => {
-      logger.error(`Error in stdin: ${err}`);
-    });
   }
 
   setOptimistArgv() {

--- a/src/dredd-command.js
+++ b/src/dredd-command.js
@@ -315,10 +315,6 @@ ${packageData.name} v${packageData.version} \
     this.logDebuggingInfo(configurationForDredd);
     this.dreddInstance = this.initDredd(configurationForDredd);
 
-    // On Windows, killing stdin / stdout / stderr pipes intentionally
-    // on either side can result `uncaughtException` causing
-    // dredd main process exiting with exitCode 7 instead of 1. This _fix_
-    // remedies the issue.
     ignorePipeErrors(process);
 
     try {

--- a/src/dredd-command.js
+++ b/src/dredd-command.js
@@ -10,6 +10,7 @@ const Dredd = require('./dredd');
 const interactiveConfig = require('./interactive-config');
 const logger = require('./logger');
 const { applyLoggingOptions } = require('./configuration');
+const { ignorePipeErrors } = require('./common');
 const { spawn } = require('./child-process');
 
 const packageData = require('../package.json');
@@ -318,6 +319,12 @@ ${packageData.name} v${packageData.version} \
     const configurationForDredd = this.initConfig();
     this.logDebuggingInfo(configurationForDredd);
     this.dreddInstance = this.initDredd(configurationForDredd);
+
+    // On Windows, killing stdin / stdout / stderr pipes intentionally
+    // on either side can result `uncaughtException` causing
+    // dredd main process exiting with exitCode 7 instead of 1. This _fix_
+    // remedies the issue.
+    ignorePipeErrors(process);
 
     try {
       this.runServerAndThenDredd();

--- a/src/dredd-command.js
+++ b/src/dredd-command.js
@@ -7,10 +7,10 @@ const spawnSync = require('cross-spawn').sync;
 
 const configUtils = require('./config-utils');
 const Dredd = require('./dredd');
+const ignorePipeErrors = require('./ignore-pipe-errors');
 const interactiveConfig = require('./interactive-config');
 const logger = require('./logger');
 const { applyLoggingOptions } = require('./configuration');
-const { ignorePipeErrors } = require('./common');
 const { spawn } = require('./child-process');
 
 const packageData = require('../package.json');

--- a/src/ignore-pipe-errors.js
+++ b/src/ignore-pipe-errors.js
@@ -1,7 +1,9 @@
+// On Windows, killing stdin / stdout / stderr pipes intentionally
+// on either side can result `uncaughtException` causing
+// dredd main process exiting with exitCode 7 instead of 1. This _fix_
+// remedies the issue.
 module.exports = function ignorePipeErrors(proc) {
-  if (proc.stdin && proc.stdout && proc.stderr) {
-    proc.stdout.on('error', () => {});
-    proc.stderr.on('error', () => {});
-    proc.stdin.on('error', () => {});
-  }
+  if (proc.stdout) proc.stdout.on('error', () => {});
+  if (proc.stderr) proc.stderr.on('error', () => {});
+  if (proc.stdin) proc.stdin.on('error', () => {});
 };

--- a/src/ignore-pipe-errors.js
+++ b/src/ignore-pipe-errors.js
@@ -1,5 +1,7 @@
 module.exports = function ignorePipeErrors(proc) {
-  proc.stdin.on('error', () => {});
-  proc.stdout.on('error', () => {});
-  proc.stderr.on('error', () => {});
+  if (proc.stdin && proc.stdout && proc.stderr) {
+    proc.stdout.on('error', () => {});
+    proc.stderr.on('error', () => {});
+    proc.stdin.on('error', () => {});
+  }
 };

--- a/src/ignore-pipe-errors.js
+++ b/src/ignore-pipe-errors.js
@@ -1,7 +1,5 @@
-function ignorePipeErrors(proc) {
+module.exports = function ignorePipeErrors(proc) {
   proc.stdin.on('error', () => {});
   proc.stdout.on('error', () => {});
   proc.stderr.on('error', () => {});
-}
-
-module.exports = { ignorePipeErrors };
+};


### PR DESCRIPTION
#### :rocket: Why this change?
Flaky test ain't fun 👎, round two.

#### :memo: Related issues and Pull Requests
Fixes #1030

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs - N/A
- [ ] To write tests - N/A
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
