### PR TITLE
Use HTTPS in the docs shortened link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -167,7 +167,7 @@ about how it works.
 Dredd's documentation is written in [Markdown][] using [Sphinx][]. [ReadTheDocs][] is used to build and publish the documentation:
 
 - [https://dredd.readthedocs.io](https://dredd.readthedocs.io) - preferred long URL
-- [http://dredd.rtfd.org](http://dredd.rtfd.org) - preferred short URL
+- [https://dredd.rtfd.io](https://dredd.rtfd.io) - preferred short URL
 
 Source of the documentation can be found in the [docs][] directory. To render Dredd's documentation on your computer, you need Python 3 and Node.js installed.
 


### PR DESCRIPTION
#### :rocket: Why this change?

It's better and now it's even possible!

#### :memo: Related issues and Pull Requests

https://github.com/rtfd/readthedocs.org/issues/328

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
