### PR TITLE
Require named function expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
     // of the codebase possible and are to be removed in the future
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
-    'func-names': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
     'max-len': 'off',

--- a/lib/childProcess.js
+++ b/lib/childProcess.js
@@ -2,11 +2,13 @@ const crossSpawn = require('cross-spawn');
 
 const ignorePipeErrors = require('./ignorePipeErrors');
 
+
 const ASCII_CTRL_C = 3;
 const IS_WINDOWS = process.platform === 'win32';
 const TERM_FIRST_CHECK_TIMEOUT_MS = 1;
 const TERM_DEFAULT_TIMEOUT_MS = 1000;
 const TERM_DEFAULT_RETRY_MS = 300;
+
 
 // Signals the child process to forcefully terminate
 function signalKill(childProcess, callback) {
@@ -26,6 +28,7 @@ function signalKill(childProcess, callback) {
     process.nextTick(callback);
   }
 }
+
 
 // Signals the child process to gracefully terminate
 function signalTerm(childProcess, callback) {
@@ -54,6 +57,7 @@ function signalTerm(childProcess, callback) {
   }
   process.nextTick(callback);
 }
+
 
 // Gracefully terminates a child process
 //
@@ -91,7 +95,7 @@ function terminate(childProcess, options = {}, callback) {
 
   // A function representing one check, whether the process already
   // ended or not. It is repeatedly called until the timeout has passed.
-  const check = function () {
+  function check() {
     if (terminated) {
       // Successfully terminated
       clearTimeout(t);
@@ -115,7 +119,7 @@ function terminate(childProcess, options = {}, callback) {
         );
       }
     }
-  };
+  }
 
   // Fire the first termination attempt and check the result
   signalTerm(childProcess, (err) => {
@@ -124,7 +128,8 @@ function terminate(childProcess, options = {}, callback) {
   });
 }
 
-const spawn = function (...args) {
+
+function spawn(...args) {
   const childProcess = crossSpawn.spawn.apply(null, args);
 
   ignorePipeErrors(childProcess);
@@ -195,7 +200,8 @@ const spawn = function (...args) {
   });
 
   return childProcess;
-};
+}
+
 
 module.exports = {
   signalKill,

--- a/lib/configUtils.js
+++ b/lib/configUtils.js
@@ -2,9 +2,8 @@ const clone = require('clone');
 const fs = require('fs');
 const yaml = require('js-yaml');
 
-const configUtils = {};
 
-configUtils.save = function (argsOrigin, path) {
+function save(argsOrigin, path) {
   if (!path) { path = './dredd.yml'; }
 
   const args = clone(argsOrigin);
@@ -20,9 +19,10 @@ configUtils.save = function (argsOrigin, path) {
   delete args._;
 
   fs.writeFileSync(path, yaml.dump(args));
-};
+}
 
-configUtils.load = function (path) {
+
+function load(path) {
   if (!path) { path = './dredd.yml'; }
 
   const yamlData = fs.readFileSync(path);
@@ -34,9 +34,10 @@ configUtils.load = function (path) {
   delete data.endpoint;
 
   return data;
-};
+}
 
-configUtils.parseCustom = function (customArray) {
+
+function parseCustom(customArray) {
   const output = {};
   if (Array.isArray(customArray)) {
     for (const string of customArray) {
@@ -45,6 +46,11 @@ configUtils.parseCustom = function (customArray) {
     }
   }
   return output;
-};
+}
 
-module.exports = configUtils;
+
+module.exports = {
+  save,
+  load,
+  parseCustom,
+};

--- a/lib/reporters/ApiaryReporter.js
+++ b/lib/reporters/ApiaryReporter.js
@@ -6,6 +6,7 @@ const request = require('request');
 const logger = require('../logger');
 const packageData = require('../../package.json');
 
+
 const CONNECTION_ERRORS = [
   'ECONNRESET',
   'ENOTFOUND',
@@ -15,6 +16,7 @@ const CONNECTION_ERRORS = [
   'EHOSTUNREACH',
   'EPIPE',
 ];
+
 
 function ApiaryReporter(emitter, stats, tests, config, runner) {
   this.type = 'apiary';
@@ -49,8 +51,9 @@ https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-test
   if (!this.configuration.apiSuite) { this.configuration.apiSuite = 'public'; }
 }
 
+
 // THIS IS HIIIIGHWAY TO HELL, HIIIIIGHWAY TO HELL. Everything should have one single interface
-ApiaryReporter.prototype._get = function (customProperty, envProperty, defaultVal) {
+ApiaryReporter.prototype._get = function _get(customProperty, envProperty, defaultVal) {
   let returnVal = defaultVal;
 
   // This will be deprecated
@@ -77,13 +80,15 @@ ApiaryReporter.prototype._get = function (customProperty, envProperty, defaultVa
   return returnVal;
 };
 
-ApiaryReporter.prototype._getKeys = function () {
+
+ApiaryReporter.prototype._getKeys = function _getKeys() {
   let returnKeys = [];
   returnKeys = returnKeys.concat(Object.keys((this.config.custom && this.config.custom.apiaryReporterEnv) || {}));
   return returnKeys.concat(Object.keys(process.env));
 };
 
-ApiaryReporter.prototype.configureEmitter = function (emitter) {
+
+ApiaryReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (blueprintsData, callback) => {
     if (this.serverError === true) { return callback(); }
     this.uuid = generateUuid();
@@ -187,7 +192,8 @@ ApiaryReporter.prototype.configureEmitter = function (emitter) {
   });
 };
 
-ApiaryReporter.prototype._createStep = function (test, callback) {
+
+ApiaryReporter.prototype._createStep = function _createStep(test, callback) {
   if (this.serverError === true) { return callback(); }
   const data = this._transformTestToReporter(test);
   const path = `/apis/${this.configuration.apiSuite}/tests/steps?testRunId=${this.remoteId}`;
@@ -197,7 +203,8 @@ ApiaryReporter.prototype._createStep = function (test, callback) {
   });
 };
 
-ApiaryReporter.prototype._performRequestAsync = function (path, method, reqBody, callback) {
+
+ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(path, method, reqBody, callback) {
   const handleRequest = (err, res, resBody) => {
     let parsedBody;
     if (err) {
@@ -263,7 +270,8 @@ to Apiary API: ${options.method} ${options.uri} \
   }
 };
 
-ApiaryReporter.prototype._transformTestToReporter = function (test) {
+
+ApiaryReporter.prototype._transformTestToReporter = function _transformTestToReporter(test) {
   return {
     testRunId: this.remoteId,
     origin: test.origin,
@@ -278,5 +286,6 @@ ApiaryReporter.prototype._transformTestToReporter = function (test) {
     },
   };
 };
+
 
 module.exports = ApiaryReporter;

--- a/lib/reporters/BaseReporter.js
+++ b/lib/reporters/BaseReporter.js
@@ -8,7 +8,7 @@ function BaseReporter(emitter, stats, tests) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-BaseReporter.prototype.configureEmitter = function (emitter) {
+BaseReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (rawBlueprint, callback) => {
     this.stats.start = new Date();
     callback();

--- a/lib/reporters/CLIReporter.js
+++ b/lib/reporters/CLIReporter.js
@@ -14,7 +14,7 @@ function CLIReporter(emitter, stats, tests, inlineErrors, details) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-CLIReporter.prototype.configureEmitter = function (emitter) {
+CLIReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (rawBlueprint, callback) => {
     logger.info('Beginning Dredd testing...');
     callback();

--- a/lib/reporters/DotReporter.js
+++ b/lib/reporters/DotReporter.js
@@ -12,7 +12,7 @@ function DotReporter(emitter, stats, tests) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-DotReporter.prototype.configureEmitter = function (emitter) {
+DotReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (rawBlueprint, callback) => {
     logger.info('Beginning Dredd testing...');
     callback();
@@ -63,7 +63,7 @@ ${this.stats.errors} errors, ${this.stats.skipped} skipped\
   });
 };
 
-DotReporter.prototype.write = function (str) {
+DotReporter.prototype.write = function write(str) {
   process.stdout.write(str);
 };
 

--- a/lib/reporters/HTMLReporter.js
+++ b/lib/reporters/HTMLReporter.js
@@ -26,7 +26,7 @@ function HTMLReporter(emitter, stats, tests, path, details) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-HTMLReporter.prototype.sanitizedPath = function (path) {
+HTMLReporter.prototype.sanitizedPath = function sanitizedPath(path) {
   const filePath = path ? file.path.abspath(path) : file.path.abspath('./report.html');
   if (fs.existsSync(filePath)) {
     logger.info(`File exists at ${filePath}, will be overwritten...`);
@@ -34,7 +34,7 @@ HTMLReporter.prototype.sanitizedPath = function (path) {
   return filePath;
 };
 
-HTMLReporter.prototype.configureEmitter = function (emitter) {
+HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   const title = str => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (rawBlueprint, callback) => {

--- a/lib/reporters/MarkdownReporter.js
+++ b/lib/reporters/MarkdownReporter.js
@@ -25,7 +25,7 @@ function MarkdownReporter(emitter, stats, tests, path, details) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-MarkdownReporter.prototype.sanitizedPath = function (path) {
+MarkdownReporter.prototype.sanitizedPath = function sanitizedPath(path) {
   const filePath = path ? file.path.abspath(path) : file.path.abspath('./report.md');
   if (fs.existsSync(filePath)) {
     logger.info(`File exists at ${filePath}, will be overwritten...`);
@@ -33,7 +33,7 @@ MarkdownReporter.prototype.sanitizedPath = function (path) {
   return filePath;
 };
 
-MarkdownReporter.prototype.configureEmitter = function (emitter) {
+MarkdownReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   const title = str => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (rawBlueprint, callback) => {

--- a/lib/reporters/NyanReporter.js
+++ b/lib/reporters/NyanReporter.js
@@ -36,7 +36,7 @@ function NyanCatReporter(emitter, stats, tests) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-NyanCatReporter.prototype.configureEmitter = function (emitter) {
+NyanCatReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (rawBlueprint, callback) => {
     this.cursorHide();
     this.draw();
@@ -89,7 +89,7 @@ NyanCatReporter.prototype.configureEmitter = function (emitter) {
   });
 };
 
-NyanCatReporter.prototype.draw = function () {
+NyanCatReporter.prototype.draw = function draw() {
   this.appendRainbow();
   this.drawScoreboard();
   this.drawRainbow();
@@ -97,7 +97,7 @@ NyanCatReporter.prototype.draw = function () {
   this.tick = !this.tick;
 };
 
-NyanCatReporter.prototype.drawScoreboard = function () {
+NyanCatReporter.prototype.drawScoreboard = function drawScoreboard() {
   const colors = {
     fail: 31,
     skipped: 36,
@@ -120,7 +120,7 @@ NyanCatReporter.prototype.drawScoreboard = function () {
   this.cursorUp(this.numberOfLines + 1);
 };
 
-NyanCatReporter.prototype.appendRainbow = function () {
+NyanCatReporter.prototype.appendRainbow = function appendRainbow() {
   const segment = (this.tick ? '_' : '-');
   const rainbowified = this.rainbowify(segment);
   const result = [];
@@ -135,7 +135,7 @@ NyanCatReporter.prototype.appendRainbow = function () {
   return result;
 };
 
-NyanCatReporter.prototype.drawRainbow = function () {
+NyanCatReporter.prototype.drawRainbow = function drawRainbow() {
   this.trajectories.forEach((line) => {
     this.write(`\u001b[${this.scoreboardWidth}C`);
     this.write(line.join(''));
@@ -145,7 +145,7 @@ NyanCatReporter.prototype.drawRainbow = function () {
   this.cursorUp(this.numberOfLines);
 };
 
-NyanCatReporter.prototype.drawNyanCat = function () {
+NyanCatReporter.prototype.drawNyanCat = function drawNyanCat() {
   const startWidth = this.scoreboardWidth + this.trajectories[0].length;
   const color = `\u001b[${startWidth}C`;
   let padding = '';
@@ -168,7 +168,7 @@ NyanCatReporter.prototype.drawNyanCat = function () {
   this.cursorUp(this.numberOfLines);
 };
 
-NyanCatReporter.prototype.face = function () {
+NyanCatReporter.prototype.face = function face() {
   if (this.stats.failures) {
     return '( x .x)';
   } else if (this.stats.skipped) {
@@ -179,23 +179,23 @@ NyanCatReporter.prototype.face = function () {
   return '( - .-)';
 };
 
-NyanCatReporter.prototype.cursorUp = function (n) {
+NyanCatReporter.prototype.cursorUp = function cursorUp(n) {
   this.write(`\u001b[${n}A`);
 };
 
-NyanCatReporter.prototype.cursorDown = function (n) {
+NyanCatReporter.prototype.cursorDown = function cursorDown(n) {
   this.write(`\u001b[${n}B`);
 };
 
-NyanCatReporter.prototype.cursorShow = function () {
+NyanCatReporter.prototype.cursorShow = function cursorShow() {
   if (this.isatty) { this.write('\u001b[?25h'); }
 };
 
-NyanCatReporter.prototype.cursorHide = function () {
+NyanCatReporter.prototype.cursorHide = function cursorHide() {
   if (this.isatty) { this.write('\u001b[?25l'); }
 };
 
-NyanCatReporter.prototype.generateColors = function () {
+NyanCatReporter.prototype.generateColors = function generateColors() {
   const colors = [];
   let i = 0;
 
@@ -211,13 +211,13 @@ NyanCatReporter.prototype.generateColors = function () {
   return colors;
 };
 
-NyanCatReporter.prototype.rainbowify = function (str) {
+NyanCatReporter.prototype.rainbowify = function rainbowify(str) {
   const color = this.rainbowColors[this.colorIndex % this.rainbowColors.length];
   this.colorIndex += 1;
   return `\u001b[38;5;${color}m${str}\u001b[0m`;
 };
 
-NyanCatReporter.prototype.write = function (str) {
+NyanCatReporter.prototype.write = function write(str) {
   process.stdout.write(str);
 };
 

--- a/lib/reporters/XUnitReporter.js
+++ b/lib/reporters/XUnitReporter.js
@@ -24,7 +24,7 @@ function XUnitReporter(emitter, stats, tests, path, details) {
   logger.verbose(`Using '${this.type}' reporter.`);
 }
 
-XUnitReporter.prototype.updateSuiteStats = function (path, stats, callback) {
+XUnitReporter.prototype.updateSuiteStats = function updateSuiteStats(path, stats, callback) {
   fs.readFile(path, (err, data) => {
     if (!err) {
       data = data.toString();
@@ -55,15 +55,15 @@ XUnitReporter.prototype.updateSuiteStats = function (path, stats, callback) {
   });
 };
 
-XUnitReporter.prototype.cdata = function (str) {
+XUnitReporter.prototype.cdata = function cdata(str) {
   return `<![CDATA[${str}]]>`;
 };
 
-XUnitReporter.prototype.appendLine = function (path, line) {
+XUnitReporter.prototype.appendLine = function appendLine(path, line) {
   fs.appendFileSync(path, `${line}\n`);
 };
 
-XUnitReporter.prototype.toTag = function (name, attrs, close, content) {
+XUnitReporter.prototype.toTag = function toTag(name, attrs, close, content) {
   const end = close ? '/>' : '>';
   const pairs = [];
   if (attrs) {
@@ -74,7 +74,7 @@ XUnitReporter.prototype.toTag = function (name, attrs, close, content) {
   return tag;
 };
 
-XUnitReporter.prototype.sanitizedPath = function (path) {
+XUnitReporter.prototype.sanitizedPath = function sanitizedPath(path) {
   const filePath = path ? file.path.abspath(path) : file.path.abspath('./report.xml');
   if (fs.existsSync(filePath)) {
     logger.info(`File exists at ${filePath}, will be overwritten...`);
@@ -83,7 +83,7 @@ XUnitReporter.prototype.sanitizedPath = function (path) {
   return filePath;
 };
 
-XUnitReporter.prototype.configureEmitter = function (emitter) {
+XUnitReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (rawBlueprint, callback) => {
     fsExtra.mkdirp(pathmodule.dirname(this.path), (err) => {
       if (!err) {

--- a/test/integration/childProcess-test.js
+++ b/test/integration/childProcess-test.js
@@ -26,11 +26,11 @@ function runChildProcess(command, fn, callback) {
   childProcess.stdout.on('data', (data) => { processInfo.stdout += data.toString(); });
   childProcess.stderr.on('data', (data) => { processInfo.stderr += data.toString(); });
 
-  const onExit = function (exitStatus, signal) {
+  function onExit(exitStatus, signal) {
     processInfo.terminated = true;
     processInfo.exitStatus = exitStatus;
     processInfo.signal = signal;
-  };
+  }
   childProcess.on('exit', onExit);
 
   const onError = (err) => { processInfo.error = err; };

--- a/test/integration/cli/hookfiles-cli-test.js
+++ b/test/integration/cli/hookfiles-cli-test.js
@@ -618,7 +618,7 @@ describe('CLI', () => {
   describe('when describing events in hookfiles', () => {
     let runtimeInfo;
 
-    const containsLine = function (str, expected) {
+    function containsLine(str, expected) {
       const lines = str.split('\n');
       for (const line of lines) {
         if (line.indexOf(expected) > -1) {
@@ -626,7 +626,7 @@ describe('CLI', () => {
         }
       }
       return false;
-    };
+    }
 
     before((done) => {
       const app = createServer();
@@ -652,7 +652,7 @@ describe('CLI', () => {
   describe('when describing both hooks and events in hookfiles', () => {
     let runtimeInfo;
 
-    const getResults = function (str) {
+    function getResults(str) {
       const ret = [];
       const lines = str.split('\n');
       for (const line of lines) {
@@ -661,7 +661,7 @@ describe('CLI', () => {
         }
       }
       return ret.join(',');
-    };
+    }
 
     before((done) => {
       const app = createServer();

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -111,10 +111,10 @@ function createServer(options = {}) {
   // is made optional, defaulting to the 'DEFAULT_SERVER_PORT' value.
   // The callback is provided not only with error object, but also with
   // runtime info about the server (what requests it got etc.).
-  const { listen } = app;
-  app.listen = function (port, callback) {
+  const originalListen = app.listen;
+  app.listen = function listen(port, callback) {
     if (typeof port === 'function') { [callback, port] = Array.from([port, DEFAULT_SERVER_PORT]); }
-    return listen.call(this, port, err => callback(err, serverRuntimeInfo));
+    return originalListen.call(this, port, err => callback(err, serverRuntimeInfo));
   };
   return app;
 }

--- a/test/integration/regressions/regression-319-354-test.js
+++ b/test/integration/regressions/regression-319-354-test.js
@@ -3,16 +3,18 @@ const { assert } = require('chai');
 
 const { runCLIWithServer, createServer, DEFAULT_SERVER_PORT } = require('../helpers');
 
+
 // Helper, tries to parse given HTTP body and in case it can be parsed as JSON,
 // it returns the resulting JS object, otherwise it returns whatever came in.
-const parseIfJson = function (body) {
+function parseIfJson(body) {
   if (!body) { return undefined; }
   try {
     return JSON.parse(body);
   } catch (error) {
     return body;
   }
-};
+}
+
 
 // This can be removed once https://github.com/apiaryio/dredd/issues/341 is done
 function parseDreddStdout(stdout) {

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -14,13 +14,13 @@ const LCov = require('mocha-lcov-reporter');
  * If you want to learn more about how coverage collecting works
  * in Dredd's test suite, see the 'npm run test:coverage' script.
  */
-module.exports = function (runner, options) {
+module.exports = function reporter(runner, options) {
   new Spec(runner, options);
 
   if (process.env.COVERAGE_DIR) {
     // Monkey-patching the 'LCov.prototype.write' so we could save
     // the LCov output to a file instead of a standard output
-    LCov.prototype.write = function (string) {
+    LCov.prototype.write = function write(string) {
       const file = path.join(process.env.COVERAGE_DIR, 'mocha.info');
       fs.appendFileSync(file, string);
     };

--- a/test/unit/configureReporters-test.js
+++ b/test/unit/configureReporters-test.js
@@ -33,7 +33,7 @@ const configureReporters = proxyquire('../../lib/configureReporters', {
   './reporters/ApiaryReporter': ApiaryReporterStub,
 });
 
-const resetStubs = function () {
+function resetStubs() {
   emitterStub.removeAllListeners();
   BaseReporterStub.resetHistory();
   CliReporterStub.resetHistory();
@@ -43,7 +43,7 @@ const resetStubs = function () {
   HtmlReporterStub.resetHistory();
   MarkdownReporterStub.resetHistory();
   return ApiaryReporterStub.resetHistory();
-};
+}
 
 
 describe('configureReporters(config, stats, tests, onSaveCallback)', () => {

--- a/test/unit/reporters/ApiaryReporter-test.js
+++ b/test/unit/reporters/ApiaryReporter-test.js
@@ -277,10 +277,10 @@ describe('ApiaryReporter', () => {
 
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)
@@ -396,10 +396,10 @@ describe('ApiaryReporter', () => {
 
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)
@@ -503,10 +503,10 @@ describe('ApiaryReporter', () => {
 
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)
@@ -562,10 +562,10 @@ describe('ApiaryReporter', () => {
 
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)
@@ -680,10 +680,10 @@ describe('ApiaryReporter', () => {
         const uri = `/apis/public/tests/run/${runId}`;
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)
@@ -874,10 +874,10 @@ describe('ApiaryReporter', () => {
         const uri = `/apis/${env.APIARY_API_NAME}/tests/runs`;
 
         requestBody = null;
-        const getBody = function (body) {
+        function getBody(body) {
           requestBody = body;
           return body;
-        };
+        }
 
         call = nock(env.APIARY_API_URL)
           .filteringRequestBody(getBody)


### PR DESCRIPTION
#### :rocket: Why this change?

I want to get rid of ESLint exceptions if possible. The changes made to reporters are debatable. The reporters should be probably rewritten to the `class` syntax. However, the ideal plan is to revamp them from the ground up, so I don't want to invest my time in them that much now.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
