### PR TITLE
Use https://dredd.org as the canonical URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@ Place an `x` between the square brackets on the lines below for every satisfied 
 
 - [ ] To write docs
 - [ ] To write tests
-- [ ] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
+- [ ] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ To report a bug, [open a new GitHub issue](https://github.com/apiaryio/dredd/iss
 
 ## 💬 Asking questions
 
-Before asking a question, please try to first search [Dredd's documentation](https://dredd.rtfd.io), [Apiary Help](https://help.apiary.io/).
+Before asking a question, please try to first search [Dredd's documentation](https://dredd.org), [Apiary Help](https://help.apiary.io/).
 
 You can always [contact Apiary Support](https://apiary.io/support), but we prefer if you ask publicly, because it allows to spread the knowledge across the community of all Dredd users:
 
@@ -39,13 +39,13 @@ The documentation is written [as code](http://www.writethedocs.org/guide/docs-as
 
 If you want to propose improvements to the documentation, you don't need to install the whole project. Usually it is just fine to use the [GitHub's editing features](https://github.com/apiaryio/dredd/edit/master/docs/installation.rst).
 
-When committing your changes, please use the [prefix your commit message](https://dredd.readthedocs.io/en/latest/internals.html#sem-rel) with `docs`:
+When committing your changes, please use the [prefix your commit message](https://dredd.org/en/latest/internals.html#sem-rel) with `docs`:
 
 ```
 docs: add more OpenAPI examples
 ```
 
-You can learn more about Dredd's codebase in the [Internals](https://dredd.readthedocs.io/en/latest/internals.html) section of the documentation.
+You can learn more about Dredd's codebase in the [Internals](https://dredd.org/en/latest/internals.html) section of the documentation.
 
 
 <a name="proposing-changes-to-code"></a>
@@ -56,12 +56,12 @@ Dredd is written in ES2015+ JavaScript and runs in [Node.js](https://nodejs.org/
 
 1.  [Fork Dredd](https://guides.github.com/activities/forking/)
 2.  Clone your fork on your computer
-3.  [Install Dredd for development](https://dredd.readthedocs.io/en/latest/internals.html#install-dev): `npm install`
+3.  [Install Dredd for development](https://dredd.org/en/latest/internals.html#install-dev): `npm install`
 4.  Create a feature branch
 5.  Write tests
 6.  Write code
-7.  Try your changes: `npm run build && ./bin/dredd` ([why the build?](https://dredd.readthedocs.io/en/latest/internals.html#programming-language))
-8.  When committing your changes, use the [Conventional Changelog](https://dredd.readthedocs.io/en/latest/internals.html#sem-rel) format for the commit message:
+7.  Try your changes: `npm run build && ./bin/dredd` ([why the build?](https://dredd.org/en/latest/internals.html#programming-language))
+8.  When committing your changes, use the [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) format for the commit message:
 
     ```
     fix: handle corner case situation
@@ -74,4 +74,4 @@ Dredd is written in ES2015+ JavaScript and runs in [Node.js](https://nodejs.org/
 11. Make sure your Pull Request is passing all tests and checks
 12. Make sure the [test coverage](https://coveralls.io/github/apiaryio/dredd) didn’t drop and all CI builds are passing
 
-You can learn more about Dredd's codebase in the [Internals](https://dredd.readthedocs.io/en/latest/internals.html) section of the documentation.
+You can learn more about Dredd's codebase in the [Internals](https://dredd.org/en/latest/internals.html) section of the documentation.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/n3ixfxh72qushyr4/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/dredd/branch/master)
 [![Dependency Status](https://david-dm.org/apiaryio/dredd.svg)](https://david-dm.org/apiaryio/dredd)
 [![devDependency Status](https://david-dm.org/apiaryio/dredd/dev-status.svg)](https://david-dm.org/apiaryio/dredd?type=dev)
-[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://dredd.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://dredd.org/en/latest/)
 [![Coverage Status](https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd)
 [![Known Vulnerabilities](https://snyk.io/test/npm/dredd/badge.svg)](https://snyk.io/test/npm/dredd)
 
@@ -29,17 +29,17 @@ documentation.
 
 ### Supported Hooks Languages
 
-Dredd supports writing [hooks](https://dredd.readthedocs.io/en/latest/hooks/)
+Dredd supports writing [hooks](https://dredd.org/en/latest/hooks/)
 — a glue code for each test setup and teardown. Following languages are supported:
 
-- [Go](https://dredd.readthedocs.io/en/latest/hooks-go/)
-- [Node.js (JavaScript)](https://dredd.readthedocs.io/en/latest/hooks-nodejs/)
-- [Perl](https://dredd.readthedocs.io/en/latest/hooks-perl/)
-- [PHP](https://dredd.readthedocs.io/en/latest/hooks-php/)
-- [Python](https://dredd.readthedocs.io/en/latest/hooks-python/)
-- [Ruby](https://dredd.readthedocs.io/en/latest/hooks-ruby/)
-- [Rust](https://dredd.readthedocs.io/en/latest/hooks-rust/)
-- Didn't find your favorite language? _[Add a new one!](https://dredd.readthedocs.io/en/latest/hooks-new-language/)_
+- [Go](https://dredd.org/en/latest/hooks-go/)
+- [Node.js (JavaScript)](https://dredd.org/en/latest/hooks-nodejs/)
+- [Perl](https://dredd.org/en/latest/hooks-perl/)
+- [PHP](https://dredd.org/en/latest/hooks-php/)
+- [Python](https://dredd.org/en/latest/hooks-python/)
+- [Ruby](https://dredd.org/en/latest/hooks-ruby/)
+- [Rust](https://dredd.org/en/latest/hooks-rust/)
+- Didn't find your favorite language? _[Add a new one!](https://dredd.org/en/latest/hooks-new-language/)_
 
 ### Supported Systems
 
@@ -93,9 +93,9 @@ $ npm install -g dredd
 [API Blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
 [Swagger]: https://swagger.io/
 
-[Documentation]: https://dredd.readthedocs.io/en/latest/
+[Documentation]: https://dredd.org/en/latest/
 [Changelog]: https://github.com/apiaryio/dredd/releases
-[Contributor's Guidelines]: https://dredd.readthedocs.io/en/latest/contributing/
+[Contributor's Guidelines]: https://dredd.org/en/latest/contributing/
 
 [Travis CI]: https://travis-ci.org/
 [CircleCI]: https://circleci.com/

--- a/docs/how-to-guides.rst
+++ b/docs/how-to-guides.rst
@@ -685,7 +685,7 @@ Command-line output of complex HTTP responses and expectations can be hard to re
 ::
 
    $ dredd apiary.apib http://127.0.0.1 --reporter=apiary
-   warn: Apiary API Key or API Project Subdomain were not provided. Configure Dredd to be able to save test reports alongside your Apiary API project: http://dredd.readthedocs.io/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
+   warn: Apiary API Key or API Project Subdomain were not provided. Configure Dredd to be able to save test reports alongside your Apiary API project: https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
    info: Beginning Dredd testing...
    pass: DELETE /honey duration: 884ms
    complete: 1 passing, 0 failing, 0 errors, 0 skipped, 1 total

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ Example Applications
 .. |devDependency Status| image:: https://david-dm.org/apiaryio/dredd/dev-status.svg
    :target: https://david-dm.org/apiaryio/dredd?type=dev
 .. |Documentation Status| image:: https://readthedocs.org/projects/dredd/badge/?version=latest
-   :target: https://dredd.readthedocs.io/en/latest/
+   :target: https://dredd.org/en/latest/
 .. |Coverage Status| image:: https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master
    :target: https://coveralls.io/github/apiaryio/dredd
 .. |Known Vulnerabilities| image:: https://snyk.io/test/npm/dredd/badge.svg

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -235,8 +235,7 @@ Contributing to documentation
 
 The documentation is written `as code <http://www.writethedocs.org/guide/docs-as-code/>`__ in the `reStructuredText <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`__ format and its source files are located in the `docs <https://github.com/apiaryio/dredd/tree/master/docs>`__ directory. It is published automatically by the `ReadTheDocs <https://readthedocs.org/>`__ when the ``master`` branch is updated.
 
--  https://dredd.readthedocs.io - preferred long URL
--  https://dredd.rtfd.io - preferred short URL
+Even though alternatives exist (dredd.readthedocs.io, dredd.rtfd.io, or dredd.io), the documentation should always be linked canonically as https://dredd.org.
 
 
 Building documentation locally

--- a/src/dredd.js
+++ b/src/dredd.js
@@ -66,7 +66,7 @@ class Dredd {
 HTTP(S) proxy specified by environment variables: \
 ${proxySettings.join(', ')}. Please read documentation on how
 Dredd works with proxies:
-https://dredd.readthedocs.io/en/latest/how-it-works/#using-https-proxy
+https://dredd.org/en/latest/how-it-works/#using-https-proxy
 `;
       logger.verbose(message);
     }

--- a/src/reporters/apiary-reporter.js
+++ b/src/reporters/apiary-reporter.js
@@ -43,7 +43,7 @@ function ApiaryReporter(emitter, stats, tests, config, runner) {
     logger.warn(`
 Apiary API Key or API Project Subdomain were not provided.
 Configure Dredd to be able to save test reports alongside your Apiary API project:
-https://dredd.readthedocs.io/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
+https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
 `);
   }
   if (!this.configuration.apiSuite) { this.configuration.apiSuite = 'public'; }

--- a/test/integration/dredd-test.js
+++ b/test/integration/dredd-test.js
@@ -352,7 +352,7 @@ describe('Dredd class Integration', () => {
 
       it('should print warning about missing Apiary API settings', () => assert.include(stderr, 'Apiary API Key or API Project Subdomain were not provided.'));
 
-      it('should print link to documentation', () => assert.include(stderr, 'https://dredd.readthedocs.io/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests'));
+      it('should print link to documentation', () => assert.include(stderr, 'https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests'));
 
       it('should print using the new reporter', () => assert.include(stdout, 'http://url.me/test/run/1234_id'));
 


### PR DESCRIPTION
#### :rocket: Why this change?

We have dredd.org, we should use it! Also, with this we won't rely on ReadTheDocs that much in the future.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
