### PR TITLE
Use different language in the script comment

### DIFF
--- a/scripts/postshrinkwrap.js
+++ b/scripts/postshrinkwrap.js
@@ -7,7 +7,7 @@ const lockfile = require('../npm-shrinkwrap');
 
 // Force all installations of Dredd to use only the pure JavaScript version
 // of the API Blueprint parser. It has slower performance, but it solves
-// roughly a billions of installation & distribution problems.
+// quite a few installation & distribution problems.
 delete lockfile.dependencies.drafter.requires.protagonist;
 delete lockfile.dependencies.protagonist;
 


### PR DESCRIPTION
#### :rocket: Why this change?

There is a typo (article) and when fixing it, I decided to use nicer language.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/1168

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
