### PR TITLE
Fix hanging test/unit/cli-test.js on Windows

### DIFF
--- a/test/unit/cli-test.js
+++ b/test/unit/cli-test.js
@@ -478,7 +478,7 @@ describe('CLI class', () => {
 
   describe('when using --server', () => {
     beforeEach((done) => {
-      sinon.spy(crossSpawnStub, 'spawn');
+      sinon.stub(crossSpawnStub, 'spawn').callsFake();
       sinon.stub(transactionRunner.prototype, 'executeAllTransactions').callsFake((transactions, hooks, cb) => cb());
       execCommand({ argv: [
         './test/fixtures/single-get.apib',


### PR DESCRIPTION
#### :rocket: Why this change?
This change prevents `'when using --server'` test case to hang on Windows. The issue was discovered when we tried to upgrade `mocha` to any version greater than 4, which disabled process force exit after all test ran (see https://github.com/mochajs/mocha/issues/2879 for more info).

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
