### PR TITLE
Hardcode the version to 'latest' in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,6 @@ import os
 import sys
 import re
 import json
-import subprocess
 import urllib.request
 
 from sphinx.errors import SphinxError
@@ -19,24 +18,6 @@ from sphinx.errors import SphinxError
 
 # Explicitly put the extensions directory to Python path
 sys.path.append(os.path.abspath('_extensions'))
-
-# Detect whether the build happens on ReadTheDocs
-IS_READTHEDOCS = os.environ.get('READTHEDOCS') == 'True'
-
-# Specify paths
-docs_dir = os.path.dirname(__file__)
-project_dir = os.path.join(docs_dir, '..')
-node_modules_bin_dir = os.path.join(project_dir, 'node_modules', '.bin')
-
-# Install all npm dependencies if on ReadTheDocs. This requires the latest
-# ReadTheDocs build image, which supports Node.js out of the box. This is
-# specified in the readthedocs.yml in the root of the project.
-if IS_READTHEDOCS:
-    subprocess.check_call('npm install', cwd=project_dir, shell=True)
-
-# Load package.json data
-with open(os.path.join(project_dir, 'package.json')) as f:
-    package_json = json.load(f)
 
 
 # -- General configuration ------------------------------------------------
@@ -65,42 +46,10 @@ project = 'Dredd'
 copyright = 'Apiary Czech Republic, s.r.o.'
 author = 'Apiary'
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-def get_release():
-    try:
-        # Is internet available? this is to be able to generate docs
-        # e.g. in train without internet connection
-        urllib.request.urlopen('https://www.npmjs.com/package/dredd', timeout=3)
-    except urllib.request.URLError as e:
-        if IS_READTHEDOCS:
-            # ReadTheDocs have problem to connect to npm, fail fast
-            raise SphinxError('Could not determine Dredd version: {}'.format(e))
-        else:
-            # Offline local development, use dummy release number
-            return package_json['version']
-    else:
-        # Online, ask Semantic Release what would be the next version
-        sem_rel_bin = os.path.join(node_modules_bin_dir, 'semantic-release')
-        sem_rel_output = subprocess.getoutput('{} pre'.format(sem_rel_bin))
-        match = re.search(r'determined version (\d+\.\d+\.\d+)', sem_rel_output, re.I)
-        if match:
-            # Semantic Release would use this version number
-            return match.group(1)
-
-        # Semantic Release wasn't able to determine a new version number,
-        # either because of some error or because there are no changes which
-        # would bump the version number. Stick to the latest released version.
-        return subprocess.getoutput('npm view dredd version').strip()
-
-# The full version, including alpha/beta/rc tags.
-release = get_release()
-if not re.match(r'\d+\.\d+\.\d+', release):
-    raise SphinxError("'{}' does not look like version number".format(release))
-
-# The short X.Y version.
-version = release
+# The project version (2.6) and release (2.6.0rc1) numbers. Figuring this
+# out for Dredd is tricky (because of Semantic Release), so it's hardcoded.
+version = 'latest'
+release = 'latest'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -176,10 +176,10 @@ The Travis CI build uses following commands to deliver coverage reports:
 
 The first mentioned command does following:
 
-1.  Uses `istanbul <https://github.com/gotwarlost/istanbul>`__ to instrument the JavaScript code
-2.  Runs the tests on the instrumented code using Mocha with a special lcov reporter, which gives us information about which lines were executed in the standard lcov format
-3. Because some integration tests execute the ``bin/dredd`` script in a subprocess, we collect the coverage stats also in this file. The results are appended to a dedicated lcov file
-4. All lcov files are then merged into one using the `lcov-result-merger <https://github.com/mweibel/lcov-result-merger>`__ utility and sent to Coveralls
+#.  Uses `istanbul <https://github.com/gotwarlost/istanbul>`__ to instrument the JavaScript code
+#.  Runs the tests on the instrumented code using Mocha with a special lcov reporter, which gives us information about which lines were executed in the standard lcov format
+#. Because some integration tests execute the ``bin/dredd`` script in a subprocess, we collect the coverage stats also in this file. The results are appended to a dedicated lcov file
+#. All lcov files are then merged into one using the `lcov-result-merger <https://github.com/mweibel/lcov-result-merger>`__ utility and sent to Coveralls
 
 Hand-made combined Mocha reporter is used to achieve running tests and collecting coverage at the same time.
 
@@ -215,18 +215,17 @@ Even though alternatives exist (dredd.readthedocs.io, dredd.rtfd.io, or dredd.io
 Building documentation locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The documentation is built by `Sphinx <http://www.sphinx-doc.org/>`__. To render it on your computer, you need `Python 3 <https://www.python.org/>`__ and `Node.js <http://nodejs.org/>`__.
+The documentation is built by `Sphinx <http://www.sphinx-doc.org/>`__. To render it on your computer, you need `Python 3 <https://www.python.org/>`__.
 
-1. Make sure ``node`` is an executable and ``npm install`` has been done for the Dredd directory.
-2. `Get Python 3 <https://www.python.org/downloads/>`__. `ReadTheDocs <https://readthedocs.org/>`__ build the documentation with Python 3.6, so make sure you have this version.
-3. Create a `virtual environment <https://docs.python.org/3/library/venv.html>`__ and activate it:
+#. `Get Python 3 <https://www.python.org/downloads/>`__. `ReadTheDocs <https://readthedocs.org/>`__ build the documentation with Python 3.6, so make sure you have this version.
+#. Create a `virtual environment <https://docs.python.org/3/library/venv.html>`__ and activate it:
 
    .. code-block:: shell
 
       python3 -m venv ./venv
       source ./venv/bin/activate
 
-4. Install dependencies for the docs:
+#. Install dependencies for the docs:
 
    .. code-block:: shell
 
@@ -246,7 +245,7 @@ Now you can use following commands:
 Installation on ReadTheDocs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The final documentation gets published by `ReadTheDocs <https://readthedocs.org/>`__. Because the documentation needs some of the npm dependencies installed and ReadTheDocs do not support this in their default build environment, we force their latest build image, which includes Node.js out of the box, in the ``readthedocs.yml``. In the Sphinx' configuration file, ``docs/conf.py``, we make sure ``npm install`` is executed on ReadTheDocs.
+The final documentation gets published by `ReadTheDocs <https://readthedocs.org/>`__. We force their latest build image in the ``readthedocs.yml`` to get Python 3.
 
 
 Writing documentation


### PR DESCRIPTION
#### :rocket: Why this change?

We're getting failed docs builds recently, because the npm in RTD's image isn't able to install npm dependencies successfully - see https://readthedocs.org/projects/dredd/builds/8343339/ To my surprise, the latest RTD image contains node@4.2.6 and npm@3.5.2. This means not only that it might be a bug in the npm, which is could be already fixed in newer versions, but also that the obvious quick solutions, such as 'npm ci' or using 'npx', are not available. This brought me to revisiting why we install npm dependencies in the first place. In the past the docs had node extensions, but now the only thing needing the dependencies was the version number, calling semantic-release. I decided to hardcode the version to 'latest' to avoid the issues and to remove the complexity.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/pull/1119

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
