### PR TITLE
Document why no-underscore-dangle is off

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
     'no-param-reassign': 'off',
     'no-plusplus': 'off',
     'no-restricted-syntax': 'off',
-    'no-underscore-dangle': 'off',
+    'no-underscore-dangle': 'off', // https://github.com/apiaryio/dredd-transactions/pull/179#discussion_r206852270
     'no-use-before-define': 'off'
   }
 };


### PR DESCRIPTION
#### :rocket: Why this change?

Unlike other exceptions in ESLint config, which are to be treated as outstanding bugs to resolve, we decided we won't ever want to turn this one on. This PR documents the decision.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd-transactions/pull/179#discussion_r206852270
- https://github.com/apiaryio/dredd/pull/1094#discussion_r206821763

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
