### PR TITLE
Do not use 'console'

### DIFF
--- a/lib/HooksWorkerClient.js
+++ b/lib/HooksWorkerClient.js
@@ -365,16 +365,16 @@ $ go get github.com/snikch/goodman/cmd/goodman
       // This is needed for transaction modification integration tests:
       // https://github.com/apiaryio/dredd-hooks-template/blob/master/features/execution_order.feature
       if (process.env.TEST_DREDD_HOOKS_HANDLER_ORDER === 'true') {
-        console.error('FOR TESTING ONLY');
+        process.stderr.write('FOR TESTING ONLY\n');
         const modifications = (transactions[0] && transactions[0].hooks_modifications) || [];
         if (!modifications.length) {
           throw new Error('Hooks must modify transaction.hooks_modifications');
         }
         for (let index = 0; index < modifications.length; index++) {
           const modification = modifications[index];
-          console.error(`${index} ${modification}`);
+          process.stderr.write(`${index} ${modification}\n`);
         }
-        console.error('FOR TESTING ONLY');
+        process.stderr.write('FOR TESTING ONLY\n');
       }
       this.stop(hookCallback);
     });

--- a/test/fixtures/scripts/dummy-server-crash.js
+++ b/test/fixtures/scripts/dummy-server-crash.js
@@ -11,5 +11,5 @@ app.get('/machines/:name', () => {
 });
 
 app.listen(process.argv[2], () => {
-  console.log(`Dummy server listening on port ${process.argv[2]}!`);
+  process.stdout.write(`Dummy server listening on port ${process.argv[2]}!\n`);
 });

--- a/test/fixtures/scripts/dummy-server-ignore-term.js
+++ b/test/fixtures/scripts/dummy-server-ignore-term.js
@@ -3,7 +3,7 @@ const express = require('express');
 require('./handle-windows-sigint.js')();
 
 function ignore() {
-  console.log('ignoring termination');
+  process.stdout.write('ignoring termination\n');
 }
 
 process.on('SIGTERM', ignore);
@@ -20,5 +20,5 @@ app.get('/machines/:name', (req, res) => {
 });
 
 app.listen(process.argv[2], () => {
-  console.log(`Dummy server listening on port ${process.argv[2]}!`);
+  process.stdout.write(`Dummy server listening on port ${process.argv[2]}!\n`);
 });

--- a/test/fixtures/scripts/dummy-server-kill.js
+++ b/test/fixtures/scripts/dummy-server-kill.js
@@ -11,5 +11,5 @@ app.get('/machines/:name', () => {
 });
 
 app.listen(process.argv[2], () => {
-  console.log(`Dummy server listening on port ${process.argv[2]}!`);
+  process.stdout.write(`Dummy server listening on port ${process.argv[2]}!\n`);
 });

--- a/test/fixtures/scripts/dummy-server.js
+++ b/test/fixtures/scripts/dummy-server.js
@@ -11,5 +11,5 @@ app.get('/machines/:name', (req, res) => {
 });
 
 app.listen(process.argv[2], () => {
-  console.log(`Dummy server listening on port ${process.argv[2]}!`);
+  process.stdout.write(`Dummy server listening on port ${process.argv[2]}!\n`);
 });

--- a/test/fixtures/test2_all.js
+++ b/test/fixtures/test2_all.js
@@ -1,11 +1,11 @@
 const hooks = require('hooks');
 
 hooks.beforeAll((done) => {
-  console.log('*** beforeAll');
+  process.stdout.write('*** beforeAll\n');
   done();
 });
 
 hooks.before('Machines > Machines collection > Get Machines', (transaction, done) => {
-  console.log('*** before');
+  process.stdout.write('*** before\n');
   done();
 });

--- a/test/fixtures/test2_events.js
+++ b/test/fixtures/test2_events.js
@@ -1,6 +1,6 @@
 const hooks = require('hooks');
 
 hooks.beforeAll((done) => {
-  console.log('hooks.beforeAll');
+  process.stdout.write('hooks.beforeAll\n');
   done();
 });

--- a/test/fixtures/test2_hooks.js
+++ b/test/fixtures/test2_hooks.js
@@ -2,6 +2,6 @@ const hooks = require('hooks');
 
 hooks.before('Machines > Machines collection > Get Machines', (transaction, done) => {
   transaction.request.headers.header = '123232323';
-  console.log('before');
+  process.stdout.write('before\n');
   done();
 });

--- a/test/fixtures/test_events.js
+++ b/test/fixtures/test_events.js
@@ -1,6 +1,6 @@
 const { afterAll } = require('hooks');
 
 afterAll((done) => {
-  console.log('hooks.afterAll');
+  process.stdout.write('hooks.afterAll\n');
   done();
 });

--- a/test/integration/cli/hookfiles-cli-test.js
+++ b/test/integration/cli/hookfiles-cli-test.js
@@ -201,7 +201,7 @@ describe('CLI', () => {
           // TCP server echoing transactions back
           const hookHandler = net.createServer((socket) => {
             socket.on('data', data => socket.write(data));
-            socket.on('error', err => console.error(err));
+            socket.on('error', err => process.stderr.write(`${err}\n`));
           });
 
           const args = [
@@ -254,7 +254,7 @@ describe('CLI', () => {
           // TCP server echoing transactions back
           const hookHandler = net.createServer((socket) => {
             socket.on('data', data => socket.write(data));
-            socket.on('error', err => console.error(err));
+            socket.on('error', err => process.stderr.write(`${err}\n`));
           });
 
           const args = [


### PR DESCRIPTION
#### :rocket: Why this change?

Currently the only warnings linter produces on Dredd's codebase are warnings about the `no-console` rule. The reasoning of the rule is following:

> In JavaScript that is designed to be executed in the browser, it’s considered a best practice to avoid using methods on console. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client. In general, calls using console should be stripped before being pushed to production.

While Dredd's code (currently) isn't destined to run in browsers, `console` is often used for debugging purposes (at least by lame people like me) and I see the benefit in having the linter warning me there's such call in the codebase. For that reason and also to follow a common convention, I think it is better not to use the `console` object directly in the production code.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
