### PR TITLE
Remove test directory after the test

### DIFF
--- a/test/integration/cli/reporters-cli-test.js
+++ b/test/integration/cli/reporters-cli-test.js
@@ -320,7 +320,10 @@ describe('CLI - Reporters', () => {
       });
     });
 
-    afterEach(() => fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`));
+    afterEach(() => {
+      fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`);
+      fs.rmdirSync(`${process.cwd()}/__test_directory`);
+    });
 
     it('should create given file', () => assert.isOk(fs.existsSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`)));
   });


### PR DESCRIPTION
#### :rocket: Why this change?

I was wondering why testing locally produces the `__test_directory` on my machine and figured out one of the tests uses this directory and it does not clean it properly. I never noticed it as empty directories do not get to Git and since this one started with `__`, it appeared at the top of my file explorer in my editor, which is apparently my blind spot.

Note the test is ugly and the directory should be a temporary directory, but that's a mission for future generations, this is a hotfix PR.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
