### PR TITLE
Remove gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![devDependency Status](https://david-dm.org/apiaryio/dredd/dev-status.svg)](https://david-dm.org/apiaryio/dredd?type=dev)
 [![Coverage Status](https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd)
 [![Known Vulnerabilities](https://snyk.io/test/npm/dredd/badge.svg)](https://snyk.io/test/npm/dredd)
-[![Join the chat at https://gitter.im/apiaryio/dredd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/apiaryio/dredd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ![Dredd - HTTP API Testing Framework](docs/_images/dredd.png?raw=true)
 


### PR DESCRIPTION
#### :rocket: Why this change?

There is no community in the Gitter channel, only occasional lonely souls. I go there very sparsely myself. Let's stop promote this support channel and let's focus on GitHub Issues. If there's need in the future, IRC or Slack would work better anyway.

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd/issues/519

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
