### PR TITLE
Mention Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ documentation.
 ### Supported API Description Formats
 
 - [API Blueprint][]
-- [OpenAPI 2][]
+- [OpenAPI 2][] (formerly known as Swagger)
 
 ### Supported Hooks Languages
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Supported API Description Formats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  `API Blueprint`_
--  `OpenAPI 2`_
+-  `OpenAPI 2`_ (formerly known as Swagger)
 
 Supported Hooks Languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,7 @@ Document Your API
 First, let’s design the API we are about to build and test. That means you will need to create an API description file, which will document how your API should look like. Dredd supports two formats of API description documents:
 
 -  `API Blueprint`_
--  `OpenAPI 2`_
+-  `OpenAPI 2`_  (formerly known as Swagger)
 
 .. tabs::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,7 @@ Document Your API
 First, let’s design the API we are about to build and test. That means you will need to create an API description file, which will document how your API should look like. Dredd supports two formats of API description documents:
 
 -  `API Blueprint`_
--  `OpenAPI 2`_  (formerly known as Swagger)
+-  `OpenAPI 2`_ (formerly known as Swagger)
 
 .. tabs::
 


### PR DESCRIPTION
#### :rocket: Why this change?

I was way too brutal in wiping out Swagger from the Dredd docs 😄 Originally I wanted to mention that OpenAPI 2 was formerly called Swagger so people are not confused and it shows up in search results correctly: https://github.com/apiaryio/dredd/issues/994#issuecomment-419152889 

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/issues/994
- https://github.com/apiaryio/dredd/pull/1133
- https://github.com/apiaryio/dredd/pull/950#issuecomment-358544305

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
