### PR TITLE
Release a vulnerability fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# GH_TOKEN and NPM_TOKEN are expected to be set
+# in https://travis-ci.org/apiaryio/dredd/settings
 sudo: false
 dist: "trusty"
 language: "node_js"
@@ -6,10 +8,6 @@ addons:
     packages:
       - "python3"
       - "python3-pip"
-env:
-  global:
-    # GH_TOKEN and NPM_TOKEN encrypted by 'travis encrypt' utility
-    - secure: "gO5DrzOfF+l3hjvs0kLYUrGEnYVwrDy7NTGNrtPmLrrfdS6qmUNbTVggjra2aDM82lZYo0slZaOtjedSd8GMNE41egHAq0aGMJfhNrXjr+ROOIkc1BRUn3vTp5lk/n4eU7bLozoiriBphmKHHwZqekSn2orvIpAtoWL/JPVzheY="
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
#### :rocket: Why this change?

The https://github.com/apiaryio/dredd/pull/1110 fixed a vulnerability in Dredd's dependencies, but we did not classify the commits as a fix and thus it did not get released, leaving the latest Dredd version still vulnerable.

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd/pull/1110, #1107

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] ~To write docs~
- [ ] ~To write tests~
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
