### PR TITLE
Lint docs and build them on Travis CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,7 @@ If you need the performance of the C++11 parser, but you are struggling to get i
 
 ### Supported Node.js Versions
 
-Given the [table with LTS schedule](https://github.com/nodejs/LTS), only versions marked as **Maintenance** or **Active** are supported, until their **Maintenance End**. The testing matrix of Dredd's CI builds must contain all currently supported versions and must not contain any unsupported versions. The same applies for the underlying libraries, such as [Dredd Transactions][] or [Gavel.js][].
+Given the [table with LTS schedule](https://github.com/nodejs/Release), only versions marked as **Maintenance** or **Active** are supported, until their **Maintenance End**. The testing matrix of Dredd's CI builds must contain all currently supported versions and must not contain any unsupported versions. The same applies for the underlying libraries, such as [Dredd Transactions][] or [Gavel.js][].
 
 In following files the latest supported Node.js version should be used:
 
@@ -147,7 +147,7 @@ Dredd is tested on the [AppVeyor][], a Windows-based CI. There are still [severa
 
 ### Linting
 
-Dredd uses [eslint][] to lint the JavaScript codebase. We are using [Airbnb's styleguide](https://github.com/airbnb/javascript) 
+Dredd uses [eslint][] to lint the JavaScript codebase. We are using [Airbnb's styleguide](https://github.com/airbnb/javascript)
 rules as a baseline with several rules disabled to allow us to have dirty
 post-decaffeinate code temporarily.
 
@@ -238,7 +238,7 @@ This is to be able to serve the same content also as
 [GitHub contributing guidelines][] when someone opens a Pull Request.
 
 [symbolic link]: https://en.wikipedia.org/wiki/Symbolic_link
-[contributing guidelines]: https://github.com/blog/1184-contributing-guidelines
+[GitHub contributing guidelines]: https://blog.github.com/2012-09-17-contributing-guidelines/
 
 ### Coverage
 
@@ -302,10 +302,10 @@ There is also one environment variable you could find useful:
 [Dredd Transactions]: https://github.com/apiaryio/dredd-transactions
 [Gavel.js]: https://github.com/apiaryio/gavel.js/
 
-[Semantic Versioning]: http://semver.org/
+[Semantic Versioning]: https://semver.org/
 [JavaScript (ES2015+)]: https://tc39.github.io/ecma262/
 [eslint]: https://eslint.org/
-[CoffeeScript]: http://coffeescript.org
+[CoffeeScript]: https://coffeescript.org
 [Coveralls]: https://coveralls.io/github/apiaryio/dredd
 [istanbul]: https://github.com/gotwarlost/istanbul
 [lcov-result-merger]: https://github.com/mweibel/lcov-result-merger
@@ -313,9 +313,9 @@ There is also one environment variable you could find useful:
 [Sphinx]: http://www.sphinx-doc.org/
 [ReadTheDocs]: https://readthedocs.org/
 [test coverage]: https://coveralls.io/github/apiaryio/dredd
-[Mocha]: http://mochajs.org/
+[Mocha]: https://mochajs.org/
 [Semantic Release]: https://github.com/semantic-release/semantic-release
-[Conventional Changelog]: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#user-content-commit-message-format
+[Conventional Changelog]: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#user-content--git-commit-guidelines
 [Commitizen CLI]: https://github.com/commitizen/cz-cli
 [md-two-spaces]: https://daringfireball.net/projects/markdown/syntax#p
 [AppVeyor]: https://www.appveyor.com/
@@ -336,7 +336,6 @@ There is also one environment variable you could find useful:
 [existing commits]: https://github.com/apiaryio/dredd/commits/master
 [docs]: https://github.com/apiaryio/dredd/tree/master/docs
 [GitHub Releases]: https://github.com/apiaryio/dredd/releases
-[GitHub contributing guidelines]: https://github.com/blog/1184-contributing-guidelines
 
 [upstream repository]: https://github.com/apiaryio/dredd
 [issues]: https://github.com/apiaryio/dredd/issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - stage: "quality checks & tests"
       env: "JOB=quality_checks"
       node_js: "8"
-      script: "npm run lint"
+      script: "npm run lint && npm run docs:lint"
     - node_js: "8"
       env: "JOB=docs_build_dry_run" # why dry run? because production build happens directly on ReadTheDocs infrastructure
       script: "npm run docs:build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 dist: "trusty"
 language: "node_js"
+addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
 env:
   global:
     # GH_TOKEN and NPM_TOKEN encrypted by 'travis encrypt' utility
@@ -13,12 +18,16 @@ before_install:
   # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
   - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
   - "npm -g install npm@5"
+  - "pip3 install --user -r docs/requirements.txt"
 install: "npm install --no-optional"
 jobs:
   include:
     - stage: "code/docs/commits quality checks"
       node_js: "8"
       script: "npm run lint"
+    - stage: "docs build dry run"
+      node_js: "8"
+      script: "npm run docs:build"
     - stage: "tests & code coverage"
       node_js: "6"
       script: "npm run test:coverage && npm run coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,18 @@ jobs:
   include:
     # stage 1, all following runs in parallel:
     - stage: "quality checks & tests"
+      env: "JOB=quality_checks"
       node_js: "8"
-      script: "npm run lint" # code, docs, commits quality checks
+      script: "npm run lint"
     - node_js: "8"
-      script: "npm run docs:build" # docs build dry run (production build happens directly on ReadTheDocs infrastructure)
+      env: "JOB=docs_build_dry_run" # why dry run? because production build happens directly on ReadTheDocs infrastructure
+      script: "npm run docs:build"
     - node_js: "6"
-      script: "npm run test:coverage && npm run coveralls" # node 6, tests & coverage,
+      env: "JOB=node6"
+      script: "npm run test:coverage && npm run coveralls"
     - node_js: "8"
-      script: "npm run test:coverage && npm run coveralls" # node 8, tests & coverage
+      env: "JOB=node8"
+      script: "npm run test:coverage && npm run coveralls"
 
     # stage 2
     - stage: "semantic release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ jobs:
     - stage: "semantic release"
       node_js: "8"
       script: "npm run semantic-release || true"
-      if: branch = master
+      if: fork = false AND branch = master AND type = push

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,19 @@ before_install:
 install: "npm install --no-optional"
 jobs:
   include:
-    - stage: "code/docs/commits quality checks"
+    # stage 1, all following runs in parallel:
+    - stage: "quality checks & tests"
       node_js: "8"
-      script: "npm run lint"
-    - stage: "docs build dry run"
-      node_js: "8"
-      script: "npm run docs:build"
-    - stage: "tests & code coverage"
-      node_js: "6"
-      script: "npm run test:coverage && npm run coveralls"
+      script: "npm run lint" # code, docs, commits quality checks
     - node_js: "8"
-      script: "npm run test:coverage && npm run coveralls"
+      script: "npm run docs:build" # docs build dry run (production build happens directly on ReadTheDocs infrastructure)
+    - node_js: "6"
+      script: "npm run test:coverage && npm run coveralls" # node 6, tests & coverage,
+    - node_js: "8"
+      script: "npm run test:coverage && npm run coveralls" # node 8, tests & coverage
+
+    # stage 2
     - stage: "semantic release"
       node_js: "8"
-      script: " npm run semantic-release || true"
+      script: "npm run semantic-release || true"
+      if: branch = master

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/n3ixfxh72qushyr4/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/dredd/branch/master)
 [![Dependency Status](https://david-dm.org/apiaryio/dredd.svg)](https://david-dm.org/apiaryio/dredd)
 [![devDependency Status](https://david-dm.org/apiaryio/dredd/dev-status.svg)](https://david-dm.org/apiaryio/dredd?type=dev)
+[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://dredd.readthedocs.io/en/latest/)
 [![Coverage Status](https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd)
 [![Known Vulnerabilities](https://snyk.io/test/npm/dredd/badge.svg)](https://snyk.io/test/npm/dredd)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,6 +161,13 @@ html_show_copyright = False
 # html_use_opensearch = ''
 
 
+# -- External links check -------------------------------------------------
+
+linkcheck_ignore = [
+    'https://crates.io/crates/dredd-hooks',  # https://github.com/sphinx-doc/sphinx/pull/5140
+]
+
+
 # -- Custom Extensions ----------------------------------------------------
 
 def setup(app):

--- a/docs/data-structures.md
+++ b/docs/data-structures.md
@@ -119,7 +119,7 @@ This validation result is returned not only when validating against [JSON Schema
 <a name="textdiff-validation-result"></a>
 ## TextDiff Validation Result (string)
 
-Block of text which looks extremely similar to the standard GNU diff/patch format. Result of the [`patch_toText()` function of the `google-diff-match-patch` library](https://github.com/google/diff-match-patch/wiki/API#patch_totextpatches--text).
+Block of text which looks extremely similar to the standard GNU diff/patch format. Result of the [`patch_toText()` function of the `google-diff-match-patch` library](https://github.com/google/diff-match-patch/wiki/API#user-content-patch_totextpatches--text).
 
 <a name="gavel-error"></a>
 ## Gavel Error (object)

--- a/docs/hooks-nodejs.md
+++ b/docs/hooks-nodejs.md
@@ -159,7 +159,7 @@ before("Machines > Machines collection > Get Machines", function (transaction) {
 
 ### Using Chai Assertions
 
-Inside hook files, you can require [Chai](http://chaijs.com/) and use its `assert`, `should` or `expect` interface in hooks and write your custom expectations. Dredd catches Chai's expectation error in hooks and makes transaction to fail.
+Inside hook files, you can require [Chai](http://www.chaijs.com/) and use its `assert`, `should` or `expect` interface in hooks and write your custom expectations. Dredd catches Chai's expectation error in hooks and makes transaction to fail.
 
 ```javascript
 var hooks = require('hooks');

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -225,7 +225,7 @@ Dredd intentionally **does not support HTTP(S) proxies for testing**. Proxy can 
 [request-proxies]: https://github.com/request/request#user-content-proxies
 
 [Apiary]: https://apiary.io/
-[Semantic Versioning]: http://semver.org/
+[Semantic Versioning]: https://semver.org/
 [API Blueprint]: https://apiblueprint.org/
 [Swagger]: https://swagger.io/
 [Gavel.js]: https://github.com/apiaryio/gavel.js

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/n3ixfxh72qushyr4/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/dredd/branch/master)
 [![Dependency Status](https://david-dm.org/apiaryio/dredd.svg)](https://david-dm.org/apiaryio/dredd)
 [![devDependency Status](https://david-dm.org/apiaryio/dredd/dev-status.svg)](https://david-dm.org/apiaryio/dredd?type=dev)
+[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://dredd.readthedocs.io/en/latest/)
 [![Coverage Status](https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd)
 [![Known Vulnerabilities](https://snyk.io/test/npm/dredd/badge.svg)](https://snyk.io/test/npm/dredd)
-[![Join the chat at https://gitter.im/apiaryio/dredd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/apiaryio/dredd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ![Dredd - HTTP API Testing Framework](_images/dredd.png)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,7 +96,7 @@ The `--no-optional` option avoids any compilation attempts when installing Dredd
 [API Blueprint]: https://apiblueprint.org/
 [Swagger]: https://swagger.io/
 
-[CoffeeScript]: http://coffeescript.org/
+[CoffeeScript]: https://coffeescript.org/
 [CI]: how-to-guides.md#continuous-integration
 
 [Homebrew]: https://brew.sh/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==1.5.6
-sphinx-autobuild==0.6.0
+sphinx-autobuild==0.7.1
 sphinx-rtd-theme==0.2.4
 recommonmark==0.4.0
 pygments-markdown-lexer==0.1.0.dev39

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:build": "sphinx-build -nW -b html docs docs/_build/",
     "docs:serve": "sphinx-autobuild docs docs/_build/",
     "docs:install": "pip install -r docs/requirements.txt",
-    "lint": "conventional-changelog-lint --from=master && eslint .",
+    "lint": "conventional-changelog-lint --from=master && eslint . && npm run docs:lint",
     "prepare": "npm run build",
     "pretest": "npm run build",
     "semantic-release": "scripts/semantic-release.sh",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "docs:lint": "sphinx-build -nW -b linkcheck docs docs/_build/",
     "docs:build": "sphinx-build -nW -b html docs docs/_build/",
     "docs:serve": "sphinx-autobuild docs docs/_build/",
-    "docs:install": "pip install -r docs/requirements.txt",
     "lint": "conventional-changelog-lint --from=master && eslint . && npm run docs:lint",
     "prepare": "npm run build",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:lint": "sphinx-build -nW -b linkcheck docs docs/_build/",
     "docs:build": "sphinx-build -nW -b html docs docs/_build/",
     "docs:serve": "sphinx-autobuild docs docs/_build/",
-    "lint": "conventional-changelog-lint --from=master && eslint . && npm run docs:lint",
+    "lint": "conventional-changelog-lint --from=master && eslint .",
     "prepare": "npm run build",
     "pretest": "npm run build",
     "semantic-release": "scripts/semantic-release.sh",


### PR DESCRIPTION
#### :rocket: Why this change?

Reverts #829. Since we have migrated the docs to Sphinx, there has been a plan to lint the docs and to build them on Travis CI as well to verify under Pull Requests that the docs can be built and there are no broken links.

This was implemented, but had to be removed as it wasn't possible to make it working on Travis CI with `nodejs` builds and Python 3. Now we're on `trusty` and it should be all good.

#### :memo: Related issues and Pull Requests

- follow-up to #829
- includes a workaround to https://github.com/sphinx-doc/sphinx/pull/5140/
- closes https://github.com/apiaryio/dredd/issues/610 (checker of broken links)
- closes https://github.com/apiaryio/dredd/issues/551

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] TO TEST THE DOCS! 🚀 
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
