### PR TITLE
Change the 'comma-dangle' ESLint rule to follow the style guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,24 @@ module.exports = {
     'node': true
   },
   rules: {
+    // Node 6 does not support dangling commas in function arguments
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "functions": "never"
+      }
+    ],
+
+    // This is to allow a convention for exporting functions solely for
+    // the purpose of the unit tests, see
+    // https://github.com/apiaryio/dredd-transactions/pull/179#discussion_r206852270
+    'no-underscore-dangle': 'off',
+
+    // Following rules were introduced to make the decaffeination
+    // of the codebase possible and are to be removed in the future
     'class-methods-use-this': 'off',
-    'comma-dangle': ['error', 'never'],
     'consistent-return': 'off',
     'func-names': 'off',
     'import/no-extraneous-dependencies': 'off',
@@ -20,7 +36,6 @@ module.exports = {
     'no-param-reassign': 'off',
     'no-plusplus': 'off',
     'no-restricted-syntax': 'off',
-    'no-underscore-dangle': 'off', // https://github.com/apiaryio/dredd-transactions/pull/179#discussion_r206852270
     'no-use-before-define': 'off'
   }
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
 };

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -281,7 +281,7 @@ ${packageData.name} v${packageData.version} \
       this.runExitingActions,
       this.loadDreddFile,
       this.checkRequiredArgs,
-      this.moveBlueprintArgToPath
+      this.moveBlueprintArgToPath,
     ]) {
       task.call(this);
       if (this.finished) { return; }
@@ -323,7 +323,7 @@ ${packageData.name} v${packageData.version} \
 
     const configuration = {
       server: this.server,
-      options: this.argv
+      options: this.argv,
     };
 
     // Push first argument (without some known configuration --key) into paths

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -44,7 +44,7 @@ class Dredd {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     this.transactions = [];
     this.runner = new Runner(this.configuration);
@@ -87,12 +87,12 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
       if (typeof val === 'string') {
         passedConfigData[key] = {
           filename: key,
-          raw: val
+          raw: val,
         };
       } else if (typeof val === 'object' && val.raw && val.filename) {
         passedConfigData[val.filename] = {
           filename: val.filename,
-          raw: val.raw
+          raw: val.raw,
         };
       }
     }

--- a/lib/Hooks.js
+++ b/lib/Hooks.js
@@ -87,7 +87,7 @@ class Hooks {
       'afterAllHooks',
       'beforeEachHooks',
       'beforeEachValidationHooks',
-      'afterEachHooks'
+      'afterEachHooks',
     ];
 
     for (const property of names) {

--- a/lib/HooksWorkerClient.js
+++ b/lib/HooksWorkerClient.js
@@ -298,7 +298,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
       'beforeEachValidation',
       'afterEach',
       'beforeAll',
-      'afterAll'
+      'afterAll',
     ];
 
     for (const eventName of eachHookNames) {
@@ -309,7 +309,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
         const message = {
           event: eventName,
           uuid,
-          data
+          data,
         };
 
         logger.verbose('Sending HTTP transaction data to hooks handler:', uuid);

--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -263,11 +263,11 @@ output;\
       context: {
         _data: data,
         _logs: [],
-        stash: this.hookStash
+        stash: this.hookStash,
       },
       libraries: {
-        _log: sandboxedLogLibraryPath
-      }
+        _log: sandboxedLogLibraryPath,
+      },
     }
       , (err, result = {}) => {
       sandbox.kill();
@@ -403,7 +403,7 @@ Interface of the hooks functions will be unified soon across all hook functions:
       origin,
       fullPath,
       protocol: this.parsedUrl.protocol,
-      skip
+      skip,
     };
 
     return configuredTransaction;
@@ -448,7 +448,7 @@ Interface of the hooks functions will be unified soon across all hook functions:
       title: transaction.id,
       message: transaction.name,
       origin: transaction.origin,
-      startedAt: transaction.startedAt
+      startedAt: transaction.startedAt,
     };
   }
 
@@ -610,7 +610,7 @@ Not performing HTTP request for '${transaction.name}'.\
     const uri = url.format({
       protocol: transaction.protocol,
       hostname: transaction.host,
-      port: transaction.port
+      port: transaction.port,
     }) + transaction.fullPath;
     const options = { http: this.configuration.http };
 

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -36,7 +36,7 @@ function addHooks(runner, transactions, callback) {
   function loadHookFile(filePath) {
     try {
       proxyquire(filePath, {
-        hooks: runner.hooks
+        hooks: runner.hooks,
       });
 
       // Fixing #168 issue

--- a/lib/blueprintUtils.js
+++ b/lib/blueprintUtils.js
@@ -72,5 +72,5 @@ module.exports = {
   characterIndexToPosition,
   rangesToLinesText,
   sortNumbersAscending,
-  warningLocationToRanges
+  warningLocationToRanges,
 };

--- a/lib/childProcess.js
+++ b/lib/childProcess.js
@@ -201,5 +201,5 @@ module.exports = {
   signalKill,
   signalTerm,
   terminate,
-  spawn
+  spawn,
 };

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -68,8 +68,8 @@ function applyConfiguration(config) {
       'hooks-worker-term-timeout': 5000,
       'hooks-worker-term-retry': 500,
       'hooks-worker-handler-host': '127.0.0.1',
-      'hooks-worker-handler-port': 61321
-    }
+      'hooks-worker-handler-port': 61321,
+    },
   };
 
   // Normalize options and config
@@ -114,5 +114,5 @@ function applyConfiguration(config) {
 
 module.exports = {
   applyConfiguration,
-  applyLoggingOptions
+  applyLoggingOptions,
 };

--- a/lib/configureReporters.js
+++ b/lib/configureReporters.js
@@ -14,7 +14,7 @@ const fileReporters = [
   'html',
   'markdown',
   'apiary',
-  'junit' // Deprecated
+  'junit', // Deprecated
 ];
 
 const cliReporters = ['dot', 'nyan'];

--- a/lib/handleRuntimeProblems.js
+++ b/lib/handleRuntimeProblems.js
@@ -29,7 +29,7 @@ module.exports = function handleRuntimeProblems(blueprintData) {
         const transactionName = [
           annotation.origin.resourceGroupName,
           annotation.origin.resourceName,
-          annotation.origin.actionName
+          annotation.origin.actionName,
         ].join(' > ');
         log(`Compilation ${annotation.type} in file '${filename}': ${annotation.message} (${transactionName})`);
       }

--- a/lib/hooksLog.js
+++ b/lib/hooksLog.js
@@ -7,7 +7,7 @@ module.exports = function hooksLog(logs = [], logger, content) {
   // Append to array of logs to allow further operations, e.g. send all hooks logs to Apiary
   logs.push({
     timestamp: Date.now(),
-    content: typeof content === 'object' ? util.format(content) : `${content}`
+    content: typeof content === 'object' ? util.format(content) : `${content}`,
   });
 
   return logs;

--- a/lib/init.js
+++ b/lib/init.js
@@ -37,7 +37,7 @@ function detect(files) {
     ci: detectCI(files),
     apiDescription: detectApiDescription(files),
     server: detectServer(files),
-    language: detectLanguage(files)
+    language: detectLanguage(files),
   };
 }
 
@@ -48,26 +48,26 @@ function prompt(config, detected, callback) {
       name: 'apiDescription',
       message: 'Location of the API description document',
       type: 'input',
-      default: config.blueprint || detected.apiDescription
+      default: config.blueprint || detected.apiDescription,
     },
     {
       name: 'server',
       message: 'Command to start the API server under test',
       type: 'input',
-      default: config.server || detected.server
+      default: config.server || detected.server,
     },
     {
       name: 'apiHost',
       message: 'Host of the API under test',
       type: 'input',
-      default: config.endpoint || 'http://127.0.0.1:3000'
+      default: config.endpoint || 'http://127.0.0.1:3000',
     },
     {
       name: 'hooks',
       message: 'Do you want to use hooks to customize Dredd\'s behavior?',
       type: 'confirm',
       default: true,
-      when: () => config.language === 'nodejs'
+      when: () => config.language === 'nodejs',
     },
     {
       name: 'language',
@@ -81,16 +81,16 @@ function prompt(config, detected, callback) {
         { name: 'PHP', value: 'php' },
         { name: 'Python', value: 'python' },
         { name: 'Ruby', value: 'ruby' },
-        { name: 'Rust', value: 'rust' }
+        { name: 'Rust', value: 'rust' },
       ],
-      when: answers => answers.hooks
+      when: answers => answers.hooks,
     },
     {
       name: 'apiary',
       message: 'Do you want to report your tests to the Apiary inspector?',
       type: 'confirm',
       default: true,
-      when: () => config.reporter !== 'apiary'
+      when: () => config.reporter !== 'apiary',
     },
     {
       name: 'apiaryApiKey',
@@ -100,7 +100,7 @@ function prompt(config, detected, callback) {
       when: answers => (
         answers.apiary
         && (!config.custom || !config.custom.apiaryApiKey)
-      )
+      ),
     },
     {
       name: 'apiaryApiName',
@@ -111,42 +111,42 @@ function prompt(config, detected, callback) {
         answers.apiary
         && answers.apiaryApiKey
         && (!config.custom || !config.custom.apiaryApiName)
-      )
+      ),
     },
     {
       name: 'appveyor',
       message: 'Found AppVeyor configuration, do you want to add Dredd?',
       type: 'confirm',
       default: true,
-      when: () => detected.ci.includes('appveyor')
+      when: () => detected.ci.includes('appveyor'),
     },
     {
       name: 'circleci',
       message: 'Found CircleCI configuration, do you want to add Dredd?',
       type: 'confirm',
       default: true,
-      when: () => detected.ci.includes('circleci')
+      when: () => detected.ci.includes('circleci'),
     },
     {
       name: 'travisci',
       message: 'Found Travis CI configuration, do you want to add Dredd?',
       type: 'confirm',
       default: true,
-      when: () => detected.ci.includes('travisci')
+      when: () => detected.ci.includes('travisci'),
     },
     {
       name: 'wercker',
       message: 'Found Wercker configuration, do you want to add Dredd?',
       type: 'confirm',
       default: true,
-      when: () => detected.ci.includes('wercker')
+      when: () => detected.ci.includes('wercker'),
     },
     {
       name: 'ci',
       message: 'Dredd is best served with Continuous Integration. Do you want to create CI configuration?',
       type: 'confirm',
       default: true,
-      when: () => !detected.ci.length
+      when: () => !detected.ci.length,
     },
     {
       name: 'createCI',
@@ -157,10 +157,10 @@ function prompt(config, detected, callback) {
         { name: 'AppVeyor', value: 'appveyor' },
         { name: 'CircleCI', value: 'circleci' },
         { name: 'Travis CI', value: 'travisci' },
-        { name: 'Wercker (Oracle Container Pipelines)', value: 'wercker' }
+        { name: 'Wercker (Oracle Container Pipelines)', value: 'wercker' },
       ],
-      when: answers => answers.ci
-    }
+      when: answers => answers.ci,
+    },
   ]).then((answers) => {
     callback(null, answers);
   });
@@ -172,7 +172,7 @@ function applyAnswers(config, answers, options = {}) {
     appveyor: updateAppVeyor,
     circleci: updateCircleCI,
     travisci: updateTravisCI,
-    wercker: updateWercker
+    wercker: updateWercker,
   };
 
   config._[0] = answers.apiDescription;
@@ -264,7 +264,7 @@ function updateCircleCI(options = {}) {
     if (!contents.jobs) { contents.jobs = {}; }
     contents.jobs.dredd = {
       docker: [{ image: 'circleci/node:latest' }],
-      steps: ['checkout', { run: INSTALL_DREDD }, { run: RUN_DREDD }]
+      steps: ['checkout', { run: INSTALL_DREDD }, { run: RUN_DREDD }],
     };
   });
 }
@@ -340,7 +340,7 @@ function detectServer(files) {
   const commands = {
     nodejs: 'npm start',
     ruby: 'bundle exec rails server',
-    python: 'python manage.py runserver'
+    python: 'python manage.py runserver',
   };
   const language = detectLanguage(files);
   return commands[language] || commands.nodejs;
@@ -370,7 +370,7 @@ function detectCI(files) {
     'wercker.yml': 'wercker',
     'appveyor.yml': 'appveyor',
     '.travis.yml': 'travisci',
-    '.circleci': 'circleci'
+    '.circleci': 'circleci',
   };
   return files.map(f => ci[f]).filter(f => !!f);
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,7 +2,7 @@ const winston = require('winston');
 
 module.exports = new (winston.Logger)({
   transports: [
-    new (winston.transports.Console)({ colorize: true })
+    new (winston.transports.Console)({ colorize: true }),
   ],
   levels: {
     silly: 14,
@@ -19,7 +19,7 @@ module.exports = new (winston.Logger)({
     request: 3,
     skip: 2,
     warn: 1,
-    error: 0
+    error: 0,
   },
   colors: {
     silly: 'gray',
@@ -36,6 +36,6 @@ module.exports = new (winston.Logger)({
     request: 'green',
     skip: 'yellow',
     warn: 'yellow',
-    error: 'red'
-  }
+    error: 'red',
+  },
 });

--- a/lib/performRequest.js
+++ b/lib/performRequest.js
@@ -128,7 +128,7 @@ function normalizeContentLengthHeader(headers, body, options = {}) {
 function createTransactionResponse(res, body) {
   const transactionRes = {
     statusCode: res.statusCode,
-    headers: Object.assign({}, res.headers)
+    headers: Object.assign({}, res.headers),
   };
   if (Buffer.byteLength(body || '')) {
     transactionRes.bodyEncoding = detectBodyEncoding(body);

--- a/lib/reporters/ApiaryReporter.js
+++ b/lib/reporters/ApiaryReporter.js
@@ -13,7 +13,7 @@ const CONNECTION_ERRORS = [
   'ETIMEDOUT',
   'ECONNREFUSED',
   'EHOSTUNREACH',
-  'EPIPE'
+  'EPIPE',
 ];
 
 function ApiaryReporter(emitter, stats, tests, config, runner) {
@@ -32,7 +32,7 @@ function ApiaryReporter(emitter, stats, tests, config, runner) {
   this.configuration = {
     apiUrl: (this._get('apiaryApiUrl', 'APIARY_API_URL', 'https://api.apiary.io')).replace(/\/$/, ''),
     apiToken: this._get('apiaryApiKey', 'APIARY_API_KEY', null),
-    apiSuite: this._get('apiaryApiName', 'APIARY_API_NAME', null)
+    apiSuite: this._get('apiaryApiName', 'APIARY_API_NAME', null),
   };
 
   this.configureEmitter(emitter);
@@ -116,7 +116,7 @@ ApiaryReporter.prototype.configureEmitter = function (emitter) {
       startedAt: this.startedAt,
       public: true,
       status: 'running',
-      agentEnvironment: ciEnvVars
+      agentEnvironment: ciEnvVars,
     };
 
     if (this.configuration.apiToken && this.configuration.apiSuite) {
@@ -151,11 +151,11 @@ ApiaryReporter.prototype.configureEmitter = function (emitter) {
 
     if (Array.from(CONNECTION_ERRORS).includes(error.code)) {
       data.resultData.result.general.push({
-        severity: 'error', message: 'Error connecting to server under test!'
+        severity: 'error', message: 'Error connecting to server under test!',
       });
     } else {
       data.resultData.result.general.push({
-        severity: 'error', message: 'Unhandled error occured when executing the transaction.'
+        severity: 'error', message: 'Unhandled error occured when executing the transaction.',
       });
     }
 
@@ -173,7 +173,7 @@ ApiaryReporter.prototype.configureEmitter = function (emitter) {
       endedAt: Math.round(new Date().getTime() / 1000),
       result: this.stats,
       status: (this.stats.failures > 0 || this.stats.errors > 0) ? 'failed' : 'passed',
-      logs: (this.runner && this.runner.logs && this.runner.logs.length) ? this.runner.logs : undefined
+      logs: (this.runner && this.runner.logs && this.runner.logs.length) ? this.runner.logs : undefined,
     };
 
     const path = `/apis/${this.configuration.apiSuite}/tests/run/${this.remoteId}`;
@@ -234,7 +234,7 @@ ${error.message}\n${resBody}
   const system = `${os.type()} ${os.release()}; ${os.arch()}`;
   const headers = {
     'User-Agent': `Dredd Apiary Reporter/${packageData.version} (${system})`,
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
   };
 
   const options = clone(this.config.http || {});
@@ -274,8 +274,8 @@ ApiaryReporter.prototype._transformTestToReporter = function (test) {
       request: test.request,
       realResponse: test.actual,
       expectedResponse: test.expected,
-      result: test.results
-    }
+      result: test.results,
+    },
   };
 };
 

--- a/lib/reporters/CLIReporter.js
+++ b/lib/reporters/CLIReporter.js
@@ -76,7 +76,7 @@ CLIReporter.prototype.configureEmitter = function (emitter) {
       'ETIMEDOUT',
       'ECONNREFUSED',
       'EHOSTUNREACH',
-      'EPIPE'
+      'EPIPE',
     ];
 
     if (connectionErrors.indexOf(error.code) > -1) {

--- a/lib/reporters/NyanReporter.js
+++ b/lib/reporters/NyanReporter.js
@@ -101,7 +101,7 @@ NyanCatReporter.prototype.drawScoreboard = function () {
   const colors = {
     fail: 31,
     skipped: 36,
-    pass: 32
+    pass: 32,
   };
 
   // Capture outer `this`

--- a/lib/reporters/XUnitReporter.js
+++ b/lib/reporters/XUnitReporter.js
@@ -38,7 +38,7 @@ XUnitReporter.prototype.updateSuiteStats = function (path, stats, callback) {
           errors: stats.errors,
           skip: stats.skipped,
           timestamp: (new Date()).toUTCString(),
-          time: stats.duration / 1000
+          time: stats.duration / 1000,
         }, false);
         const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
         fs.writeFile(path, `${xmlHeader}\n${newStats}\n${restOfFile}</testsuite>`, (error) => {
@@ -94,7 +94,7 @@ XUnitReporter.prototype.configureEmitter = function (emitter) {
           errors: this.stats.errors,
           skip: this.stats.skipped,
           timestamp: (new Date()).toUTCString(),
-          time: this.stats.duration / 1000
+          time: this.stats.duration / 1000,
         }, false)
         );
         callback();
@@ -112,7 +112,7 @@ XUnitReporter.prototype.configureEmitter = function (emitter) {
   emitter.on('test pass', (test) => {
     const attrs = {
       name: htmlencode.htmlEncode(test.title),
-      time: test.duration / 1000
+      time: test.duration / 1000,
     };
 
     if (this.details) {
@@ -136,7 +136,7 @@ ${prettifyResponse(test.actual)}\
   emitter.on('test skip', (test) => {
     const attrs = {
       name: htmlencode.htmlEncode(test.title),
-      time: test.duration / 1000
+      time: test.duration / 1000,
     };
     this.appendLine(this.path, this.toTag('testcase', attrs, false, this.toTag('skipped', null, true)));
   });
@@ -144,7 +144,7 @@ ${prettifyResponse(test.actual)}\
   emitter.on('test fail', (test) => {
     const attrs = {
       name: htmlencode.htmlEncode(test.title),
-      time: test.duration / 1000
+      time: test.duration / 1000,
     };
     const diff = `\
 Message:
@@ -165,7 +165,7 @@ ${prettifyResponse(test.actual)}\
   emitter.on('test error', (error, test) => {
     const attrs = {
       name: htmlencode.htmlEncode(test.title),
-      time: test.duration / 1000
+      time: test.duration / 1000,
     };
     const errorMessage = `\nError: \n${error}\nStacktrace: \n${error.stack}`;
     this.appendLine(

--- a/lib/sandboxHooksCode.js
+++ b/lib/sandboxHooksCode.js
@@ -29,7 +29,7 @@ output\
 
   const sandbox = new Pitboss(wrappedCode);
   sandbox.run({ libraries: {
-    _Hooks: '../../../lib/Hooks', console: 'console'
+    _Hooks: '../../../lib/Hooks', console: 'console',
   } }, (err, result) => {
     sandbox.kill();
     if (err) { return callback(err); }

--- a/lib/sortTransactions.js
+++ b/lib/sortTransactions.js
@@ -13,7 +13,7 @@ module.exports = function sortTransactions(arr) {
     const sortedMethods = [
       'CONNECT', 'OPTIONS',
       'POST', 'GET', 'HEAD', 'PUT', 'PATCH', 'DELETE',
-      'TRACE'
+      'TRACE',
     ];
 
     const methodIndexA = sortedMethods.indexOf(a.request.method);

--- a/lib/which.js
+++ b/lib/which.js
@@ -8,5 +8,5 @@ module.exports = {
     } catch (e) {
       return false;
     }
-  }
+  },
 };

--- a/test/fixtures/blueprint-data.js
+++ b/test/fixtures/blueprint-data.js
@@ -8,43 +8,43 @@ module.exports = {
         code: 3,
         message: 'no parameters specified, expected a nested list of parameters, one parameter per list item',
         location: [[178, 13]],
-        type: 'warning'
+        type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 5,
         message: 'ignoring unrecognized block',
         location: [[195, 19]],
-        type: 'warning'
+        type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 10,
         message: 'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
         location: [[269, 2], [275, 4], [283, 25], [312, 20], [336, 4], [344, 2]],
-        type: 'warning'
+        type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 3,
         message: 'no parameters specified, expected a nested list of parameters, one parameter per list item',
         location: [[378, 13]],
-        type: 'warning'
+        type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 5,
         message: 'ignoring unrecognized block',
         location: [[395, 19]],
-        type: 'warning'
+        type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 10,
         message: 'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
         location: [[469, 2], [475, 4], [483, 25], [512, 20], [536, 4], [544, 2]],
-        type: 'warning'
-      }
-    ]
-  }
+        type: 'warning',
+      },
+    ],
+  },
 };

--- a/test/fixtures/sanitation/any-content-guard-pattern-matching.js
+++ b/test/fixtures/sanitation/any-content-guard-pattern-matching.js
@@ -24,7 +24,7 @@ hooks.afterEach((transaction, done) => {
       end: transaction.test.end,
       duration: transaction.test.duration,
       startedAt: transaction.test.startedAt,
-      message: transaction.fail
+      message: transaction.fail,
     };
   }
   done();

--- a/test/fixtures/sanitation/transaction-secured-erroring-hooks.js
+++ b/test/fixtures/sanitation/transaction-secured-erroring-hooks.js
@@ -10,7 +10,7 @@ hooks.after('Resource > Update Resource', (transaction, done) => {
       end: transaction.test.end,
       duration: transaction.test.duration,
       startedAt: transaction.test.startedAt,
-      message: transaction.fail
+      message: transaction.fail,
     };
   }
   done();

--- a/test/fixtures/scripts/handle-windows-sigint.js
+++ b/test/fixtures/scripts/handle-windows-sigint.js
@@ -20,7 +20,7 @@ module.exports = () => {
   // manually pressing Ctrl+C)
   const rl = readline.createInterface({
     input: process.stdin,
-    output: process.stdout
+    output: process.stdout,
   });
   rl.on('SIGINT', () => {
     process.emit('SIGINT');

--- a/test/integration/childProcess-test.js
+++ b/test/integration/childProcess-test.js
@@ -18,7 +18,7 @@ function runChildProcess(command, fn, callback) {
     terminated: false,
     exitStatus: undefined,
     signal: undefined,
-    onCrash
+    onCrash,
   };
 
   const childProcess = spawn(COFFEE_BIN, [command]);

--- a/test/integration/cli/api-blueprint-cli-test.js
+++ b/test/integration/cli/api-blueprint-cli-test.js
@@ -26,7 +26,7 @@ describe('CLI - API Blueprint Document', () => {
       let runtimeInfo;
       const args = [
         './test/fixtures/error-blueprint.apib',
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -46,7 +46,7 @@ describe('CLI - API Blueprint Document', () => {
       const args = [
         './test/fixtures/warning-blueprint.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--no-color'
+        '--no-color',
       ];
 
       beforeEach((done) => {

--- a/test/integration/cli/api-description-cli-test.js
+++ b/test/integration/cli/api-description-cli-test.js
@@ -30,7 +30,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = [
         './test/fixtures/__non-existent__.apib',
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -49,7 +49,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = [
         os.homedir(),
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -71,7 +71,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = [
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}/single-get.apib`,
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -97,7 +97,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = [
         `http://127.0.0.1:${NON_EXISTENT_PORT}/single-get.apib`,
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -121,7 +121,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = [
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}/__non-existent__.apib`,
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -151,7 +151,7 @@ describe('CLI - API Description Document', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--path=./test/fixtures/single-get-uri-template.apib'
+        '--path=./test/fixtures/single-get-uri-template.apib',
       ];
 
       beforeEach((done) => {
@@ -174,7 +174,7 @@ describe('CLI - API Description Document', () => {
       const args = [
         './test/fixtures/single-get-uri-template.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        `--path=http://127.0.0.1:${DEFAULT_SERVER_PORT}/single-get.yaml`
+        `--path=http://127.0.0.1:${DEFAULT_SERVER_PORT}/single-get.yaml`,
       ];
 
       beforeEach((done) => {
@@ -203,7 +203,7 @@ describe('CLI - API Description Document', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--path=./test/fixtures/single-get-uri-template.apib',
-        '--path=./test/fixtures/single-get-path.apib'
+        '--path=./test/fixtures/single-get-path.apib',
       ];
 
       beforeEach((done) => {
@@ -227,7 +227,7 @@ describe('CLI - API Description Document', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--path=./test/fixtures/single-get-uri-temp*.apib'
+        '--path=./test/fixtures/single-get-uri-temp*.apib',
       ];
 
       beforeEach((done) => {
@@ -250,7 +250,7 @@ describe('CLI - API Description Document', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--path=./test/fixtures/__non-existent__.apib'
+        '--path=./test/fixtures/__non-existent__.apib',
       ];
 
       beforeEach((done) => {

--- a/test/integration/cli/configuration-cli-test.js
+++ b/test/integration/cli/configuration-cli-test.js
@@ -15,24 +15,24 @@ let stderr = '';
 let stdout = '';
 
 const addHooksStub = proxyquire('../../../lib/addHooks', {
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const transactionRunner = proxyquire('../../../lib/TransactionRunner', {
   './addHooks': addHooksStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const dreddStub = proxyquire('../../../lib/Dredd', {
   './TransactionRunner': transactionRunner,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const CLIStub = proxyquire('../../../lib/CLI', {
   './Dredd': dreddStub,
   './configUtils': configUtils,
   console: loggerStub,
-  fs
+  fs,
 });
 
 function execCommand(custom = {}, cb) {
@@ -59,7 +59,7 @@ describe('CLI class Integration', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => {
       sinon.stub(loggerStub, method).callsFake((chunk) => { stdout += `\n${method}: ${chunk}`; });
     });
@@ -71,7 +71,7 @@ describe('CLI class Integration', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => { loggerStub[method].restore(); });
   });
 
@@ -151,18 +151,18 @@ describe('CLI class Integration', () => {
 
     const errorCmd = { argv: [
       `http://127.0.0.1:${PORT + 1}/connection-error.apib`,
-      `http://127.0.0.1:${PORT + 1}`
-    ]
+      `http://127.0.0.1:${PORT + 1}`,
+    ],
     };
     const wrongCmd = { argv: [
       `http://127.0.0.1:${PORT}/not-found.apib`,
-      `http://127.0.0.1:${PORT}`
-    ]
+      `http://127.0.0.1:${PORT}`,
+    ],
     };
     const goodCmd = { argv: [
       `http://127.0.0.1:${PORT}/file.apib`,
-      `http://127.0.0.1:${PORT}`
-    ]
+      `http://127.0.0.1:${PORT}`,
+    ],
     };
 
     before((done) => {

--- a/test/integration/cli/hookfiles-cli-test.js
+++ b/test/integration/cli/hookfiles-cli-test.js
@@ -75,7 +75,7 @@ describe('CLI', () => {
             `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
             '--server-wait=0',
             '--language=foo/bar/hook-handler',
-            '--hookfiles=./test/fixtures/scripts/emptyfile'
+            '--hookfiles=./test/fixtures/scripts/emptyfile',
           ];
           runCLIWithServer(args, app, (err, info) => {
             runtimeInfo = info;
@@ -116,7 +116,7 @@ describe('CLI', () => {
             `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
             '--server-wait=0',
             '--language=node ./test/fixtures/scripts/exit-3.js',
-            '--hookfiles=./test/fixtures/scripts/emptyfile'
+            '--hookfiles=./test/fixtures/scripts/emptyfile',
           ];
           runCLIWithServer(args, app, (err, info) => {
             runtimeInfo = info;
@@ -153,7 +153,7 @@ describe('CLI', () => {
             `--server=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
             '--server-wait=0',
             '--language=node ./test/fixtures/scripts/kill-self.js',
-            '--hookfiles=./test/fixtures/scripts/emptyfile'
+            '--hookfiles=./test/fixtures/scripts/emptyfile',
           ];
           runCLIWithServer(args, app, (err, info) => {
             runtimeInfo = info;
@@ -210,7 +210,7 @@ describe('CLI', () => {
             `--server=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
             '--server-wait=0',
             `--language=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
-            '--hookfiles=test/fixtures/hooks.js'
+            '--hookfiles=test/fixtures/hooks.js',
           ];
           hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () =>
             runCLIWithServer(args, app, (err, info) => {
@@ -263,7 +263,7 @@ describe('CLI', () => {
             `--server=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
             '--server-wait=0',
             `--language=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
-            '--hookfiles=./test/fixtures/scripts/emptyfile'
+            '--hookfiles=./test/fixtures/scripts/emptyfile',
           ];
           hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () =>
             runCLIWithServer(args, app, (err, info) => {
@@ -305,7 +305,7 @@ describe('CLI', () => {
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
           '-h',
-          'Accept:application/json'
+          'Accept:application/json',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -328,7 +328,7 @@ describe('CLI', () => {
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
           '-u',
-          'username:password'
+          'username:password',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -352,7 +352,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/apiary.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '-s'
+          '-s',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -380,7 +380,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '-e'
+          '-e',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -406,7 +406,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '-d'
+          '-d',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -432,7 +432,7 @@ describe('CLI', () => {
             './test/fixtures/single-get.apib',
             `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
             '-m',
-            'POST'
+            'POST',
           ];
           runCLIWithServer(args, app, (err, info) => {
             runtimeInfo = info;
@@ -454,7 +454,7 @@ describe('CLI', () => {
             './test/fixtures/single-get.apib',
             `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
             '-m',
-            'GET'
+            'GET',
           ];
           runCLIWithServer(args, app, (err, info) => {
             runtimeInfo = info;
@@ -480,7 +480,7 @@ describe('CLI', () => {
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
           '--path=./test/fixtures/multifile/*.apib',
           '--only=Message API > /message > GET',
-          '--no-color'
+          '--no-color',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -505,7 +505,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '--no-color'
+          '--no-color',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -530,7 +530,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '--color=false'
+          '--color=false',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -555,7 +555,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '-l=error'
+          '-l=error',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -579,7 +579,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/single-get.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '-t'
+          '-t',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -604,7 +604,7 @@ describe('CLI', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--hookfiles=./test/fixtures/*_hooks.*'
+        '--hookfiles=./test/fixtures/*_hooks.*',
       ];
       runCLIWithServer(args, app, (err, info) => {
         runtimeInfo = info;
@@ -635,7 +635,7 @@ describe('CLI', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--hookfiles=./test/fixtures/*_events.*'
+        '--hookfiles=./test/fixtures/*_events.*',
       ];
       runCLIWithServer(args, app, (err, info) => {
         runtimeInfo = info;
@@ -670,7 +670,7 @@ describe('CLI', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--hookfiles=./test/fixtures/*_all.*'
+        '--hookfiles=./test/fixtures/*_all.*',
       ];
       runCLIWithServer(args, app, (err, info) => {
         runtimeInfo = info;
@@ -694,14 +694,14 @@ describe('CLI', () => {
           res.json({
             data: {
               expires: 1234,
-              token: 'this should pass since it is a string'
-            }
+              token: 'this should pass since it is a string',
+            },
           })
         );
 
         const args = [
           './test/fixtures/schema.apib',
-          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -721,14 +721,14 @@ describe('CLI', () => {
           res.json({
             data: {
               expires: 'this should fail since it is a string',
-              token: 'this should pass since it is a string'
-            }
+              token: 'this should pass since it is a string',
+            },
           })
         );
 
         const args = [
           './test/fixtures/schema.apib',
-          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -748,7 +748,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/multifile/*.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '--names'
+          '--names',
         ];
         runCLI(args, (err, info) => {
           cliInfo = info;
@@ -779,7 +779,7 @@ describe('CLI', () => {
         const args = [
           './test/fixtures/multifile/*.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-          '--hookfiles=./test/fixtures/multifile/multifile_hooks.coffee'
+          '--hookfiles=./test/fixtures/multifile/multifile_hooks.coffee',
         ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -799,7 +799,7 @@ describe('CLI', () => {
         assert.deepEqual(runtimeInfo.server.requestCounts, {
           '/name': 1,
           '/greeting': 1,
-          '/message': 1
+          '/message': 1,
         });
       });
     });
@@ -815,7 +815,7 @@ describe('CLI', () => {
           './test/fixtures/multiple-examples.apib',
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
           '--path=./test/fixtures/multifile/*.apib',
-          '--names'
+          '--names',
         ];
         runCLI(args, (err, info) => {
           cliInfo = info;
@@ -846,7 +846,7 @@ describe('CLI', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--sandbox',
-        '--hookfiles=./test/fixtures/sandboxed-hook.js'
+        '--hookfiles=./test/fixtures/sandboxed-hook.js',
       ];
       runCLIWithServer(args, app, (err, info) => {
         runtimeInfo = info;

--- a/test/integration/cli/openapi2-cli-test.js
+++ b/test/integration/cli/openapi2-cli-test.js
@@ -26,7 +26,7 @@ describe('CLI - OpenAPI 2 Document', () => {
       let runtimeInfo;
       const args = [
         './test/fixtures/error-openapi2.yaml',
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
       beforeEach((done) => {
@@ -46,7 +46,7 @@ describe('CLI - OpenAPI 2 Document', () => {
       const args = [
         './test/fixtures/warning-openapi2.yaml',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--no-color'
+        '--no-color',
       ];
 
       beforeEach((done) => {

--- a/test/integration/cli/reporters-cli-test.js
+++ b/test/integration/cli/reporters-cli-test.js
@@ -27,7 +27,7 @@ describe('CLI - Reporters', () => {
     const args = [
       './test/fixtures/single-get.apib',
       `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-      '--reporter=nyan'
+      '--reporter=nyan',
     ];
 
     beforeEach(done =>
@@ -58,7 +58,7 @@ describe('CLI - Reporters', () => {
         res.json({
           _id: '1234_id',
           testRunId: '6789_testRunId',
-          reportUrl: 'http://example.com/test/run/1234_id'
+          reportUrl: 'http://example.com/test/run/1234_id',
         })
       );
 
@@ -78,7 +78,7 @@ describe('CLI - Reporters', () => {
       const args = [
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--reporter=apiary'
+        '--reporter=apiary',
       ];
 
       beforeEach(done =>
@@ -96,7 +96,7 @@ describe('CLI - Reporters', () => {
         assert.deepEqual(apiaryRuntimeInfo.requestCounts, {
           '/apis/public/tests/runs': 1,
           '/apis/public/tests/run/1234_id': 1,
-          '/apis/public/tests/steps?testRunId=1234_id': 1
+          '/apis/public/tests/steps?testRunId=1234_id': 1,
         });
       });
       it('should send results from gavel', () => {
@@ -118,7 +118,7 @@ describe('CLI - Reporters', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--reporter=apiary',
-        '--hookfiles=./test/fixtures/hooks-log.coffee'
+        '--hookfiles=./test/fixtures/hooks-log.coffee',
       ];
 
       beforeEach(done =>
@@ -195,7 +195,7 @@ describe('CLI - Reporters', () => {
         '--reporter=apiary',
         '--level=info',
         '--sandbox',
-        '--hookfiles=./test/fixtures/sandboxed-hooks-log.js'
+        '--hookfiles=./test/fixtures/sandboxed-hooks-log.js',
       ];
 
       beforeEach(done =>
@@ -259,7 +259,7 @@ describe('CLI - Reporters', () => {
       './test/fixtures/single-get.apib',
       `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       '--reporter=xunit',
-      '--output=__test_file_output__.xml'
+      '--output=__test_file_output__.xml',
     ];
 
     beforeEach(done =>
@@ -280,7 +280,7 @@ describe('CLI - Reporters', () => {
       '--reporter=xunit',
       '--output=__test_file_output1__.xml',
       '--reporter=xunit',
-      '--output=__test_file_output2__.xml'
+      '--output=__test_file_output2__.xml',
     ];
 
     beforeEach(done =>
@@ -305,7 +305,7 @@ describe('CLI - Reporters', () => {
       './test/fixtures/single-get.apib',
       `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       '--reporter=xunit',
-      '--output=./__test_directory/__test_file_output__.xml'
+      '--output=./__test_directory/__test_file_output__.xml',
     ];
 
     beforeEach((done) => {
@@ -334,7 +334,7 @@ describe('CLI - Reporters', () => {
     const args = [
       './test/fixtures/single-get.apib',
       `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-      '--reporter=apiary'
+      '--reporter=apiary',
     ];
 
     beforeEach((done) => {

--- a/test/integration/cli/server-process-cli-test.js
+++ b/test/integration/cli/server-process-cli-test.js
@@ -70,7 +70,7 @@ describe('CLI - Server Process', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         `--server=node ./test/fixtures/scripts/dummy-server.js ${DEFAULT_SERVER_PORT}`,
-        '--server-wait=1'
+        '--server-wait=1',
       ];
 
       beforeEach(done =>
@@ -91,7 +91,7 @@ describe('CLI - Server Process', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--server=/foo/bar/baz',
-        '--server-wait=1'
+        '--server-wait=1',
       ];
 
       beforeEach(done =>
@@ -110,26 +110,26 @@ describe('CLI - Server Process', () => {
       description: 'When crashes before requests',
       apiDescriptionDocument: './test/fixtures/single-get.apib',
       server: 'node test/fixtures/scripts/exit-3.js',
-      expectServerBoot: false
+      expectServerBoot: false,
     },
     {
       description: 'When crashes during requests',
       apiDescriptionDocument: './test/fixtures/apiary.apib',
       server: `node test/fixtures/scripts/dummy-server-crash.js ${DEFAULT_SERVER_PORT}`,
-      expectServerBoot: true
+      expectServerBoot: true,
     },
     {
       description: 'When killed before requests',
       apiDescriptionDocument: './test/fixtures/single-get.apib',
       server: 'node test/fixtures/scripts/kill-self.js',
-      expectServerBoot: false
+      expectServerBoot: false,
     },
     {
       description: 'When killed during requests',
       apiDescriptionDocument: './test/fixtures/apiary.apib',
       server: `node test/fixtures/scripts/dummy-server-kill.js ${DEFAULT_SERVER_PORT}`,
-      expectServerBoot: true
-    }
+      expectServerBoot: true,
+    },
     ]) {
       describe(scenario.description, () => {
         let cliInfo;
@@ -137,7 +137,7 @@ describe('CLI - Server Process', () => {
           scenario.apiDescriptionDocument,
           `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
           `--server=${scenario.server}`,
-          '--server-wait=1'
+          '--server-wait=1',
         ];
 
         beforeEach(done =>
@@ -169,7 +169,7 @@ describe('CLI - Server Process', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         `--server=node test/fixtures/scripts/dummy-server-ignore-term.js ${DEFAULT_SERVER_PORT}`,
         '--server-wait=1',
-        '--level=verbose'
+        '--level=verbose',
       ];
 
       beforeEach(done =>

--- a/test/integration/dredd-test.js
+++ b/test/integration/dredd-test.js
@@ -16,17 +16,17 @@ let stderr = '';
 let stdout = '';
 
 const addHooksStub = proxyquire('../../lib/addHooks', {
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const transactionRunner = proxyquire('../../lib/TransactionRunner', {
   './addHooks': addHooksStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const Dredd = proxyquire('../../lib/Dredd', {
   './TransactionRunner': transactionRunner,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 function execCommand(options = {}, cb) {
@@ -56,7 +56,7 @@ describe('Dredd class Integration', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => {
       sinon.stub(loggerStub, method).callsFake((chunk) => { stdout += `\n${method}: ${chunk}`; });
     });
@@ -69,7 +69,7 @@ describe('Dredd class Integration', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => {
       loggerStub[method].restore();
     });
@@ -81,8 +81,8 @@ describe('Dredd class Integration', () => {
       before((done) => {
         const cmd = {
           options: {
-            path: './test/fixtures/single-get.apib'
-          }
+            path: './test/fixtures/single-get.apib',
+          },
         };
 
         const app = express();
@@ -103,8 +103,8 @@ describe('Dredd class Integration', () => {
       before((done) => {
         const cmd = {
           options: {
-            path: ['./test/fixtures/single-get.apib']
-          }
+            path: ['./test/fixtures/single-get.apib'],
+          },
         };
 
         const app = express();
@@ -137,13 +137,13 @@ describe('Dredd class Integration', () => {
         options: {
           path: ['./test/fixtures/single-get.apib'],
           reporter: ['apiary'],
-          level: 'verbose'
+          level: 'verbose',
         },
         custom: {
           apiaryApiUrl: `http://127.0.0.1:${PORT + 1}`,
           apiaryApiKey: 'the-key',
-          apiaryApiName: 'the-api-name'
-        }
+          apiaryApiName: 'the-api-name',
+        },
       };
 
       receivedHeaders = {};
@@ -170,7 +170,7 @@ describe('Dredd class Integration', () => {
         res.status(201).json({
           _id: '1234_id',
           testRunId: '6789_testRunId',
-          reportUrl: 'http://url.me/test/run/1234_id'
+          reportUrl: 'http://url.me/test/run/1234_id',
         });
       });
 
@@ -220,8 +220,8 @@ describe('Dredd class Integration', () => {
       before((done) => {
         const cmd = {
           options: {
-            path: ['./test/fixtures/single-get.apib', './test/fixtures/single-get.apib']
-          }
+            path: ['./test/fixtures/single-get.apib', './test/fixtures/single-get.apib'],
+          },
         };
 
         const app = express();
@@ -253,13 +253,13 @@ describe('Dredd class Integration', () => {
           options: {
             path: ['./test/fixtures/single-get.apib'],
             reporter: ['apiary'],
-            level: 'verbose'
+            level: 'verbose',
           },
           custom: {
             apiaryReporterEnv: {
-              APIARY_API_URL: `http://127.0.0.1:${PORT + 1}`
-            }
-          }
+              APIARY_API_URL: `http://127.0.0.1:${PORT + 1}`,
+            },
+          },
         };
 
         const apiary = express();
@@ -273,7 +273,7 @@ describe('Dredd class Integration', () => {
           res.status(201).json({
             _id: '1234_id',
             testRunId: '6789_testRunId',
-            reportUrl: 'http://url.me/test/run/1234_id'
+            reportUrl: 'http://url.me/test/run/1234_id',
           });
         });
 
@@ -312,13 +312,13 @@ describe('Dredd class Integration', () => {
           options: {
             path: ['./test/fixtures/single-get.apib'],
             reporter: ['apiary'],
-            level: 'verbose'
+            level: 'verbose',
           },
           custom: {
             apiaryReporterEnv: {
-              APIARY_API_URL: `http://127.0.0.1:${PORT + 1}`
-            }
-          }
+              APIARY_API_URL: `http://127.0.0.1:${PORT + 1}`,
+            },
+          },
         };
 
         const apiary = express();
@@ -333,7 +333,7 @@ describe('Dredd class Integration', () => {
           res.status(201).json({
             _id: '1234_id',
             testRunId: '6789_testRunId',
-            reportUrl: 'http://url.me/test/run/1234_id'
+            reportUrl: 'http://url.me/test/run/1234_id',
           });
         });
 
@@ -379,20 +379,20 @@ describe('Dredd class Integration', () => {
     const errorCmd = {
       server: `http://127.0.0.1:${PORT + 1}`,
       options: {
-        path: [`http://127.0.0.1:${PORT + 1}/connection-error.apib`]
-      }
+        path: [`http://127.0.0.1:${PORT + 1}/connection-error.apib`],
+      },
     };
 
     const wrongCmd = {
       options: {
-        path: [`http://127.0.0.1:${PORT}/not-found.apib`]
-      }
+        path: [`http://127.0.0.1:${PORT}/not-found.apib`],
+      },
     };
 
     const goodCmd = {
       options: {
-        path: [`http://127.0.0.1:${PORT}/file.apib`]
-      }
+        path: [`http://127.0.0.1:${PORT}/file.apib`],
+      },
     };
 
     afterEach(() => { connectedToServer = null; });
@@ -490,8 +490,8 @@ describe('Dredd class Integration', () => {
           options: {
             path: './test/fixtures/single-get.apib',
             sandbox: true,
-            hookfiles: './test/fixtures/sandboxed-hook.js'
-          }
+            hookfiles: './test/fixtures/sandboxed-hook.js',
+          },
         };
 
         const app = express();
@@ -528,12 +528,12 @@ describe('Dredd class Integration', () => {
 after('Machines > Machines collection > Get Machines', function(transaction){
   transaction['fail'] = 'failed in sandboxed hook from string';
 });\
-`
+`,
           },
           options: {
             path: './test/fixtures/single-get.apib',
-            sandbox: true
-          }
+            sandbox: true,
+          },
         };
 
         const app = express();
@@ -574,12 +574,12 @@ before('Machines collection > Get Machines', function(transaction){
   throw(new Error('Fixed transaction name'));
 });
 \
-`
+`,
           },
           options: {
             path: './test/fixtures/single-get-nogroup.apib',
-            sandbox: true
-          }
+            sandbox: true,
+          },
         };
 
         const app = express();
@@ -608,8 +608,8 @@ before('Machines collection > Get Machines', function(transaction){
     before(done =>
       execCommand({
         options: {
-          path: './test/fixtures/multiple-responses.yaml'
-        }
+          path: './test/fixtures/multiple-responses.yaml',
+        },
       }
         , (err) => {
         let groups;
@@ -630,7 +630,7 @@ before('Machines collection > Get Machines', function(transaction){
     [
       { action: 'skip', statusCode: '400' },
       { action: 'skip', statusCode: '500' },
-      { action: 'fail', statusCode: '200' }
+      { action: 'fail', statusCode: '200' },
     ].forEach((expected, i) =>
       context(`the transaction #${i + 1}`, () => {
         it(`has status code ${expected.statusCode}`, () => assert.equal(expected.statusCode, actual[i].statusCode));
@@ -647,8 +647,8 @@ before('Machines collection > Get Machines', function(transaction){
       execCommand({
         options: {
           path: './test/fixtures/multiple-responses.yaml',
-          hookfiles: './test/fixtures/openapi2-multiple-responses.js'
-        }
+          hookfiles: './test/fixtures/openapi2-multiple-responses.js',
+        },
       }
         , (err) => {
         let groups;
@@ -669,7 +669,7 @@ before('Machines collection > Get Machines', function(transaction){
     [
       { action: 'skip', statusCode: '400' },
       { action: 'fail', statusCode: '200' },
-      { action: 'fail', statusCode: '500' } // Unskipped in hooks
+      { action: 'fail', statusCode: '500' }, // Unskipped in hooks
     ].forEach((expected, i) =>
       context(`the transaction #${i + 1}`, () => {
         it(`has status code ${expected.statusCode}`, () => assert.equal(expected.statusCode, actual[i].statusCode));
@@ -689,8 +689,8 @@ before('Machines collection > Get Machines', function(transaction){
       execCommand({
         options: {
           path: './test/fixtures/multiple-responses.yaml',
-          hookfiles: './test/fixtures/openapi2-transaction-names.js'
-        }
+          hookfiles: './test/fixtures/openapi2-transaction-names.js',
+        },
       }
         , (err) => {
         let groups;
@@ -705,7 +705,7 @@ before('Machines collection > Get Machines', function(transaction){
       assert.deepEqual(matches, [
         '/honey > GET > 200 > application/json',
         '/honey > GET > 400 > application/json',
-        '/honey > GET > 500 > application/json'
+        '/honey > GET > 500 > application/json',
       ])
     );
   });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -49,7 +49,7 @@ function recordServerRequest(serverRuntimeInfo, req) {
     method: req.method,
     url: req.url,
     headers: clone(req.headers),
-    body: clone(req.body)
+    body: clone(req.body),
   };
 
   serverRuntimeInfo.lastRequest = recordedReq;
@@ -66,7 +66,7 @@ function getSSLCredentials() {
   const httpsDir = path.join(__dirname, '../fixtures/https');
   return {
     key: fs.readFileSync(path.join(httpsDir, 'server.key'), 'utf8'),
-    cert: fs.readFileSync(path.join(httpsDir, 'server.crt'), 'utf8')
+    cert: fs.readFileSync(path.join(httpsDir, 'server.crt'), 'utf8'),
   };
 }
 
@@ -95,7 +95,7 @@ function createServer(options = {}) {
     requested: false,
     lastRequest: null,
     requests: {},
-    requestCounts: {}
+    requestCounts: {},
   };
 
   let app = express();
@@ -239,5 +239,5 @@ module.exports = {
   runCLIWithServer,
   isProcessRunning,
   kill,
-  killAll
+  killAll,
 };

--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -178,7 +178,7 @@ ${protocol}_proxy=${PROXY_URL}\
         },
         expectedLog,
         expectedDestination: 'server',
-        expectedUrl: '/machines'
+        expectedUrl: '/machines',
       })
     );
 
@@ -195,7 +195,7 @@ ${protocol}_proxy=${PROXY_URL}\
         },
         expectedLog,
         expectedDestination: 'proxy',
-        expectedUrl: `${serverUrl}/apis/public/tests/runs`
+        expectedUrl: `${serverUrl}/apis/public/tests/runs`,
       });
     });
 
@@ -208,7 +208,7 @@ ${protocol}_proxy=${PROXY_URL}\
         },
         expectedLog,
         expectedDestination: 'proxy',
-        expectedUrl: `${serverUrl}/example.apib`
+        expectedUrl: `${serverUrl}/example.apib`,
       })
     );
   });
@@ -240,7 +240,7 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
       },
       expectedLog,
       expectedDestination: 'server',
-      expectedUrl: '/machines'
+      expectedUrl: '/machines',
     })
   );
 
@@ -257,7 +257,7 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
       },
       expectedLog,
       expectedDestination: 'server',
-      expectedUrl: '/apis/public/tests/runs'
+      expectedUrl: '/apis/public/tests/runs',
     });
   });
 
@@ -270,7 +270,7 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
       },
       expectedLog,
       expectedDestination: 'server',
-      expectedUrl: '/example.apib'
+      expectedUrl: '/example.apib',
     })
   );
 });

--- a/test/integration/regressions/regression-152-test.js
+++ b/test/integration/regressions/regression-152-test.js
@@ -14,8 +14,8 @@ describe('Regression: Issue #152', () =>
       const dredd = new Dredd({
         options: {
           path: './test/fixtures/single-get.apib',
-          hookfiles: './test/fixtures/regression-152.coffee'
-        }
+          hookfiles: './test/fixtures/regression-152.coffee',
+        },
       });
 
       runDreddWithServer(dredd, app, (...args) => {

--- a/test/integration/regressions/regression-319-354-test.js
+++ b/test/integration/regressions/regression-319-354-test.js
@@ -71,9 +71,9 @@ describe('Regression: Issues #319 and #354', () => {
     producer: {
       address: {
         city: null,
-        street: ''
-      }
-    }
+        street: '',
+      },
+    },
   };
 
   const brickTypeSchema = {
@@ -91,13 +91,13 @@ describe('Regression: Issues #319 and #354', () => {
             type: 'object',
             properties: {
               city: { type: ['string', 'null'] },
-              street: { type: 'string' }
-            }
-          }
-        }
-      }
+              street: { type: 'string' },
+            },
+          },
+        },
+      },
     },
-    required: ['name']
+    required: ['name'],
   };
 
   const userPayload = {
@@ -106,8 +106,8 @@ describe('Regression: Issues #319 and #354', () => {
     shoeSize: 42,
     address: {
       city: null,
-      street: ''
-    }
+      street: '',
+    },
   };
 
   const userSchema = {
@@ -121,19 +121,19 @@ describe('Regression: Issues #319 and #354', () => {
         type: 'object',
         properties: {
           city: { type: ['string', 'null'] },
-          street: { type: 'string' }
-        }
-      }
-    }
+          street: { type: 'string' },
+        },
+      },
+    },
   };
 
   const userArrayPayload = [
-    userPayload
+    userPayload,
   ];
 
   const userArraySchema = {
     $schema: 'http://json-schema.org/draft-04/schema#',
-    type: 'array'
+    type: 'array',
   };
 
   describe('Tested app is consistent with the API description', () => {
@@ -152,7 +152,7 @@ describe('Regression: Issues #319 and #354', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--inline-errors',
         '--details',
-        '--no-color'
+        '--no-color',
       ];
       runCLIWithServer(args, app, (err, info) => {
         if (info) { results = parseDreddStdout(info.dredd.stdout); }
@@ -207,7 +207,7 @@ describe('Regression: Issues #319 and #354', () => {
 
     const incorrectUserArrayPayload = {
       page: 1,
-      items: [incorrectUserPayload]
+      items: [incorrectUserPayload],
     };
 
     beforeEach((done) => {
@@ -225,7 +225,7 @@ describe('Regression: Issues #319 and #354', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
         '--inline-errors',
         '--details',
-        '--no-color'
+        '--no-color',
       ];
       runCLIWithServer(args, app, (err, info) => {
         if (info) { results = parseDreddStdout(info.dredd.stdout); }

--- a/test/integration/request-test.js
+++ b/test/integration/request-test.js
@@ -73,7 +73,7 @@ describe("Sending 'multipart/form-data' request described in API Blueprint", () 
       '{"test": 42}',
       '',
       '--CUSTOM-BOUNDARY--',
-      ''
+      '',
     ];
     assert.equal(runtimeInfo.server.lastRequest.body, lines.join('\r\n'));
   });
@@ -116,7 +116,7 @@ describe("Sending 'multipart/form-data' request described in OpenAPI 2", () => {
       '{"test": 42}',
       '',
       '--CUSTOM-BOUNDARY--',
-      ''
+      '',
     ];
     assert.equal(runtimeInfo.server.lastRequest.body, lines.join('\r\n'));
   });
@@ -159,7 +159,7 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
       '{"test": 42}',
       '',
       '--BOUNDARY--',
-      ''
+      '',
     ];
     assert.equal(runtimeInfo.server.lastRequest.body, lines.join('\r\n'));
   });
@@ -171,12 +171,12 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/request/application-x-www-form-urlencoded.apib'
+  path: './test/fixtures/request/application-x-www-form-urlencoded.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/request/application-x-www-form-urlencoded.yaml'
-}
+  path: './test/fixtures/request/application-x-www-form-urlencoded.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Sending 'application/x-www-form-urlencoded' request described in ${apiDescription.name}`, () => {
     let runtimeInfo;
@@ -243,12 +243,12 @@ describe('Sending \'text/plain\' request', () => {
 [
   {
     name: 'API Blueprint',
-    path: './test/fixtures/request/application-octet-stream.apib'
+    path: './test/fixtures/request/application-octet-stream.apib',
   },
   {
     name: 'OpenAPI 2',
-    path: './test/fixtures/request/application-octet-stream.yaml'
-  }
+    path: './test/fixtures/request/application-octet-stream.yaml',
+  },
 ].forEach(apiDescription =>
   describe(`Sending 'application/octet-stream' request described in ${apiDescription.name}`, () => {
     let runtimeInfo;
@@ -261,8 +261,8 @@ describe('Sending \'text/plain\' request', () => {
       const dredd = new Dredd({
         options: {
           path: apiDescription.path,
-          hookfiles: './test/fixtures/request/application-octet-stream-hooks.js'
-        }
+          hookfiles: './test/fixtures/request/application-octet-stream-hooks.js',
+        },
       });
       runDreddWithServer(dredd, app, (err, info) => {
         runtimeInfo = info;
@@ -292,12 +292,12 @@ describe('Sending \'text/plain\' request', () => {
 [
   {
     name: 'API Blueprint',
-    path: './test/fixtures/request/image-png.apib'
+    path: './test/fixtures/request/image-png.apib',
   },
   {
     name: 'OpenAPI 2',
-    path: './test/fixtures/request/image-png.yaml'
-  }
+    path: './test/fixtures/request/image-png.yaml',
+  },
 ].forEach(apiDescription =>
   describe(`Sending 'image/png' request described in ${apiDescription.name}`, () => {
     let runtimeInfo;
@@ -310,8 +310,8 @@ describe('Sending \'text/plain\' request', () => {
       const dredd = new Dredd({
         options: {
           path: apiDescription.path,
-          hookfiles: './test/fixtures/request/image-png-hooks.js'
-        }
+          hookfiles: './test/fixtures/request/image-png-hooks.js',
+        },
       });
       runDreddWithServer(dredd, app, (err, info) => {
         runtimeInfo = info;

--- a/test/integration/response-test.js
+++ b/test/integration/response-test.js
@@ -6,12 +6,12 @@ const Dredd = require('../../lib/Dredd');
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib'
+  path: './test/fixtures/response/empty-body-empty-schema.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml'
-}
+  path: './test/fixtures/response/empty-body-empty-schema.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Specifying neither response body nor schema in the ${apiDescription.name}`, () => {
     describe('when the server returns non-empty responses', () => {
@@ -52,12 +52,12 @@ const Dredd = require('../../lib/Dredd');
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body.apib'
+  path: './test/fixtures/response/empty-body.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body.yaml'
-}
+  path: './test/fixtures/response/empty-body.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Specifying no response body in the ${apiDescription.name}, but specifying a schema`, () => {
     describe('when the server returns a response not valid according to the schema', () => {
@@ -97,12 +97,12 @@ const Dredd = require('../../lib/Dredd');
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib'
+  path: './test/fixtures/response/empty-body-empty-schema.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml'
-}
+  path: './test/fixtures/response/empty-body-empty-schema.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
     describe('when the server returns a non-empty responses', () => {
@@ -115,8 +115,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/empty-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;
@@ -138,8 +138,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/empty-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;
@@ -154,12 +154,12 @@ const Dredd = require('../../lib/Dredd');
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib'
+  path: './test/fixtures/response/empty-body-empty-schema.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml'
-}
+  path: './test/fixtures/response/empty-body-empty-schema.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
     describe('when the server returns non-empty responses', () => {
@@ -172,8 +172,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/empty-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;
@@ -195,8 +195,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/empty-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;
@@ -211,12 +211,12 @@ const Dredd = require('../../lib/Dredd');
 
 [{
   name: 'API Blueprint',
-  path: './test/fixtures/response/204-205-body.apib'
+  path: './test/fixtures/response/204-205-body.apib',
 },
 {
   name: 'OpenAPI 2',
-  path: './test/fixtures/response/204-205-body.yaml'
-}
+  path: './test/fixtures/response/204-205-body.yaml',
+},
 ].forEach(apiDescription =>
   describe(`Working with HTTP 204 and 205 responses in the ${apiDescription.name}`, () => {
     describe('when the actual response is non-empty', () => {
@@ -293,12 +293,12 @@ const Dredd = require('../../lib/Dredd');
 [
   {
     name: 'API Blueprint',
-    path: './test/fixtures/response/binary.apib'
+    path: './test/fixtures/response/binary.apib',
   },
   {
     name: 'OpenAPI 2',
-    path: './test/fixtures/response/binary.yaml'
-  }
+    path: './test/fixtures/response/binary.yaml',
+  },
 ].forEach(apiDescription =>
   describe(`Working with binary responses in the ${apiDescription.name}`, () => {
     const imagePath = path.join(__dirname, '../fixtures/image.png');
@@ -314,8 +314,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/binary-ignore-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/binary-ignore-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;
@@ -335,8 +335,8 @@ const Dredd = require('../../lib/Dredd');
         const dredd = new Dredd({
           options: {
             path: apiDescription.path,
-            hookfiles: './test/fixtures/response/binary-assert-body-hooks.js'
-          }
+            hookfiles: './test/fixtures/response/binary-assert-body-hooks.js',
+          },
         });
         runDreddWithServer(dredd, app, (err, info) => {
           runtimeInfo = info;

--- a/test/integration/sanitation-test.js
+++ b/test/integration/sanitation-test.js
@@ -42,8 +42,8 @@ describe('Sanitation of Reported Data', () => {
       emitter,
       options: {
         path: `./test/fixtures/sanitation/${fixtureName}.apib`,
-        hookfiles: `./test/fixtures/sanitation/${fixtureName}.js`
-      }
+        hookfiles: `./test/fixtures/sanitation/${fixtureName}.js`,
+      },
     });
   }
 
@@ -74,7 +74,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
@@ -109,7 +109,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain response body', () => {
@@ -147,7 +147,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain confidential body attribute', () => {
@@ -185,7 +185,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain confidential body attribute', () => {
@@ -226,7 +226,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does contain the sensitive data censored', () => {
@@ -257,7 +257,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain confidential header', () => {
@@ -296,7 +296,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain confidential header', () => {
@@ -338,7 +338,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does contain the sensitive data censored', () => assert.include(events[2].test.request.uri, 'CENSORED'));
@@ -368,7 +368,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does contain the sensitive data censored', () => assert.include(JSON.stringify(events), 'CENSORED'));
@@ -396,7 +396,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
@@ -427,7 +427,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test pass', 'end'
+        'start', 'test start', 'test pass', 'end',
       ])
     );
     it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
@@ -462,7 +462,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test is failed', () => {
@@ -501,7 +501,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
@@ -541,7 +541,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test skip', 'end'
+        'start', 'test start', 'test skip', 'end',
       ])
     );
     it('emitted test is skipped', () => {
@@ -580,7 +580,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test error', 'end'
+        'start', 'test start', 'test error', 'end',
       ])
     );
     it('sensitive data leak to emitted test data', () => {
@@ -614,7 +614,7 @@ describe('Sanitation of Reported Data', () => {
     });
     it('emits expected events in expected order', () =>
       assert.deepEqual((Array.from(events).map(event => event.name)), [
-        'start', 'test start', 'test fail', 'end'
+        'start', 'test start', 'test fail', 'end',
       ])
     );
     it('sensitive data cannot be found anywhere in the emitted test data', () => {

--- a/test/unit/CLI-test.js
+++ b/test/unit/CLI-test.js
@@ -18,17 +18,17 @@ let stderr = '';
 let stdout = '';
 
 const addHooksStub = proxyquire('../../lib/addHooks', {
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const transactionRunner = proxyquire('../../lib/TransactionRunner', {
   './addHooks': addHooksStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const DreddStub = proxyquire('../../lib/Dredd', {
   './TransactionRunner': transactionRunner,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const initStub = sinon.stub().callsFake((config, save, callback) => {
@@ -43,7 +43,7 @@ const CLIStub = proxyquire('../../lib/CLI', {
   './init': initStub,
   './configUtils': configUtilsStub,
   fs: fsStub,
-  'cross-spawn': crossSpawnStub
+  'cross-spawn': crossSpawnStub,
 });
 
 function execCommand(custom = {}, cb) {
@@ -51,7 +51,7 @@ function execCommand(custom = {}, cb) {
   stderr = '';
   let finished = false;
   (new CLIStub({
-    custom
+    custom,
   }, ((code) => {
       if (!finished) {
         finished = true;
@@ -70,7 +70,7 @@ describe('CLI class', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => {
       sinon.stub(loggerStub, method).callsFake((chunk) => { stdout += `\n${method}: ${chunk}`; });
     });
@@ -84,7 +84,7 @@ describe('CLI class', () => {
     [
       'log', 'info', 'silly', 'verbose', 'test',
       'hook', 'complete', 'pass', 'skip', 'debug',
-      'fail', 'request', 'expected', 'actual'
+      'fail', 'request', 'expected', 'actual',
     ].forEach((method) => {
       loggerStub[method].restore();
     });
@@ -119,7 +119,7 @@ describe('CLI class', () => {
     before(() => {
       dc = new CLIStub({ exit() {
         hasCalledExit = true;
-      }
+      },
       });
       dc.run();
     });
@@ -151,8 +151,8 @@ describe('CLI class', () => {
         exit() {},
         custom: {
           argv: ['./file.apib', 'http://127.0.0.1:3000'],
-          env: { NO_KEY: 'NO_VAL' }
-        }
+          env: { NO_KEY: 'NO_VAL' },
+        },
       });
 
       sinon.stub(dc, 'initDredd').callsFake((configuration) => {
@@ -215,13 +215,13 @@ describe('CLI class', () => {
           argv: [
             './test/fixtures/single-get.apib',
             `http://127.0.0.1:${PORT}`,
-            '--path=./test/fixtures/single-get.apib'
-          ]
+            '--path=./test/fixtures/single-get.apib',
+          ],
         },
         exit(code) {
           exitStatus = code;
           server.close();
-        }
+        },
       });
 
       const server = app.listen(PORT, () => dc.run());
@@ -311,7 +311,7 @@ describe('CLI class', () => {
           skipped: 0,
           start: 0,
           end: 0,
-          duration: 0
+          duration: 0,
         };
         cb(null, stats);
       });
@@ -346,7 +346,7 @@ describe('CLI class', () => {
           timestamp: false,
           silent: false,
           path: [],
-          $0: 'node ./bin/dredd'
+          $0: 'node ./bin/dredd',
         }));
 
       execCommand({ argv: ['--names'] }, () => done());
@@ -381,8 +381,8 @@ describe('CLI class', () => {
         './test/fixtures/single-get.apib',
         `http://127.0.0.1:${PORT}`,
         '--server',
-        'foo/bar'
-      ]
+        'foo/bar',
+      ],
       }, () => done());
     });
 

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -13,7 +13,7 @@ const Dredd = proxyquire('../../lib/Dredd', {
   request: requestStub,
   'dredd-transactions': dreddTransactionsStub,
   fs: fsStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 describe('Dredd class', () => {
@@ -28,7 +28,7 @@ describe('Dredd class', () => {
     before(() => {
       configuration = {
         server: 'http://127.0.0.1:3000/',
-        blueprintPath: './test/fixtures/apiary.apib'
+        blueprintPath: './test/fixtures/apiary.apib',
       };
       sinon.stub(loggerStub, 'info').callsFake(() => { });
       sinon.stub(loggerStub, 'log').callsFake(() => { });
@@ -64,8 +64,8 @@ describe('Dredd class', () => {
           header: 'Accept:application/json',
           user: 'bob:test',
           sorted: true,
-          path: ['./test/fixtures/apiary.apib']
-        }
+          path: ['./test/fixtures/apiary.apib'],
+        },
       };
     });
 
@@ -122,8 +122,8 @@ describe('Dredd class', () => {
           server: 'http://127.0.0.1:3000/',
           options: {
             silent: true,
-            path: ['./test/fixtures/multifile/*.apib', './test/fixtures/multifile/*.apib']
-          }
+            path: ['./test/fixtures/multifile/*.apib', './test/fixtures/multifile/*.apib'],
+          },
         };
         dredd = new Dredd(configuration);
       });
@@ -182,8 +182,8 @@ describe('Dredd class', () => {
           server: 'http://127.0.0.1:3000/',
           options: {
             silent: true,
-            path: ['./test/fixtures/multifile/*.balony', './test/fixtures/multifile/*.apib']
-          }
+            path: ['./test/fixtures/multifile/*.balony', './test/fixtures/multifile/*.apib'],
+          },
         };
         dredd = new Dredd(configuration);
       });
@@ -209,8 +209,8 @@ describe('Dredd class', () => {
           server: 'http://127.0.0.1:3000/',
           options: {
             silent: true,
-            path: ['./test/fixtures/multifile/*.balony']
-          }
+            path: ['./test/fixtures/multifile/*.balony'],
+          },
         };
         dredd = new Dredd(configuration);
       });
@@ -235,7 +235,7 @@ describe('Dredd class', () => {
         configuration = {
           server: 'http://127.0.0.1:3000/',
           options: {
-            silent: true
+            silent: true,
           },
           data: {
             testingDirectObject: {
@@ -247,7 +247,7 @@ GET /url
 + Response 200 (application/json)
 
         {"a":"b"}'\
-`
+`,
             },
             testingDirectBlueprintString: `\
 # API name
@@ -256,8 +256,8 @@ GET /url
 + Response 200 (application/json)
 
         {"a":"b"}'\
-`
-          }
+`,
+          },
         };
         dredd = new Dredd(configuration);
         sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
@@ -336,8 +336,8 @@ GET /url
           server: 'http://127.0.0.1:3000/',
           options: {
             silent: true,
-            path: ['http://some.path.to/file.apib', 'https://another.path.to/apiary.apib', './test/fixtures/multifile/*.apib']
-          }
+            path: ['http://some.path.to/file.apib', 'https://another.path.to/apiary.apib', './test/fixtures/multifile/*.apib'],
+          },
         };
         dredd = new Dredd(configuration);
         fsStub.readFile('./test/fixtures/single-get.apib', 'utf8', (err, content) => {
@@ -369,7 +369,7 @@ GET /url
               'https://another.path.to/apiary.apib',
               './test/fixtures/multifile/message.apib',
               './test/fixtures/multifile/greeting.apib',
-              './test/fixtures/multifile/name.apib'
+              './test/fixtures/multifile/name.apib',
             ]);
             done();
           })
@@ -489,8 +489,8 @@ GET /url
         url: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./test/fixtures/error-blueprint.apib']
-        }
+          path: ['./test/fixtures/error-blueprint.apib'],
+        },
       };
       dredd = new Dredd(configuration);
     });
@@ -522,8 +522,8 @@ GET /url
         url: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./test/fixtures/warning-ambiguous.apib']
-        }
+          path: ['./test/fixtures/warning-ambiguous.apib'],
+        },
       };
       dredd = new Dredd(configuration);
     });
@@ -559,8 +559,8 @@ GET /url
         url: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./balony/path.apib']
-        }
+          path: ['./balony/path.apib'],
+        },
       };
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
@@ -589,8 +589,8 @@ GET /url
         server: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./test/fixtures/error-uri-template.apib']
-        }
+          path: ['./test/fixtures/error-uri-template.apib'],
+        },
       };
 
       dredd = new Dredd(configuration);
@@ -620,8 +620,8 @@ GET /url
         server: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./test/fixtures/warning-ambiguous.apib']
-        }
+          path: ['./test/fixtures/warning-ambiguous.apib'],
+        },
       };
       sinon.spy(loggerStub, 'warn');
       dredd = new Dredd(configuration);
@@ -661,8 +661,8 @@ GET /url
         server: 'http://127.0.0.1:3000/',
         options: {
           silent: true,
-          path: ['./test/fixtures/apiary.apib']
-        }
+          path: ['./test/fixtures/apiary.apib'],
+        },
       };
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
@@ -695,9 +695,9 @@ GET /url
               apiaryApiUrl: `http://127.0.0.1:${PORT + 1}`,
               apiaryApiKey: 'the-key',
               apiaryApiName: 'the-api-name',
-              dreddRestDebug: '1'
-            }
-          }
+              dreddRestDebug: '1',
+            },
+          },
         };
 
         dredd = new Dredd(configuration);
@@ -709,7 +709,7 @@ GET /url
           res.status(201).json({
             _id: '1234_id',
             testRunId: '6789_testRunId',
-            reportUrl: 'http://url.me/test/run/1234_id'
+            reportUrl: 'http://url.me/test/run/1234_id',
           })
         );
 
@@ -751,9 +751,9 @@ GET /url
               apiaryApiUrl: `http://127.0.0.1:${PORT + 1}`,
               apiaryApiKey: 'the-key',
               apiaryApiName: 'the-api-name',
-              dreddRestDebug: '1'
-            }
-          }
+              dreddRestDebug: '1',
+            },
+          },
         };
 
         dredd = new Dredd(configuration);

--- a/test/unit/Hooks-test.js
+++ b/test/unit/Hooks-test.js
@@ -16,8 +16,8 @@ describe('Hooks', () => {
         logs: [{ content: 'message1' }, { content: 'message2' }],
         logger: {
           hook() {},
-          error() {}
-        }
+          error() {},
+        },
       };
 
       const hooks = new Hooks(options);
@@ -34,8 +34,8 @@ describe('Hooks', () => {
         logs: [{ content: 'message1' }, { content: 'message2' }],
         logger: {
           hook() {},
-          error() {}
-        }
+          error() {},
+        },
       };
       sinon.spy(options.logger, 'hook');
       sinon.spy(options.logger, 'error');
@@ -170,7 +170,7 @@ describe('Hooks', () => {
         'beforeEachHooks',
         'afterEachHooks',
         'afterAllHooks',
-        'beforeEachValidationHooks'
+        'beforeEachValidationHooks',
       ];
 
       properties.forEach((property) => {
@@ -198,7 +198,7 @@ describe('Hooks', () => {
       properties = [
         'beforeHooks',
         'afterHooks',
-        'beforeValidationHooks'
+        'beforeValidationHooks',
       ];
 
       properties.forEach((property) => {

--- a/test/unit/HooksWorkerClient-test.js
+++ b/test/unit/HooksWorkerClient-test.js
@@ -30,7 +30,7 @@ const logLevels = ['error', 'log', 'info', 'warn'];
 const HooksWorkerClient = proxyquire('../../lib/HooksWorkerClient', {
   'cross-spawn': crossSpawnStub,
   './which': whichStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const TransactionRunner = require('../../lib/TransactionRunner');
@@ -167,8 +167,8 @@ describe('Hooks worker client', () => {
       beforeEach(() => {
         runner.hooks.configuration = {
           options: {
-            language: 'nodejs'
-          }
+            language: 'nodejs',
+          },
         };
       });
 
@@ -193,8 +193,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'ruby',
-            hookfiles: 'somefile.rb'
-          }
+            hookfiles: 'somefile.rb',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -243,8 +243,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'ruby',
-            hookfiles: 'somefile.rb'
-          }
+            hookfiles: 'somefile.rb',
+          },
         };
       });
 
@@ -272,8 +272,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'python',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -322,8 +322,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'python',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
       });
 
@@ -350,8 +350,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'php',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -400,8 +400,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'php',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
       });
 
@@ -430,8 +430,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'go',
-            hookfiles: 'gobinary'
-          }
+            hookfiles: 'gobinary',
+          },
         };
       });
       afterEach(() => {
@@ -469,8 +469,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'go',
-            hookfiles: 'gobinary'
-          }
+            hookfiles: 'gobinary',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -522,8 +522,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'rust',
-            hookfiles: 'rustbinary'
-          }
+            hookfiles: 'rustbinary',
+          },
         };
       });
       afterEach(() => whichStub.which.restore());
@@ -549,8 +549,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'rust',
-            hookfiles: 'rustbinary'
-          }
+            hookfiles: 'rustbinary',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -604,8 +604,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'perl',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
@@ -654,8 +654,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'perl',
-            hookfiles: 'somefile.py'
-          }
+            hookfiles: 'somefile.py',
+          },
         };
       });
 
@@ -682,8 +682,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: './my-fancy-command',
-            hookfiles: 'someotherfile'
-          }
+            hookfiles: 'someotherfile',
+          },
         };
 
         sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
@@ -730,8 +730,8 @@ describe('Hooks worker client', () => {
         runner.hooks.configuration = {
           options: {
             language: 'ruby',
-            hookfiles: 'somefile.rb'
-          }
+            hookfiles: 'somefile.rb',
+          },
         };
 
         sinon.stub(HooksWorkerClient.prototype, 'spawnHandler').callsFake(callback => callback());
@@ -765,7 +765,7 @@ describe('Hooks worker client', () => {
         'beforeEachValidation',
         'afterEach',
         'beforeAll',
-        'afterAll'
+        'afterAll',
       ];
 
       Array.from(eventTypes).forEach((eventType) => {
@@ -829,7 +829,7 @@ describe('Hooks worker client', () => {
       'beforeEachValidation',
       'afterEach',
       'beforeAll',
-      'afterAll'
+      'afterAll',
     ];
 
     Array.from(eventTypes).forEach((eventType) => {
@@ -873,7 +873,7 @@ describe('Hooks worker client', () => {
           const keys = [
             'data',
             'event',
-            'uuid'
+            'uuid',
           ];
 
           Array.from(keys).forEach((key) => {
@@ -901,7 +901,7 @@ describe('Hooks worker client', () => {
   describe('when hook handler server is running and modifying transactions', () => {
     let transaction = {
       name: 'API > Hello > World',
-      request: { method: 'POST', uri: '/message', headers: {}, body: 'Hello World!' }
+      request: { method: 'POST', uri: '/message', headers: {}, body: 'Hello World!' },
     };
 
     return [
@@ -909,7 +909,7 @@ describe('Hooks worker client', () => {
       'beforeEach',
       'beforeEachValidation',
       'afterEach',
-      'afterAll'
+      'afterAll',
     ].forEach((eventName) => {
       let getFirstTransaction;
       let transactionData;
@@ -992,36 +992,36 @@ describe('Hooks worker client', () => {
   describe("'hooks-worker-*' configuration options", () => {
     const scenarios = [{
       property: 'timeout',
-      option: 'hooks-worker-timeout'
+      option: 'hooks-worker-timeout',
     },
     {
       property: 'connectTimeout',
-      option: 'hooks-worker-connect-timeout'
+      option: 'hooks-worker-connect-timeout',
     },
     {
       property: 'connectRetry',
-      option: 'hooks-worker-connect-retry'
+      option: 'hooks-worker-connect-retry',
     },
     {
       property: 'afterConnectWait',
-      option: 'hooks-worker-after-connect-wait'
+      option: 'hooks-worker-after-connect-wait',
     },
     {
       property: 'termTimeout',
-      option: 'hooks-worker-term-timeout'
+      option: 'hooks-worker-term-timeout',
     },
     {
       property: 'termRetry',
-      option: 'hooks-worker-term-retry'
+      option: 'hooks-worker-term-retry',
     },
     {
       property: 'handlerHost',
-      option: 'hooks-worker-handler-host'
+      option: 'hooks-worker-handler-host',
     },
     {
       property: 'handlerPort',
-      option: 'hooks-worker-handler-port'
-    }
+      option: 'hooks-worker-handler-port',
+    },
     ];
 
     Array.from(scenarios).forEach((scenario) => {

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -23,7 +23,7 @@ const addHooks = proxyquire('../../lib/addHooks', {
   proxyquire: proxyquireStub,
   './sandboxHooksCode': sandboxHooksCodeSpy,
   './HooksWorkerClient': hooksWorkerClientStub,
-  fs: fsStub
+  fs: fsStub,
 });
 
 describe('addHooks(runner, transactions, callback)', () => {
@@ -38,9 +38,9 @@ describe('addHooks(runner, transactions, callback)', () => {
       logs: ['item'],
       configuration: {
         options: {
-          hookfiles: null
-        }
-      }
+          hookfiles: null,
+        },
+      },
     };
 
     it('should create hooks instance at runner.hooks', done =>
@@ -76,9 +76,9 @@ describe('addHooks(runner, transactions, callback)', () => {
       runner = {
         configuration: {
           options: {
-            hookfiles: null
-          }
-        }
+            hookfiles: null,
+          },
+        },
       };
 
       sinon.spy(globStub, 'sync');
@@ -102,9 +102,9 @@ describe('addHooks(runner, transactions, callback)', () => {
         configuration: {
           options: {
             language: 'ruby',
-            hookfiles: './test/fixtures/non-js-hooks.rb'
-          }
-        }
+            hookfiles: './test/fixtures/non-js-hooks.rb',
+          },
+        },
       };
 
       sinon.stub(hooksWorkerClientStub.prototype, 'start').callsFake(cb => cb());
@@ -128,9 +128,9 @@ describe('addHooks(runner, transactions, callback)', () => {
       runner = {
         configuration: {
           options: {
-            hookfiles: './test/**/*_hooks.*'
-          }
-        }
+            hookfiles: './test/**/*_hooks.*',
+          },
+        },
       };
     });
 
@@ -151,7 +151,7 @@ describe('addHooks(runner, transactions, callback)', () => {
         assert.deepEqual(runner.hooks.configuration.options.hookfiles, [
           pathStub.resolve(process.cwd(), './test/fixtures/multifile/multifile_hooks.coffee'),
           pathStub.resolve(process.cwd(), './test/fixtures/test2_hooks.js'),
-          pathStub.resolve(process.cwd(), './test/fixtures/test_hooks.coffee')
+          pathStub.resolve(process.cwd(), './test/fixtures/test_hooks.coffee'),
         ]);
         done();
       })
@@ -163,9 +163,9 @@ describe('addHooks(runner, transactions, callback)', () => {
         runner = {
           configuration: {
             options: {
-              hookfiles: './test/**/*_hooks.*'
-            }
-          }
+              hookfiles: './test/**/*_hooks.*',
+            },
+          },
         };
         sinon.stub(globStub, 'sync').callsFake(() => ['file1.js', 'file2.coffee']);
         sinon.stub(pathStub, 'resolve').callsFake(() => '/Users/netmilk/projects/dredd/file2.coffee');
@@ -204,9 +204,9 @@ describe('addHooks(runner, transactions, callback)', () => {
           configuration: {
             options: {
               hookfiles: './test/fixtures/sandboxed-hook.js',
-              sandbox: true
-            }
-          }
+              sandbox: true,
+            },
+          },
         };
 
         sinon.spy(loggerStub, 'warn');
@@ -269,12 +269,12 @@ describe('addHooks(runner, transactions, callback)', () => {
 after('Machines > Machines collection > Get Machines', function(transaction){
   transaction['fail'] = 'failed in sandboxed hook';
 });\
-`
+`,
             },
             options: {
-              sandbox: true
-            }
-          }
+              sandbox: true,
+            },
+          },
         };
 
         sinon.spy(loggerStub, 'warn');
@@ -327,10 +327,10 @@ after('Machines > Machines collection > Get Machines', function(transaction){
 after('Machines > Machines collection > Get Machines', function(transaction){
   transaction['fail'] = 'failed in sandboxed hook';
 });\
-`
+`,
             },
-            options: {}
-          }
+            options: {},
+          },
         };
       });
 
@@ -357,12 +357,12 @@ after(' > Machines collection > Get Machines', function(transaction){
 before(' > Machines collection > Get Machines', function(transaction){
   transaction['fail'] = 'failed in sandboxed hook';
 });\
-`
+`,
               },
               options: {
-                sandbox: true
-              }
-            }
+                sandbox: true,
+              },
+            },
           };
 
           addHooks(runner, transactions, () => {
@@ -383,12 +383,12 @@ after(' > Machines collection > Get Machines', function(transaction){
 before(' > Machines collection > Get Machines', function(transaction){
   transaction['fail'] = 'failed in sandboxed hook';
 });\
-`
+`,
               },
               options: {
-                sandbox: true
-              }
-            }
+                sandbox: true,
+              },
+            },
           };
 
           addHooks(runner, transactions, () => {
@@ -406,9 +406,9 @@ before(' > Machines collection > Get Machines', function(transaction){
       const runner = {
         configuration: {
           options: {
-            hookfiles: './test/fixtures/groupless-names.js'
-          }
-        }
+            hookfiles: './test/fixtures/groupless-names.js',
+          },
+        },
       };
 
       addHooks(runner, transactions, () => {
@@ -422,9 +422,9 @@ before(' > Machines collection > Get Machines', function(transaction){
       const runner = {
         configuration: {
           options: {
-            hookfiles: './test/fixtures/groupless-names.js'
-          }
-        }
+            hookfiles: './test/fixtures/groupless-names.js',
+          },
+        },
       };
 
       addHooks(runner, transactions, () => {

--- a/test/unit/blueprintUtils-test.js
+++ b/test/unit/blueprintUtils-test.js
@@ -38,7 +38,7 @@ describe('blueprintUtils', () => {
         [str.indexOf('seven'), 2],
         [str.indexOf('eight'), 2],
         // Also add just one single line warning location
-        [str.indexOf('ten'), 3]
+        [str.indexOf('ten'), 3],
       ];
       const ranges = blueprintUtils.warningLocationToRanges(location, str);
       assert.isArray(ranges);
@@ -46,7 +46,7 @@ describe('blueprintUtils', () => {
       assert.deepEqual(ranges, [
         { start: 2, end: 4 },
         { start: 6, end: 8 },
-        { start: 10, end: 10 }
+        { start: 10, end: 10 },
       ]);
     });
 
@@ -72,13 +72,13 @@ describe('blueprintUtils', () => {
           sourceMap: [
             {
               element: 'sourceMap',
-              content: [[59, 17], [78, 10]]
-            }
-          ]
+              content: [[59, 17], [78, 10]],
+            },
+          ],
         },
         content:
           'message-body asset is expected to be a pre-formatted code ' +
-          'block, every of its line indented by exactly 8 spaces or 2 tabs'
+          'block, every of its line indented by exactly 8 spaces or 2 tabs',
       };
 
       location = [];
@@ -105,7 +105,7 @@ describe('blueprintUtils', () => {
         const line = blueprintUtils.rangesToLinesText([
           { start: 2, end: 4 },
           { start: 8, end: 8 },
-          { start: 10, end: 15 }
+          { start: 10, end: 15 },
         ]);
         assert.strictEqual(line, 'lines 2-4, line 8, lines 10-15');
       })
@@ -151,13 +151,13 @@ describe('blueprintUtils', () => {
             sourceMap: [
               {
                 element: 'sourceMap',
-                content: [[70, 23], [95, 24]]
-              }
-            ]
+                content: [[70, 23], [95, 24]],
+              },
+            ],
           },
           content:
             'message-body asset is expected to be a pre-formatted code ' +
-            'block, every of its line indented by exactly 8 spaces or 2 tabs'
+            'block, every of its line indented by exactly 8 spaces or 2 tabs',
         },
         {
           element: 'annotation',
@@ -167,13 +167,13 @@ describe('blueprintUtils', () => {
             sourceMap: [
               {
                 element: 'sourceMap',
-                content: [[168, 39]]
-              }
-            ]
+                content: [[168, 39]],
+              },
+            ],
           },
           content:
             'headers is expected to be a pre-formatted code block, every ' +
-            'of its line indented by exactly 12 spaces or 3 tabs'
+            'of its line indented by exactly 12 spaces or 3 tabs',
         },
         {
           element: 'annotation',
@@ -183,13 +183,13 @@ describe('blueprintUtils', () => {
             sourceMap: [
               {
                 element: 'sourceMap',
-                content: [[224, 33]]
-              }
-            ]
+                content: [[224, 33]],
+              },
+            ],
           },
           content:
             'message-body asset is expected to be a pre-formatted code ' +
-            'block, every of its line indented by exactly 12 spaces or 3 tabs'
+            'block, every of its line indented by exactly 12 spaces or 3 tabs',
         },
         {
           element: 'annotation',
@@ -199,14 +199,14 @@ describe('blueprintUtils', () => {
             sourceMap: [
               {
                 element: 'sourceMap',
-                content: [[302, 12], [318, 12], [334, 14]]
-              }
-            ]
+                content: [[302, 12], [318, 12], [334, 14]],
+              },
+            ],
           },
           content:
             'message-body asset is expected to be a pre-formatted code ' +
-            'block, every of its line indented by exactly 8 spaces or 2 tabs'
-        }
+            'block, every of its line indented by exactly 8 spaces or 2 tabs',
+        },
       ];
 
       for (const annotation of annotations) {
@@ -224,7 +224,7 @@ describe('blueprintUtils', () => {
           'lines 5-6',
           'line 12',
           'line 16',
-          'lines 21-23'
+          'lines 21-23',
         ];
         const result = [];
         for (let lineIndex = 0; lineIndex < expectedLines.length; lineIndex++) {

--- a/test/unit/configUtils-test.js
+++ b/test/unit/configUtils-test.js
@@ -7,7 +7,7 @@ const { assert } = require('chai');
 
 const configUtils = proxyquire('../../lib/configUtils', {
   fs: fsStub,
-  'js-yaml': yamlStub
+  'js-yaml': yamlStub,
 });
 
 const argvData = {
@@ -58,7 +58,7 @@ const argvData = {
   q: false,
   path: [],
   p: [],
-  $0: 'node ./bin/dredd'
+  $0: 'node ./bin/dredd',
 };
 
 describe('configUtils', () => {
@@ -224,7 +224,7 @@ endpoint: endpoint\
   describe('parseCustom(arrayOfCustoms)', () => {
     const custom = [
       'customOpt:itsValue:can:contain:delimiters',
-      'customOpt2:itsValue'
+      'customOpt2:itsValue',
     ];
 
     it('shold return an object', () => {

--- a/test/unit/configuration-test.js
+++ b/test/unit/configuration-test.js
@@ -14,7 +14,7 @@ describe('configuration.applyLoggingOptions()', () => {
   it('applies logging options', () => {
     config = configuration.applyLoggingOptions({
       color: 'true',
-      level: 'debug'
+      level: 'debug',
     });
 
     assert.propertyVal(config, 'color', true);
@@ -50,8 +50,8 @@ describe('configuration.applyConfiguration()', () => {
     config = configuration.applyConfiguration({
       options: {
         color: 'true',
-        level: 'debug'
-      }
+        level: 'debug',
+      },
     });
 
     assert.nestedPropertyVal(config, 'options.color', true);

--- a/test/unit/configureReporters-test.js
+++ b/test/unit/configureReporters-test.js
@@ -30,7 +30,7 @@ const configureReporters = proxyquire('../../lib/configureReporters', {
   './reporters/NyanReporter': NyanCatReporterStub,
   './reporters/HTMLReporter': HtmlReporterStub,
   './reporters/MarkdownReporter': MarkdownReporterStub,
-  './reporters/ApiaryReporter': ApiaryReporterStub
+  './reporters/ApiaryReporter': ApiaryReporterStub,
 });
 
 const resetStubs = function () {
@@ -53,8 +53,8 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       reporter: [],
       output: [],
       silent: false,
-      'inline-errors': false
-    }
+      'inline-errors': false,
+    },
   };
 
   before(() => loggerStub.transports.console.silent = true);

--- a/test/unit/hooksLog-test.js
+++ b/test/unit/hooksLog-test.js
@@ -9,7 +9,7 @@ const loggerStub = require('../../lib/logger');
 
 describe('hooksLog()', () => {
   const exampleLogs = [
-    { content: 'some text' }
+    { content: 'some text' },
   ];
 
   before(() => {

--- a/test/unit/hooksLogSandboxed-test.js
+++ b/test/unit/hooksLogSandboxed-test.js
@@ -6,12 +6,12 @@ const { assert } = require('chai');
 const hooksLogStubSpy = sinon.spy(require('../../lib/hooksLog'));
 
 const hooksLogSandboxed = proxyquire('../../lib/hooksLogSandboxed', {
-  './hooksLog': hooksLogStubSpy
+  './hooksLog': hooksLogStubSpy,
 });
 
 describe('hooksLogSandboxed()', () => {
   const exampleLog = [
-    { content: 'some text' }
+    { content: 'some text' },
   ];
 
   describe('basic functionality', () => {

--- a/test/unit/init/applyAnswers-test.js
+++ b/test/unit/init/applyAnswers-test.js
@@ -14,7 +14,7 @@ describe('init._applyAnswers()', () => {
     appveyor: sinon.spy(),
     circleci: sinon.spy(),
     travisci: sinon.spy(),
-    wercker: sinon.spy()
+    wercker: sinon.spy(),
   };
 
   beforeEach(() => Object.keys(ci).forEach(name => ci[name].resetHistory()));
@@ -22,7 +22,7 @@ describe('init._applyAnswers()', () => {
   it('applies the API description and the API host as positional CLI arguments', () => {
     const config = applyAnswers(createConfig(), {
       apiDescription: 'apiary.apib',
-      apiHost: 'http://127.0.0.1:5000'
+      apiHost: 'http://127.0.0.1:5000',
     });
     assert.deepEqual(config._, ['apiary.apib', 'http://127.0.0.1:5000']);
   });

--- a/test/unit/init/detectLanguage-test.js
+++ b/test/unit/init/detectLanguage-test.js
@@ -11,7 +11,7 @@ describe('init._detectLanguage()', () => {
   [
     { name: 'Rust', value: 'rust', file: 'Cargo.toml' },
     { name: 'Go', value: 'go', file: 'foo.go' },
-    { name: 'PHP', value: 'php', file: 'composer.json' }
+    { name: 'PHP', value: 'php', file: 'composer.json' },
   ].forEach(({ name, value, file }) => {
     it(`prioritizes ${name} over Python`, () =>
       assert.equal(detectLanguage(['README', 'Pipfile', file]), value)

--- a/test/unit/init/printClosingMessage-test.js
+++ b/test/unit/init/printClosingMessage-test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 
 const {
-  _printClosingMessage: printClosingMessage
+  _printClosingMessage: printClosingMessage,
 } = require('../../../lib/init');
 
 

--- a/test/unit/init/updateWercker-test.js
+++ b/test/unit/init/updateWercker-test.js
@@ -18,7 +18,7 @@ describe('init._updateWercker()', () => {
 
   it('adds commands to install and run Dredd', () => {
     const contents = { build: { steps: [
-      { script: { name: 'pipenv-install', code: 'pipenv install' } }
+      { script: { name: 'pipenv-install', code: 'pipenv install' } },
     ] } };
     updateWercker(createOptions(contents));
 

--- a/test/unit/mergeSandboxedHooks-test.js
+++ b/test/unit/mergeSandboxedHooks-test.js
@@ -12,7 +12,7 @@ describe('mergeSandboxedHooks', () => {
     before: { 'Transaction Name': ['original'] },
     after: { 'Transaction Name': ['original'] },
     afterEach: ['original'],
-    afterAll: ['original']
+    afterAll: ['original'],
   };
 
   const toBeMergedObject = {
@@ -21,7 +21,7 @@ describe('mergeSandboxedHooks', () => {
     before: { 'Transaction Name': ['merged'] },
     after: { 'Transaction Name': ['merged'] },
     afterEach: ['merged'],
-    afterAll: ['merged']
+    afterAll: ['merged'],
   };
 
   let originalHooks;

--- a/test/unit/performRequest/createTransactionResponse-test.js
+++ b/test/unit/performRequest/createTransactionResponse-test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 
 const {
-  _createTransactionResponse: createTransactionResponse
+  _createTransactionResponse: createTransactionResponse,
 } = require('../../../lib/performRequest');
 
 
@@ -18,7 +18,7 @@ describe('performRequest._createTransactionResponse()', () => {
     const headers = { 'Content-Type': 'application/json' };
     const transactionRes = createTransactionResponse({
       statusCode: 200,
-      headers
+      headers,
     });
     headers['X-Header'] = 'abcd';
 
@@ -46,7 +46,7 @@ describe('performRequest._createTransactionResponse()', () => {
         statusCode: 200,
         headers: {},
         body: Buffer.from([0xFF, 0xBE]).toString('base64'),
-        bodyEncoding: 'base64'
+        bodyEncoding: 'base64',
       }
     )
   );

--- a/test/unit/performRequest/detectBodyEncoding-test.js
+++ b/test/unit/performRequest/detectBodyEncoding-test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 
 const {
-  _detectBodyEncoding: detectBodyEncoding
+  _detectBodyEncoding: detectBodyEncoding,
 } = require('../../../lib/performRequest');
 
 

--- a/test/unit/performRequest/getBodyAsBuffer-test.js
+++ b/test/unit/performRequest/getBodyAsBuffer-test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 
 const {
-  _getBodyAsBuffer: getBodyAsBuffer
+  _getBodyAsBuffer: getBodyAsBuffer,
 } = require('../../../lib/performRequest');
 
 

--- a/test/unit/performRequest/normalizeBodyEncoding-test.js
+++ b/test/unit/performRequest/normalizeBodyEncoding-test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 
 const {
-  _normalizeBodyEncoding: normalizeBodyEncoding
+  _normalizeBodyEncoding: normalizeBodyEncoding,
 } = require('../../../lib/performRequest');
 
 

--- a/test/unit/performRequest/normalizeContentLengthHeader-test.js
+++ b/test/unit/performRequest/normalizeContentLengthHeader-test.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const { assert } = require('chai');
 
 const {
-  _normalizeContentLengthHeader: normalizeContentLengthHeader
+  _normalizeContentLengthHeader: normalizeContentLengthHeader,
 } = require('../../../lib/performRequest');
 
 
@@ -28,7 +28,7 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
   describe('when there is no body and the Content-Length is set to 0', () => {
     beforeEach(() => {
       headers = normalizeContentLengthHeader({
-        'Content-Length': '0'
+        'Content-Length': '0',
       }, Buffer.from(''), { logger });
     });
 
@@ -56,7 +56,7 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
   describe('when there is body and the Content-Length is correct', () => {
     beforeEach(() => {
       headers = normalizeContentLengthHeader({
-        'Content-Length': '4'
+        'Content-Length': '4',
       }, Buffer.from('abcd'), { logger });
     });
 
@@ -71,7 +71,7 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
   describe('when there is no body and the Content-Length is wrong', () => {
     beforeEach(() => {
       headers = normalizeContentLengthHeader({
-        'Content-Length': '42'
+        'Content-Length': '42',
       }, Buffer.from(''), { logger });
     });
 
@@ -86,7 +86,7 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
   describe('when there is body and the Content-Length is wrong', () => {
     beforeEach(() => {
       headers = normalizeContentLengthHeader({
-        'Content-Length': '42'
+        'Content-Length': '42',
       }, Buffer.from('abcd'), { logger });
     });
 
@@ -101,7 +101,7 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
   describe('when the existing header name has unusual casing', () => {
     beforeEach(() => {
       headers = normalizeContentLengthHeader({
-        'CoNtEnT-lEnGtH': '4'
+        'CoNtEnT-lEnGtH': '4',
       }, Buffer.from('abcd'), { logger });
     });
 

--- a/test/unit/performRequest/performRequest-test.js
+++ b/test/unit/performRequest/performRequest-test.js
@@ -10,7 +10,7 @@ describe('performRequest()', () => {
   const transactionReq = {
     method: 'POST',
     headers: { 'Content-Type': 'text/plain' },
-    body: 'Hello'
+    body: 'Hello',
   };
   const res = { statusCode: 200, headers: { 'Content-Type': 'text/plain' } };
   const request = sinon.stub().callsArgWithAsync(1, null, res, Buffer.from('Bye'));
@@ -129,7 +129,7 @@ describe('performRequest()', () => {
         statusCode: 200,
         headers: { 'Content-Type': 'text/plain' },
         body: 'Bye',
-        bodyEncoding: 'utf-8'
+        bodyEncoding: 'utf-8',
       });
       done();
     });

--- a/test/unit/prettifyResponse-test.js
+++ b/test/unit/prettifyResponse-test.js
@@ -9,7 +9,7 @@ describe('prettifyResponse(response)', () => {
     it('should print JSON.stringified application/json header based response', () => {
       const output = prettifyResponse({
         headers: {
-          'content-type': 'application/json'
+          'content-type': 'application/json',
         },
         body:
           { a: 'b' } });
@@ -27,9 +27,9 @@ body: \n{
     it('should print indented XML when content-type is text/html', () => {
       const output = prettifyResponse({
         headers: {
-          'content-type': 'text/html'
+          'content-type': 'text/html',
         },
-        body: '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>'
+        body: '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>',
       });
 
       const expectedOutput = `\
@@ -51,9 +51,9 @@ body: \n<div>before paragraph
 
       prettifyResponse({
         headers: {
-          'content-type': 'application/json'
+          'content-type': 'application/json',
         },
-        body
+        body,
       });
     });
 

--- a/test/unit/reporters/ApiaryReporter-test.js
+++ b/test/unit/reporters/ApiaryReporter-test.js
@@ -9,7 +9,7 @@ const blueprintData = require('../../fixtures/blueprint-data');
 const loggerStub = require('../../../lib/logger');
 
 const ApiaryReporter = proxyquire('../../../lib/reporters/ApiaryReporter', {
-  '../logger': loggerStub
+  '../logger': loggerStub,
 });
 
 const PORT = 9876;
@@ -63,25 +63,25 @@ describe('ApiaryReporter', () => {
           resourceGroupName: '',
           resourceName: '/greeting',
           actionName: 'GET',
-          exampleName: ''
+          exampleName: '',
         },
 
         actual: {
           statusCode: 400,
           headers: {
-            'content-type': 'text/plain'
+            'content-type': 'text/plain',
           },
 
-          body: 'Foo bar'
+          body: 'Foo bar',
         },
 
         expected: {
           headers: {
-            'content-type': 'application/json'
+            'content-type': 'application/json',
           },
 
           body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-          status: '202'
+          status: '202',
         },
 
         request: {
@@ -89,11 +89,11 @@ describe('ApiaryReporter', () => {
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-            'Content-Length': 44
+            'Content-Length': 44,
           },
 
           uri: '/machines',
-          method: 'POST'
+          method: 'POST',
         },
 
         results: {
@@ -101,8 +101,8 @@ describe('ApiaryReporter', () => {
             results: [{
               pointer: '/content-type',
               severity: 'error',
-              message: 'Value of the ‘content-type’ must be application/json.'
-            }
+              message: 'Value of the ‘content-type’ must be application/json.',
+            },
             ],
             realType: 'application/vnd.apiary.http-headers+json',
             expectedType: 'application/vnd.apiary.http-headers+json',
@@ -116,23 +116,23 @@ describe('ApiaryReporter', () => {
                 message: 'Value of the ‘content-type’ must be application/json.',
                 validator: 'enum',
                 validatorName: 'enum',
-                validatorValue: ['application/json']
+                validatorValue: ['application/json'],
               },
 
-              length: 1
-            }
+              length: 1,
+            },
           },
 
           body: {
             results: [{
               message: "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
-              severity: 'error'
-            }
+              severity: 'error',
+            },
             ],
             realType: 'text/plain',
             expectedType: 'application/json',
             validator: null,
-            rawData: null
+            rawData: null,
           },
 
           statusCode: {
@@ -142,11 +142,11 @@ describe('ApiaryReporter', () => {
             rawData: '@@ -1,3 +1,9 @@\n-400\n+undefined\n',
             results: [{
               severity: 'error',
-              message: 'Real and expected data does not match.'
-            }
-            ]
-          }
-        }
+              message: 'Real and expected data does not match.',
+            },
+            ],
+          },
+        },
       };
 
       nock.disableNetConnect();
@@ -164,7 +164,7 @@ describe('ApiaryReporter', () => {
       describe('when custom settings contain API URL without trailing slash', () => {
         const custom = {
           apiaryReporterEnv: env,
-          apiaryApiUrl: 'https://api.example.com:1234'
+          apiaryApiUrl: 'https://api.example.com:1234',
         };
 
         it('uses the provided API URL in configuration', () => {
@@ -180,7 +180,7 @@ describe('ApiaryReporter', () => {
       describe('when custom settings contain API URL with trailing slash', () => {
         const custom = {
           apiaryReporterEnv: env,
-          apiaryApiUrl: 'https://api.example.com:1234/'
+          apiaryApiUrl: 'https://api.example.com:1234/',
         };
 
         it('uses the provided API URL in configuration, without trailing slash', () => {
@@ -198,7 +198,7 @@ describe('ApiaryReporter', () => {
       describe('when custom settings contain API URL without trailing slash', () => {
         const custom = {
           apiaryReporterEnv: env,
-          apiaryApiUrl: 'https://api.example.com:1234'
+          apiaryApiUrl: 'https://api.example.com:1234',
         };
 
         it('should use API URL without double slashes', (done) => {
@@ -214,7 +214,7 @@ describe('ApiaryReporter', () => {
       describe('when custom settings contain API URL with trailing slash', () => {
         const custom = {
           apiaryReporterEnv: env,
-          apiaryApiUrl: 'https://api.example.com:1234/'
+          apiaryApiUrl: 'https://api.example.com:1234/',
         };
 
         describe('when provided with root path', () =>
@@ -774,19 +774,19 @@ describe('ApiaryReporter', () => {
         actual: {
           statusCode: 400,
           headers: {
-            'content-type': 'text/plain'
+            'content-type': 'text/plain',
           },
 
-          body: 'Foo bar'
+          body: 'Foo bar',
         },
 
         expected: {
           headers: {
-            'content-type': 'application/json'
+            'content-type': 'application/json',
           },
 
           body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-          status: '202'
+          status: '202',
         },
 
         request: {
@@ -794,11 +794,11 @@ describe('ApiaryReporter', () => {
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-            'Content-Length': 44
+            'Content-Length': 44,
           },
 
           uri: '/machines',
-          method: 'POST'
+          method: 'POST',
         },
 
         results: {
@@ -806,8 +806,8 @@ describe('ApiaryReporter', () => {
             results: [{
               pointer: '/content-type',
               severity: 'error',
-              message: 'Value of the ‘content-type’ must be application/json.'
-            }
+              message: 'Value of the ‘content-type’ must be application/json.',
+            },
             ],
             realType: 'application/vnd.apiary.http-headers+json',
             expectedType: 'application/vnd.apiary.http-headers+json',
@@ -821,23 +821,23 @@ describe('ApiaryReporter', () => {
                 message: 'Value of the ‘content-type’ must be application/json.',
                 validator: 'enum',
                 validatorName: 'enum',
-                validatorValue: ['application/json']
+                validatorValue: ['application/json'],
               },
 
-              length: 1
-            }
+              length: 1,
+            },
           },
 
           body: {
             results: [{
               message: "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
-              severity: 'error'
-            }
+              severity: 'error',
+            },
             ],
             realType: 'text/plain',
             expectedType: 'application/json',
             validator: null,
-            rawData: null
+            rawData: null,
           },
 
           statusCode: {
@@ -847,11 +847,11 @@ describe('ApiaryReporter', () => {
             rawData: '@@ -1,3 +1,9 @@\n-400\n+undefined\n',
             results: [{
               severity: 'error',
-              message: 'Real and expected data does not match.'
-            }
-            ]
-          }
-        }
+              message: 'Real and expected data does not match.',
+            },
+            ],
+          },
+        },
       };
 
       nock.disableNetConnect();

--- a/test/unit/reporters/BaseReporter-test.js
+++ b/test/unit/reporters/BaseReporter-test.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events');
 const loggerStub = require('../../../lib/logger');
 
 const BaseReporter = proxyquire('../../../lib/reporters/BaseReporter', {
-  '../logger': loggerStub
+  '../logger': loggerStub,
 });
 
 describe('BaseReporter', () => {
@@ -23,7 +23,7 @@ describe('BaseReporter', () => {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     tests = [];
     emitter = new EventEmitter();
@@ -60,7 +60,7 @@ describe('BaseReporter', () => {
     before(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
     });
 
@@ -74,7 +74,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
@@ -89,7 +89,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'skipped',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test skip', test);
@@ -102,7 +102,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'failed',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test fail', test);
@@ -117,7 +117,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'error',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test error', new Error('Error'), test);
@@ -132,7 +132,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
       emitter.emit('test start', test);
       test.start = '2017-06-15T09:29:50.588Z';
@@ -146,7 +146,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'pass',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
       emitter.emit('test start', test);
       test.start = '2017-06-15T09:29:50.588Z';
@@ -160,7 +160,7 @@ describe('BaseReporter', () => {
     beforeEach(() => {
       test = {
         status: 'pass',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
       emitter.emit('test start', test);
       test.start = '2017-06-15T09:29:50.588Z';

--- a/test/unit/reporters/CLIReporter-test.js
+++ b/test/unit/reporters/CLIReporter-test.js
@@ -6,7 +6,7 @@ const { EventEmitter } = require('events');
 const loggerStub = require('../../../lib/logger');
 
 const CLIReporter = proxyquire('../../../lib/reporters/CLIReporter', {
-  '../logger': loggerStub
+  '../logger': loggerStub,
 });
 
 describe('CLIReporter', () => {
@@ -35,7 +35,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
     });
 
@@ -68,7 +68,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'fail',
-        title: 'Failing Test'
+        title: 'Failing Test',
       };
     });
 
@@ -113,7 +113,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'error',
-        title: 'Error Test'
+        title: 'Error Test',
       };
     });
 
@@ -134,7 +134,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'error',
-        title: 'Error Test'
+        title: 'Error Test',
       };
     });
 
@@ -165,7 +165,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'skip',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
     });
 
@@ -186,7 +186,7 @@ describe('CLIReporter', () => {
     before(() => {
       test = {
         status: 'fail',
-        title: 'Failing Test'
+        title: 'Failing Test',
       };
     });
 

--- a/test/unit/reporters/DotReporter-test.js
+++ b/test/unit/reporters/DotReporter-test.js
@@ -7,7 +7,7 @@ const { EventEmitter } = require('events');
 const loggerStub = require('../../../lib/logger');
 
 const DotReporter = proxyquire('../../../lib/reporters/DotReporter', {
-  '../logger': loggerStub
+  '../logger': loggerStub,
 });
 
 describe('DotReporter', () => {
@@ -30,7 +30,7 @@ describe('DotReporter', () => {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     tests = [];
     emitter = new EventEmitter();
@@ -67,7 +67,7 @@ describe('DotReporter', () => {
       before(() => {
         test = {
           status: 'fail',
-          title: 'failing test'
+          title: 'failing test',
         };
       });
 
@@ -93,7 +93,7 @@ describe('DotReporter', () => {
     before(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
     });
 
@@ -112,7 +112,7 @@ describe('DotReporter', () => {
     before(() => {
       test = {
         status: 'skipped',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
     });
 
@@ -131,7 +131,7 @@ describe('DotReporter', () => {
     before(() => {
       test = {
         status: 'failed',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
     });
 
@@ -150,7 +150,7 @@ describe('DotReporter', () => {
     before(() => {
       test = {
         status: 'error',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
     });
 

--- a/test/unit/reporters/HTMLReporter-test.js
+++ b/test/unit/reporters/HTMLReporter-test.js
@@ -12,7 +12,7 @@ const fsExtraStub = { mkdirp(path, cb) { return cb(); } };
 const HTMLReporter = proxyquire('../../../lib/reporters/HTMLReporter', {
   '../logger': loggerStub,
   fs: fsStub,
-  'fs-extra': fsExtraStub
+  'fs-extra': fsExtraStub,
 });
 
 describe('HTMLReporter', () => {
@@ -36,7 +36,7 @@ describe('HTMLReporter', () => {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     tests = [];
     htmlReporter = new HTMLReporter(emitter, stats, tests, 'test.html');
@@ -130,7 +130,7 @@ describe('HTMLReporter', () => {
     before(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
     });
 
@@ -154,7 +154,7 @@ describe('HTMLReporter', () => {
     before(() => {
       test = {
         status: 'skipped',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
     });
 
@@ -169,7 +169,7 @@ describe('HTMLReporter', () => {
     before(() => {
       test = {
         status: 'failed',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
     });
 
@@ -184,7 +184,7 @@ describe('HTMLReporter', () => {
     before(() => {
       test = {
         status: 'error',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
     });
 

--- a/test/unit/reporters/MarkdownReporter-test.js
+++ b/test/unit/reporters/MarkdownReporter-test.js
@@ -12,7 +12,7 @@ const fsExtraStub = { mkdirp(path, cb) { return cb(); } };
 const MarkdownReporter = proxyquire('../../../lib/reporters/MarkdownReporter', {
   '../logger': loggerStub,
   fs: fsStub,
-  'fs-extra': fsExtraStub
+  'fs-extra': fsExtraStub,
 });
 
 describe('MarkdownReporter', () => {
@@ -36,7 +36,7 @@ describe('MarkdownReporter', () => {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     tests = [];
     mdReporter = new MarkdownReporter(emitter, stats, tests, 'test.md');
@@ -134,7 +134,7 @@ describe('MarkdownReporter', () => {
     beforeEach(() => {
       test = {
         status: 'pass',
-        title: 'Passing Test'
+        title: 'Passing Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
@@ -160,7 +160,7 @@ describe('MarkdownReporter', () => {
     beforeEach(() => {
       test = {
         status: 'skipped',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test skip', test);
@@ -176,7 +176,7 @@ describe('MarkdownReporter', () => {
     beforeEach(() => {
       test = {
         status: 'failed',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test fail', test);
@@ -192,7 +192,7 @@ describe('MarkdownReporter', () => {
     beforeEach(() => {
       test = {
         status: 'error',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
       emitter.emit('test start', test);
       emitter.emit('test error', new Error('Error'), test);

--- a/test/unit/reporters/NyanReporter-test.js
+++ b/test/unit/reporters/NyanReporter-test.js
@@ -7,7 +7,7 @@ const { EventEmitter } = require('events');
 const loggerStub = require('../../../lib/logger');
 
 const NyanCatReporter = proxyquire('../../../lib/reporters/NyanReporter', {
-  '../logger': loggerStub
+  '../logger': loggerStub,
 });
 
 describe('NyanCatReporter', () => {
@@ -30,7 +30,7 @@ describe('NyanCatReporter', () => {
       skipped: 0,
       start: 0,
       end: 0,
-      duration: 0
+      duration: 0,
     };
     tests = [];
     nyanReporter = new NyanCatReporter(emitter, stats, tests);
@@ -82,7 +82,7 @@ describe('NyanCatReporter', () => {
       beforeEach(() => {
         const test = {
           status: 'fail',
-          title: 'failing test'
+          title: 'failing test',
         };
         nyanReporter.errors = [test];
         emitter.emit('test start', test);
@@ -105,7 +105,7 @@ describe('NyanCatReporter', () => {
       beforeEach(() => {
         const test = {
           status: 'pass',
-          title: 'Passing Test'
+          title: 'Passing Test',
         };
         sinon.stub(nyanReporter, 'write');
         sinon.spy(nyanReporter, 'draw');
@@ -124,7 +124,7 @@ describe('NyanCatReporter', () => {
       beforeEach(() => {
         const test = {
           status: 'skipped',
-          title: 'Skipped Test'
+          title: 'Skipped Test',
         };
         sinon.spy(nyanReporter, 'draw');
         sinon.stub(nyanReporter, 'write');
@@ -143,7 +143,7 @@ describe('NyanCatReporter', () => {
       beforeEach(() => {
         const test = {
           status: 'failed',
-          title: 'Failed Test'
+          title: 'Failed Test',
         };
         sinon.spy(nyanReporter, 'draw');
         sinon.stub(nyanReporter, 'write');
@@ -162,7 +162,7 @@ describe('NyanCatReporter', () => {
       beforeEach(() => {
         const test = {
           status: 'error',
-          title: 'Errored Test'
+          title: 'Errored Test',
         };
         sinon.spy(nyanReporter, 'draw');
         sinon.stub(nyanReporter, 'write');

--- a/test/unit/reporters/XUnitReporter-test.js
+++ b/test/unit/reporters/XUnitReporter-test.js
@@ -12,7 +12,7 @@ const fsExtraStub = { mkdirp(path, cb) { return cb(); } };
 const XUnitReporter = proxyquire('../../../lib/reporters/XUnitReporter', {
   '../logger': loggerStub,
   fs: fsStub,
-  'fs-extra': fsExtraStub
+  'fs-extra': fsExtraStub,
 });
 
 describe('XUnitReporter', () => {
@@ -174,22 +174,22 @@ describe('XUnitReporter', () => {
           body: '{ "test": "body" }',
           schema: '{ "test": "schema" }',
           headers: {
-            Accept: 'application/json'
-          }
+            Accept: 'application/json',
+          },
         },
         expected: {
           body: '{ "test": "body" }',
           schema: '{ "test": "schema" }',
           headers: {
-            'Content-Type': 'application/json'
-          }
+            'Content-Type': 'application/json',
+          },
         },
         actual: {
           body: '<html></html>',
           headers: {
-            'Content-Type': 'text/html'
-          }
-        }
+            'Content-Type': 'text/html',
+          },
+        },
       };
     });
 
@@ -221,7 +221,7 @@ describe('XUnitReporter', () => {
     before(() => {
       test = {
         status: 'skipped',
-        title: 'Skipped Test'
+        title: 'Skipped Test',
       };
     });
 
@@ -242,7 +242,7 @@ describe('XUnitReporter', () => {
     before(() => {
       test = {
         status: 'failed',
-        title: 'Failed Test'
+        title: 'Failed Test',
       };
     });
 
@@ -263,7 +263,7 @@ describe('XUnitReporter', () => {
     before(() => {
       test = {
         status: 'error',
-        title: 'Errored Test'
+        title: 'Errored Test',
       };
     });
 

--- a/test/unit/resolveHookfiles-test.js
+++ b/test/unit/resolveHookfiles-test.js
@@ -17,7 +17,7 @@ describe('resolveHookfiles()', () => {
     it('resolves them into absolute paths', () => {
       const hookfiles = [
         path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb')
+        path.join(cwd, 'non-js-hooks.rb'),
       ];
       const paths = resolveHookfiles(hookfiles, cwd);
       assert.deepEqual(paths, hookfiles);
@@ -29,7 +29,7 @@ describe('resolveHookfiles()', () => {
       const paths = resolveHookfiles(['./hooks.js', './non-js-hooks.rb'], cwd);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb')
+        path.join(cwd, 'non-js-hooks.rb'),
       ]);
     })
   );
@@ -47,7 +47,7 @@ describe('resolveHookfiles()', () => {
     it('resolves them into absolute paths', () => {
       const paths = resolveHookfiles(['./**/hooks.js'], cwd);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks.js')
+        path.join(cwd, 'hooks.js'),
       ]);
     })
   );
@@ -66,7 +66,7 @@ describe('resolveHookfiles()', () => {
       const paths = resolveHookfiles(['./non-js-hooks.rb', './**/hooks.js'], cwd);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb')
+        path.join(cwd, 'non-js-hooks.rb'),
       ]);
     });
 
@@ -94,7 +94,7 @@ describe('resolveHookfiles()', () => {
         './hooks-glob/bar/b.js',
         './hooks-glob/baz/c.js',
         './hooks-glob/foo/o.js',
-        './hooks-glob/bar/p.js'
+        './hooks-glob/bar/p.js',
       ], cwd);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks-glob/foo/a.js'),
@@ -107,7 +107,7 @@ describe('resolveHookfiles()', () => {
         path.join(cwd, 'test_hooks.coffee'),
         path.join(cwd, 'hooks-glob/baz/x.js'),
         path.join(cwd, 'hooks-glob/foo/y.js'),
-        path.join(cwd, 'hooks-glob/bar/z.js')
+        path.join(cwd, 'hooks-glob/bar/z.js'),
       ]);
     });
   });

--- a/test/unit/sandboxHooksCode-test.js
+++ b/test/unit/sandboxHooksCode-test.js
@@ -41,7 +41,7 @@ describe('sandboxHooksCode(hooksCode, callback)', () => {
       'beforeEach',
       'afterEach',
       'beforeEachValidation',
-      'beforeValidation'
+      'beforeValidation',
     ];
 
     functions.forEach((name) => {
@@ -77,7 +77,7 @@ throw(new Error('${name} is not a function'))
       'afterEachHooks',
       'afterAllHooks',
       'beforeValidationHooks',
-      'beforeEachValidationHooks'
+      'beforeEachValidationHooks',
     ];
 
     properties.forEach((property) => {

--- a/test/unit/transactionRunner-test.js
+++ b/test/unit/transactionRunner-test.js
@@ -15,7 +15,7 @@ const loggerStub = require('../../lib/logger');
 
 const Runner = proxyquire('../../lib/TransactionRunner', {
   html: htmlStub,
-  './logger': loggerStub
+  './logger': loggerStub,
 });
 
 const Hooks = require('../../lib/Hooks');
@@ -30,8 +30,8 @@ describe('TransactionRunner', () => {
       method: [],
       only: [],
       header: [],
-      reporter: []
-    }
+      reporter: [],
+    },
   };
 
   let transaction;
@@ -69,8 +69,8 @@ describe('TransactionRunner', () => {
             method: [],
             only: [],
             header: [],
-            reporter: []
-          }
+            reporter: [],
+          },
         };
 
         runner = new Runner(configuration);
@@ -91,8 +91,8 @@ describe('TransactionRunner', () => {
             method: [],
             only: [],
             header: [],
-            reporter: []
-          }
+            reporter: [],
+          },
         };
         runner = new Runner(configuration);
         runner.config(configuration);
@@ -110,28 +110,28 @@ describe('TransactionRunner', () => {
           body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n',
           headers: {
             'Content-Type': {
-              value: 'application/json'
-            }
+              value: 'application/json',
+            },
           },
           uri: '/machines',
-          method: 'POST'
+          method: 'POST',
         },
         response: {
           body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           headers: {
             'content-type': {
-              value: 'application/json'
-            }
+              value: 'application/json',
+            },
           },
-          status: '202'
+          status: '202',
         },
         origin: {
           apiName: 'Machines API',
           resourceGroupName: 'Group Machine',
           resourceName: 'Machine',
           actionName: 'Delete Message',
-          exampleName: 'Bogus example name'
-        }
+          exampleName: 'Bogus example name',
+        },
       };
 
       runner = new Runner(configuration);
@@ -144,68 +144,68 @@ describe('TransactionRunner', () => {
       [{
         description: 'is hostname',
         input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello' },
       },
       {
         description: 'is IPv4',
         input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello' },
       },
       {
         description: 'has path',
         input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello' },
       },
       {
         description: 'has path with trailing slash',
         input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello' },
       },
       {
         description: 'has path and request path is /',
         input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' },
       },
       {
         description: 'has path with trailing slash and request path is /',
         input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' },
       },
       {
         description: 'has path and request has no path',
         input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1' },
       },
       {
         description: 'has path with trailing slash and request has no path',
         input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '' },
-        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' }
+        expected: { host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/' },
       },
       {
         description: 'is hostname with no protocol',
         input: { serverUrl: '127.0.0.1', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' },
       },
       {
         description: 'is IPv4 with no protocol',
         input: { serverUrl: '127.0.0.1:4000', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: '4000', protocol: 'http:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: '4000', protocol: 'http:', fullPath: '/hello' },
       },
       {
         description: 'is hostname with // instead of protocol',
         input: { serverUrl: '//127.0.0.1', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' },
       },
       {
         description: 'is hostname with trailing slash',
         input: { serverUrl: 'http://127.0.0.1/', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' }
+        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' },
       },
       {
         description: 'is hostname with no protocol and with trailing slash',
         input: { serverUrl: '127.0.0.1/', requestPath: '/hello' },
-        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' }
-      }
+        expected: { host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello' },
+      },
 
       ].forEach(({ description, input, expected }) =>
         context(`${description}: '${input.serverUrl}' + '${input.requestPath}'`, () => {
@@ -226,7 +226,7 @@ describe('TransactionRunner', () => {
               host: configuredTransaction.host,
               port: configuredTransaction.port,
               protocol: configuredTransaction.protocol,
-              fullPath: configuredTransaction.fullPath
+              fullPath: configuredTransaction.fullPath,
             }, expected)
           );
         })
@@ -381,25 +381,25 @@ describe('TransactionRunner', () => {
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-            'Content-Length': 44
+            'Content-Length': 44,
           },
           uri: '/machines',
-          method: 'POST'
+          method: 'POST',
         },
         expected: {
-          headers: { 'content-type': 'application/json'
+          headers: { 'content-type': 'application/json',
           },
           body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-          status: '202'
+          status: '202',
         },
         origin: {
           resourceGroupName: 'Group Machine',
           resourceName: 'Machine',
           actionName: 'Delete Message',
-          exampleName: 'Bogus example name'
+          exampleName: 'Bogus example name',
         },
         fullPath: '/machines',
-        protocol: 'http:'
+        protocol: 'http:',
       };
     });
 
@@ -514,8 +514,8 @@ describe('TransactionRunner', () => {
 
           runner.hooks.beforeHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.skip = true; }
-            ]
+              (hookTransaction) => { hookTransaction.skip = true; },
+            ],
           };
           done();
         });
@@ -754,25 +754,25 @@ describe('TransactionRunner', () => {
             headers: {
               'Content-Type': 'application/json',
               'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-              'Content-Length': 44
+              'Content-Length': 44,
             },
             uri: `/machines${name}`,
-            method: 'POST'
+            method: 'POST',
           },
           expected: {
-            headers: { 'content-type': 'application/json'
+            headers: { 'content-type': 'application/json',
             },
             body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-            statusCode: '202'
+            statusCode: '202',
           },
           origin: {
             resourceGroupName: 'Group Machine',
             resourceName: 'Machine',
             actionName: 'Delete Message',
-            exampleName: 'Bogus example name'
+            exampleName: 'Bogus example name',
           },
           fullPath: `/machines${name}`,
-          protocol: 'http:'
+          protocol: 'http:',
         });
 
         transactions.push(transaction);
@@ -789,7 +789,7 @@ describe('TransactionRunner', () => {
         'beforeValidationSpy',
         'afterSpy',
         'afterEachSpy',
-        'afterAllSpy'
+        'afterAllSpy',
       ];
 
       spies = {};
@@ -1249,8 +1249,8 @@ describe('TransactionRunner', () => {
         method: [],
         header: [],
         reporter: [],
-        only: []
-      }
+        only: [],
+      },
     };
     // Do not actually search & load hookfiles from disk
     // hookfiles: './**/*_hooks.*'
@@ -1269,25 +1269,25 @@ describe('TransactionRunner', () => {
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-            'Content-Length': 44
+            'Content-Length': 44,
           },
           uri: '/machines',
-          method: 'POST'
+          method: 'POST',
         },
         expected: {
-          headers: { 'content-type': 'application/json'
+          headers: { 'content-type': 'application/json',
           },
           body: '{\n  "type": "bulldozer",\n "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-          statusCode: '202'
+          statusCode: '202',
         },
         origin: {
           resourceGroupName: 'Group Machine',
           resourceName: 'Machine',
           actionName: 'Delete Message',
-          exampleName: 'Bogus example name'
+          exampleName: 'Bogus example name',
         },
         fullPath: '/machines',
-        protocol: 'http:'
+        protocol: 'http:',
       });
 
       server = nock('http://127.0.0.1:3000')
@@ -1311,13 +1311,13 @@ describe('TransactionRunner', () => {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => loggerStub.info('before')
-          ]
+          ],
         };
         runner.hooks.beforeValidationHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => loggerStub.info('beforeValidation')
-          ]
+          ],
         };
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
@@ -1325,8 +1325,8 @@ describe('TransactionRunner', () => {
             function (transaction, done) {
               loggerStub.info('after');
               done();
-            }
-          ]
+            },
+          ],
         };
       });
 
@@ -1350,13 +1350,13 @@ describe('TransactionRunner', () => {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => loggerStub.info('before')
-          ]
+          ],
         };
         runner.hooks.beforeValidationHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => loggerStub.info('beforeValidation')
-          ]
+          ],
         };
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
@@ -1364,8 +1364,8 @@ describe('TransactionRunner', () => {
             function (transaction, done) {
               loggerStub.info('after');
               done();
-            }
-          ]
+            },
+          ],
         };
       });
 
@@ -1393,8 +1393,8 @@ describe('TransactionRunner', () => {
             function (transaction, cb) {
               loggerStub.info('second');
               cb();
-            }
-          ]
+            },
+          ],
         };
       });
 
@@ -1635,8 +1635,8 @@ function(transactions){
           transactions = [{
             name: 'Test!',
             request: { headers: {}, body: '' },
-            skip: true
-          }
+            skip: true,
+          },
           ];
 
           runner.executeAllTransactions(transactions, runner.hooks, (err) => {
@@ -1658,8 +1658,8 @@ function(transactions){
           transactions = [{
             name: 'Test!',
             request: { headers: {}, body: '' },
-            skip: true
-          }
+            skip: true,
+          },
           ];
 
           runner.executeAllTransactions(transactions, runner.hooks, (err) => {
@@ -1688,25 +1688,25 @@ function(transactions){
             headers: {
               'Content-Type': 'application/json',
               'User-Agent': 'Dredd/0.2.1 (Darwin 13.0.0; x64)',
-              'Content-Length': 44
+              'Content-Length': 44,
             },
             uri: '/machines',
-            method: 'POST'
+            method: 'POST',
           },
           expected: {
-            headers: { 'content-type': 'application/json'
+            headers: { 'content-type': 'application/json',
             },
             body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-            statusCode: '202'
+            statusCode: '202',
           },
           origin: {
             resourceGroupName: 'Group Machine',
             resourceName: 'Machine',
             actionName: 'Delete Message',
-            exampleName: 'Bogus example name'
+            exampleName: 'Bogus example name',
           },
           fullPath: '/machines',
-          protocol: 'http:'
+          protocol: 'http:',
         };
 
         [1, 2].forEach((i) => {
@@ -1872,7 +1872,7 @@ function(transactions){
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => JSON.parse('<<<>>>!@#!@#!@#4234234')
-          ]
+          ],
         };
         sinon.stub(configuration.emitter, 'emit');
       });
@@ -1893,7 +1893,7 @@ function(transactions){
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => JSON.parse('<<<>>>!@#!@#!@#4234234')
-          ]
+          ],
         };
         sinon.stub(configuration.emitter, 'emit');
       });
@@ -1914,7 +1914,7 @@ function(transactions){
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => assert.isOk(false)
-          ]
+          ],
         };
         sinon.stub(configuration.emitter, 'emit');
       });
@@ -1964,7 +1964,7 @@ function(transactions){
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
             transaction => assert.isOk(false)
-          ]
+          ],
         };
         sinon.stub(configuration.emitter, 'emit');
       });
@@ -2022,8 +2022,8 @@ function(transactions){
           clonedTransaction = clone(transaction);
           runner.hooks.beforeHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message before'; }
-            ]
+              (hookTransaction) => { hookTransaction.fail = 'Message before'; },
+            ],
           };
           sinon.stub(configuration.emitter, 'emit');
         });
@@ -2096,8 +2096,8 @@ function(transactions){
             clonedTransaction = clone(transaction);
             runner.hooks.afterHooks = {
               'Group Machine > Machine > Delete Message > Bogus example name': [
-                (hookTransaction) => { hookTransaction.fail = 'Message after'; }
-              ]
+                (hookTransaction) => { hookTransaction.fail = 'Message after'; },
+              ],
             };
           });
 
@@ -2157,8 +2157,8 @@ function(transactions){
 
           runner.hooks.afterHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message after fail'; }
-            ]
+              (hookTransaction) => { hookTransaction.fail = 'Message after fail'; },
+            ],
           };
           sinon.stub(configuration.emitter, 'emit');
         });
@@ -2242,8 +2242,8 @@ function(transactions){
           clonedTransaction = clone(transaction);
           runner.hooks.afterHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message after pass'; }
-            ]
+              (hookTransaction) => { hookTransaction.fail = 'Message after pass'; },
+            ],
           };
           sinon.stub(configuration.emitter, 'emit');
         });
@@ -2368,8 +2368,8 @@ function(transactions){
               body.name = 'Michael';
               transaction.request.body = JSON.stringify(body);
               transaction.request.headers['Content-Length'] = transaction.request.body.length;
-            }
-          ]
+            },
+          ],
         };
 
         const app = express();


### PR DESCRIPTION
#### :rocket: Why this change?

Step by step, I'd like to remove all ESLint exceptions we have in our linter configuration. I was able to remove this one with the help of just running `eslint . --fix`, so I guess reviewing the PR isn't even really necessary.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
