### PR TITLE
Lock growl version to 1.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4820,9 +4820,9 @@
       "dev": true
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "gulp-sourcemaps": {
@@ -6235,7 +6235,7 @@
         "diff": "1.4.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.0.5",
-        "growl": "1.9.2",
+        "growl": "1.10.5",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",


### PR DESCRIPTION
#### :rocket: Why this change?
`mocha@3.0.0` is using `growl@1.9.2` as its dev dependency, which has critical security vulnerability (see `CVE-2017-16042` for more info). This commit remedies the issue by locking `growl` to version 1.10.5. Note that this change is considered as hotfix and we should update `mocha` version to the latest version.

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
