### PR TITLE
Fix link to docs builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://david-dm.org/apiaryio/dredd.svg)](https://david-dm.org/apiaryio/dredd)
 [![devDependency Status](https://david-dm.org/apiaryio/dredd/dev-status.svg)](https://david-dm.org/apiaryio/dredd?type=dev)
 [![Greenkeeper badge](https://badges.greenkeeper.io/apiaryio/dredd.svg)](https://greenkeeper.io/)
-[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://dredd.org/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/dredd/badge/?version=latest)](https://readthedocs.org/projects/dredd/builds/)
 [![Coverage Status](https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd)
 [![Known Vulnerabilities](https://snyk.io/test/npm/dredd/badge.svg)](https://snyk.io/test/npm/dredd)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,7 +84,7 @@ Example Applications
 .. |devDependency Status| image:: https://david-dm.org/apiaryio/dredd/dev-status.svg
    :target: https://david-dm.org/apiaryio/dredd?type=dev
 .. |Documentation Status| image:: https://readthedocs.org/projects/dredd/badge/?version=latest
-   :target: https://dredd.org/en/latest/
+   :target: https://readthedocs.org/projects/dredd/builds/
 .. |Coverage Status| image:: https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master
    :target: https://coveralls.io/github/apiaryio/dredd
 .. |Known Vulnerabilities| image:: https://snyk.io/test/npm/dredd/badge.svg


### PR DESCRIPTION
#### :rocket: Why this change?

I didn't know https://readthedocs.org/projects/dredd/builds/ is actually accessible publicly, but it seems so from anonymous browser window. It is a better link to have there as when the badge is red, it leads to a place where to resolve the problem.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
