### PR TITLE
Remove unnecessary bitwise operators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
     'max-len': 'off',
-    'no-bitwise': 'off',
     'no-continue': 'off',
     'no-empty': 'off',
     'no-multi-assign': 'off',

--- a/lib/reporters/NyanReporter.js
+++ b/lib/reporters/NyanReporter.js
@@ -26,7 +26,7 @@ function NyanCatReporter(emitter, stats, tests) {
   this.numberOfLines = 4;
   this.trajectories = [[], [], [], []];
   this.nyanCatWidth = 11;
-  this.trajectoryWidthMax = (((windowWidth * 0.75) | 0) - this.nyanCatWidth);
+  this.trajectoryWidthMax = (((windowWidth * 0.75) | 0) - this.nyanCatWidth); // eslint-disable-line no-bitwise
   this.scoreboardWidth = 5;
   this.tick = 0;
   this.errors = [];

--- a/test/unit/reporters/HTMLReporter-test.js
+++ b/test/unit/reporters/HTMLReporter-test.js
@@ -73,7 +73,7 @@ describe('HTMLReporter', () => {
 
     it('should write the prelude to the buffer', done =>
       emitter.emit('start', '', () => {
-        assert.isOk(~htmlReporter.buf.indexOf('Dredd'));
+        assert.isOk(htmlReporter.buf.includes('Dredd'));
         done();
       })
     );
@@ -137,7 +137,7 @@ describe('HTMLReporter', () => {
     it('should call the pass event', () => {
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
-      assert.isOk(~htmlReporter.buf.indexOf('Pass'));
+      assert.isOk(htmlReporter.buf.includes('Pass'));
     });
 
     describe('when details=true', () =>
@@ -145,7 +145,7 @@ describe('HTMLReporter', () => {
       it('should write details for passing tests', () => {
         htmlReporter.details = true;
         emitter.emit('test pass', test);
-        assert.isOk(~htmlReporter.buf.indexOf('Request'));
+        assert.isOk(htmlReporter.buf.includes('Request'));
       })
     );
   });
@@ -161,7 +161,7 @@ describe('HTMLReporter', () => {
     it('should call the skip event', () => {
       emitter.emit('test start', test);
       emitter.emit('test skip', test);
-      assert.isOk(~htmlReporter.buf.indexOf('Skip'));
+      assert.isOk(htmlReporter.buf.includes('Skip'));
     });
   });
 
@@ -176,7 +176,7 @@ describe('HTMLReporter', () => {
     it('should call the fail event', () => {
       emitter.emit('test start', test);
       emitter.emit('test fail', test);
-      assert.isOk(~htmlReporter.buf.indexOf('Fail'));
+      assert.isOk(htmlReporter.buf.includes('Fail'));
     });
   });
 
@@ -191,7 +191,7 @@ describe('HTMLReporter', () => {
     it('should call the error event', () => {
       emitter.emit('test start', test);
       emitter.emit('test error', new Error('Error'), test);
-      assert.isOk(~htmlReporter.buf.indexOf('Error'));
+      assert.isOk(htmlReporter.buf.includes('Error'));
     });
   });
 });

--- a/test/unit/reporters/MarkdownReporter-test.js
+++ b/test/unit/reporters/MarkdownReporter-test.js
@@ -80,7 +80,7 @@ describe('MarkdownReporter', () => {
 
     it('should write the title to the buffer', done =>
       emitter.emit('start', '', () => {
-        assert.isOk(~mdReporter.buf.indexOf('Dredd'));
+        assert.isOk(mdReporter.buf.includes('Dredd'));
         done();
       })
     )
@@ -141,7 +141,7 @@ describe('MarkdownReporter', () => {
     });
 
     it('should write pass to the buffer', (done) => {
-      assert.isOk(~mdReporter.buf.indexOf('Pass'));
+      assert.isOk(mdReporter.buf.includes('Pass'));
       done();
     });
 
@@ -150,7 +150,7 @@ describe('MarkdownReporter', () => {
       it('should write details for passing tests', (done) => {
         mdReporter.details = true;
         emitter.emit('test pass', test);
-        assert.isOk(~mdReporter.buf.indexOf('Request'));
+        assert.isOk(mdReporter.buf.includes('Request'));
         done();
       })
     );
@@ -167,7 +167,7 @@ describe('MarkdownReporter', () => {
     });
 
     it('should write skip to the buffer', (done) => {
-      assert.isOk(~mdReporter.buf.indexOf('Skip'));
+      assert.isOk(mdReporter.buf.includes('Skip'));
       done();
     });
   });
@@ -183,7 +183,7 @@ describe('MarkdownReporter', () => {
     });
 
     it('should write fail to the buffer', (done) => {
-      assert.isOk(~mdReporter.buf.indexOf('Fail'));
+      assert.isOk(mdReporter.buf.includes('Fail'));
       done();
     });
   });
@@ -199,7 +199,7 @@ describe('MarkdownReporter', () => {
     });
 
     it('should write error to the buffer', (done) => {
-      assert.isOk(~mdReporter.buf.indexOf('Error'));
+      assert.isOk(mdReporter.buf.includes('Error'));
       done();
     });
   });


### PR DESCRIPTION
#### :rocket: Why this change?

Because `~` in combination with `.indexOf()` comes from the stone age.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
