### PR TITLE
Fix the hiring link

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -6,7 +6,7 @@
             <h3>Dredd is hiring!</h3>
             <p>Join the&nbsp;Apiary&nbsp;team and get&nbsp;paid for improving&nbsp;Dredd</p>
         </div>
-        <a href="https://bit.ly/dredd-hiring" class="btn btn-neutral" target="_blank">
+        <a href="https://www.linkedin.com/jobs/view/fullstack-javascript-developer-apiary-open-source-tools-at-oracle-apiary-1048749931/" class="btn btn-neutral" target="_blank">
             <span class="fa fa-linkedin-square"></span>
             Apply
         </a>


### PR DESCRIPTION
#### :rocket: Why this change?

The destination of bit.ly short links cannot be changed once created, it is an 'enterprise feature'. I thought this is possible and it's the main reason I used the shortener. The job is expiring after time, so the link will need to change over time again. I'm removing bit.ly for now, fixing the link with this commit, and let's see whether there's better solution in the future.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
