### PR TITLE
Improve ESLint ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,8 @@
-lib
-docs/_build
+.github
+.vscode
+coverage
+docs
+
+# In case Python virtualenv is present in the project directory, this ignores
+# its contents (some Python projects vendor JavaScript files, etc.)
+site-packages


### PR DESCRIPTION
#### :rocket: Why this change?

Running ESlint locally catches a lot of files which it shouldn't catch.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
