### PR TITLE
Fix link to dredd-test-rails source

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -153,5 +153,5 @@ Advanced Examples
 For more complex example applications, please refer to:
 
 -  `Express.js example application <https://github.com/apiaryio/dredd-example>`__
--  `Ruby on Rails example application <https://github.com/theodorton/dredd-test-rails>`__
+-  `Ruby on Rails example application <https://gitlab.com/theodorton/dredd-test-rails>`__
 -  `Laravel example application <https://github.com/ddelnano/dredd-hooks-php/wiki/Laravel-Example>`__


### PR DESCRIPTION
#### :rocket: Why this change?

This is the canonical link to the dredd-test-rails repository.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
