### PR TITLE
Revamp hooks docs

### DIFF
--- a/docs/_static/css/dredd.css
+++ b/docs/_static/css/dredd.css
@@ -1,9 +1,32 @@
+/*
+  Minor tuning to get the Font-Awesome icons used in buttons slightly padded.
+*/
 .btn .fa {
   margin-right: 0.3rem;
 }
+.btn.float-right .fa {
+  margin-right: 0;
+  margin-left: 0.3rem;
+}
 
+/*
+  The :rfc: role renders bold for no obvious reason. This resets it so
+  the links don't stand out.
+*/
 a.rfc strong {
   font-weight: normal;
+}
+
+/*
+  Workaround for https://github.com/djungelorm/sphinx-tabs/pull/35
+*/
+.rst-content .section ul:last-child,
+.rst-content .toctree-wrapper ul:last-child,
+article ul:last-child {
+  margin-bottom: 24px;
+}
+.rst-content .tab ul:last-child {
+  margin-bottom: 0;
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ import subprocess
 import urllib.request
 
 from sphinx.errors import SphinxError
+from pygments.lexers.data import YamlLexer
 
 
 ###########################################################################
@@ -175,6 +176,26 @@ sphinx_tabs_valid_builders = ['linkcheck']
 # Directory with individual templates overriding the ones from the theme
 templates_path = ['_templates']
 
-# An extension adding the '_static/css/dredd.css' stylesheet
+
+# -- Custom Pygments lexers for OpenAPI -----------------------------------
+
+class OpenAPI2Lexer(YamlLexer):
+    name = 'OpenAPI 2'
+    aliases = ['openapi2', 'swagger']
+    mimetypes = ['application/swagger+yaml']
+
+class OpenAPI3Lexer(YamlLexer):
+    name = 'OpenAPI 3'
+    aliases = ['openapi3']
+    mimetypes = ['application/vnd.oai.openapi']
+
+
+# -- Setting up extensions ------------------------------------------------
+
 def setup(app):
+    # An extension adding the '_static/css/dredd.css' stylesheet
     app.add_css_file('css/dredd.css')
+
+    # Adding
+    app.add_lexer('openapi2', OpenAPI2Lexer())
+    app.add_lexer('openapi3', OpenAPI3Lexer())

--- a/docs/hooks/index.rst
+++ b/docs/hooks/index.rst
@@ -1,8 +1,9 @@
 .. include:: ../_links.rst
+.. _hook-scripts:
 .. _hooks:
 
-Hook Scripts
-============
+Hooks
+=====
 
 Similar to any other testing framework, Dredd supports executing code around each test step. Hooks are code blocks executed in defined stage of :ref:`execution lifecycle <execution-life-cycle>`. In the hooks code you have an access to compiled HTTP :ref:`transaction object <transaction-object-structure>` which you can modify.
 

--- a/docs/hooks/index.rst
+++ b/docs/hooks/index.rst
@@ -1,111 +1,191 @@
 .. include:: ../_links.rst
+
+
 .. _hook-scripts:
 .. _hooks:
 
 Hooks
 =====
 
-Similar to any other testing framework, Dredd supports executing code around each test step. Hooks are code blocks executed in defined stage of :ref:`execution lifecycle <execution-life-cycle>`. In the hooks code you have an access to compiled HTTP :ref:`transaction object <transaction-object-structure>` which you can modify.
+Dredd supports *hooks*, which are blocks of arbitrary code that run before or after each test step. The concept is similar to XUnit's ``setUp`` and ``tearDown`` functions, `Cucumber hooks <https://docs.cucumber.io/cucumber/api/#hooks>`__, or `Git hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`__. Hooks are usually used for:
 
-Hooks are usually used for:
+-  Loading database fixtures,
+-  cleaning up after test step(s),
+-  handling auth and sessions,
+-  passing data between transactions (saving state from responses),
+-  modifying a request generated from the API description,
+-  changing generated expectations,
+-  setting custom expectations,
+-  debugging by logging stuff.
 
--  loading db fixtures
--  cleanup after test step or steps
--  handling authentication and sessions
--  passing data between transactions (saving state from responses to *stash*)
--  modifying request generated from API description
--  changing generated expectations
--  setting custom expectations
--  debugging via logging stuff
 
-Languages
----------
+Getting started
+---------------
 
-You can interact with your server implementation in following languages:
+Let's have a description of a blog API, which allows to list all articles, and to publish a new one.
+
+.. tabs::
+
+   .. group-tab:: API Blueprint
+
+      .. literalinclude:: ../../test/fixtures/blog/api.apib
+         :language: apiblueprint
+
+   .. group-tab:: OpenAPI 2
+
+      .. literalinclude:: ../../test/fixtures/blog/api.yaml
+         :language: yaml
+
+Now let's say the real instance of the API has the POST request protected so it is not possible for everyone to publish new articles. We do not want to hardcode secret tokens in our API description, but we want to get Dredd to pass the auth. This is where the hooks can help.
+
+
+Writing hooks
+~~~~~~~~~~~~~
+
+Hooks are functions, which are registered to be ran for a specific test step (HTTP transaction) and at a specific point in Dredd's :ref:`execution life cycle <execution-life-cycle>`. Hook functions take one or more `transaction objects <transaction>`__, which they can modify. Let's use hooks to add an `Authorization header <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization>`__ to Dredd's request.
+
+Dredd supports :ref:`writing hooks in multiple programming languages <supported-languages>`, but we'll go with JavaScript hooks in this tutorial as they're available out of the box.
+
+.. tabs::
+
+   .. group-tab:: API Blueprint
+
+      Let's create a file called ``hooks.js`` with the following content:
+
+      .. literalinclude:: ../../test/fixtures/blog/hooks-apib.js
+         :language: javascript
+
+      As you can see, we're registering the hook function to be executed **before** the HTTP transaction ``Articles > Publish an article``. This path-like identifier is a :ref:`transaction name <transaction-names>`.
+
+   .. group-tab:: OpenAPI 2
+
+      Let's create a file called ``hooks.js`` with the following content:
+
+      .. literalinclude:: ../../test/fixtures/blog/hooks-openapi2.js
+         :language: javascript
+
+      As you can see, we're registering the hook function to be executed **before** the HTTP transaction ``Articles > Publish an article > 201 > application/json``. This path-like identifier is a :ref:`transaction name <transaction-names>`.
+
+
+Running Dredd with hooks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+With the API instance running locally at ``http://127.0.0.1``, you can now run Dredd with hooks using the :option:`--hookfiles` option:
+
+.. tabs::
+
+   .. group-tab:: API Blueprint
+
+      .. code-block:: text
+
+         dredd ./blog.apib http://127.0.0.1 --hookfiles=./hooks.js
+
+   .. group-tab:: OpenAPI 2
+
+      .. code-block:: text
+
+         dredd ./blog.yaml http://127.0.0.1 --hookfiles=./hooks.js
+
+Now the tests should pass even if publishing new article requires auth.
+
+
+.. _supported-languages:
+
+Supported languages
+-------------------
+
+Dredd itself is written in JavaScript, so it supports :ref:`JavaScript hooks <hooks-js>` out of the box. Hook handlers for other languages need to be installed before they can be used. Supported languages are:
 
 .. toctree::
    :maxdepth: 1
 
-   Go <go>
+   JavaScript <js>
    JavaScript (Sandboxed) <js-sandbox>
-   Node.js <nodejs>
+   Go <go>
    Perl <perl>
    PHP <php>
    Python <python>
    Ruby <ruby>
    Rust <rust>
-   Other languages <new-language>
 
-Dredd doesn’t speak your language? :ref:`It’s very easy to write support for your language. <hooks-new-language>` Your contribution is more than welcome!
+.. toctree::
+   :hidden:
 
-Using Hook Files
-----------------
+   New language <new-language>
 
-To use a hook file with Dredd, use the :option:`--hookfiles` flag in the command line. You can use this flag multiple times or use a `glob <https://www.npmjs.com/package/glob>`__ expression for loading multiple hook files. Dredd executes hook files in alphabetical order.
+.. note::
 
-Example:
+   If you don't see your favorite language, :ref:`it's fairly easy to contribute support for it <hooks-new-language>`! Join the :ref:`Contributors Hall of Fame <maintainers>` where we praise those who added support for additional languages.
 
-.. code-block:: shell
+   (Especially if your language of choice is **Java**, there's an eternal fame and glory waiting for you - see :ghissue:`#875`)
 
-   $ dredd single-get.apib http://machines.apiary.io --hookfiles=*_hooks.*
 
+.. _transaction-names:
 .. _getting-transaction-names:
 
-Getting Transaction Names
--------------------------
+Transaction names
+-----------------
 
-For addressing specific test steps is used the **transaction names** of the compiled HTTP transactions (*actions*) from the API description.
+Transaction names are path-like strings, which allow hook functions to address specific HTTP transactions. They intuitively follow the structure of your API description document.
 
-In order to retrieve transaction names please run Dredd with the :option:`--names` option last and it will print all available names of transactions.
+You can get a list of all transaction names available in your API description document by calling Dredd with the :option:`--names` option:
 
-For example, given an API Blueprint file ``api-description.apib`` as following:
+.. tabs::
 
-.. code-block:: apiblueprint
+   .. group-tab:: API Blueprint
 
-   FORMAT: 1A
+      .. code-block:: text
+         :emphasize-lines: 3, 5
 
-   # Machines API
+         $ dredd ./blog.apib http://127.0.0.1 --names
+         info: Beginning Dredd testing...
+         info: Articles > List articles
+         skip: GET (200) /articles
+         info: Articles > Publish an article
+         skip: POST (201) /articles
+         complete: 0 passing, 0 failing, 0 errors, 2 skipped, 2 total
+         complete: Tests took 9ms
 
-   # Group Machines
+      As you can see, the document ``./blog.apib`` contains two transactions, which you can address in hooks as:
 
-   # Machines collection [/machines]
+      - ``Articles > List articles``
+      - ``Articles > Publish an article``
 
-   ## Get Machines [GET]
+   .. group-tab:: OpenAPI 2
 
-   - Response 200 (application/json; charset=utf-8)
+      .. code-block:: text
+         :emphasize-lines: 3, 5
 
-       [{"type": "bulldozer", "name": "willy"}]
+         $ dredd ./blog.yaml http://127.0.0.1 --names
+         info: Beginning Dredd testing...
+         info: Articles > List articles > 200 > application/json
+         skip: GET (200) /articles
+         info: Articles > Publish an article > 201 > application/json
+         skip: POST (201) /articles
+         complete: 0 passing, 0 failing, 0 errors, 2 skipped, 2 total
+         complete: Tests took 9ms
 
-Run this command to retrieve all transaction names:
+      As you can see, the document ``./blog.yaml`` contains two transactions, which you can address in hooks as:
 
-.. code-block:: shell
+      - ``Articles > List articles > 200 > application/json``
+      - ``Articles > Publish an article > 201 > application/json``
 
-   $ dredd single-get.apib http://machines.apiary.io --names
-   info: Machines > Machines collection > Get Machines
+.. note::
+   The transaction names and the :option:`--names` workflow mostly do their job, but with `many documented flaws <https://github.com/apiaryio/dredd/labels/Epic%3A%20Transaction%20Names>`__. A successor to transaction names is being designed in :ghissue:`#227`
 
-The ``Machines > Machines collection > Get Machines`` is the name of a transaction which you can use in your hooks. The same approach works also for `OpenAPI 2`_ documents.
 
 .. _types-of-hooks:
 
-Types of Hooks
+Types of hooks
 --------------
 
-Dredd supports following types of hooks:
+Hooks get executed at specific points in Dredd's :ref:`execution life cycle <execution-life-cycle>`. Available types of hooks are:
 
 -  ``beforeAll`` called at the beginning of the whole test run
 -  ``beforeEach`` called before each HTTP transaction
--  ``before`` called before some specific HTTP transaction
+-  ``before`` called before a specific HTTP transaction
 -  ``beforeEachValidation`` called before each HTTP transaction is validated
--  ``beforeValidation`` called before some specific HTTP transaction is validated
--  ``after`` called after some specific HTTP transaction regardless its result
+-  ``beforeValidation`` called before a specific HTTP transaction is validated
+-  ``after`` called after a specific HTTP transaction regardless its result
 -  ``afterEach`` called after each HTTP transaction
 -  ``afterAll`` called after whole test run
-
-Refer to :ref:`Dredd execution lifecycle <execution-life-cycle>` when is each hook executed.
-
-.. _transaction-object-structure:
-
-Transaction Object Structure
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The main purpose of hooks is to work with the transaction object they get as the first argument, in order to inspect or modify Dredd’s behavior. See :ref:`transaction object reference <transaction>` to learn more about its contents.

--- a/docs/hooks/js.rst
+++ b/docs/hooks/js.rst
@@ -1,3 +1,4 @@
+.. _hooks-js:
 .. _hooks-nodejs:
 
 Writing Dredd Hooks In Node.js
@@ -13,7 +14,7 @@ Usage
 API Reference
 -------------
 
--  For ``before``, ``after``, ``beforeValidation``, ``beforeEach``, ``afterEach`` and ``beforeEachValidation`` a :ref:`Transaction Object <transaction-object-structure>` is passed as the first argument to the hook function.
+-  For ``before``, ``after``, ``beforeValidation``, ``beforeEach``, ``afterEach`` and ``beforeEachValidation`` a :ref:`Transaction Object <transaction>` is passed as the first argument to the hook function.
 -  An array of Transaction Objects is passed to ``beforeAll`` and ``afterAll``.
 -  The second argument is an optional callback function for async execution.
 -  Any modifications on the ``transaction`` object are propagated to the actual HTTP transactions.

--- a/docs/how-to-guides.rst
+++ b/docs/how-to-guides.rst
@@ -83,7 +83,7 @@ Now we can create a ``hooks.js`` file. The file will contain setup and teardown 
 OpenAPI 2
 ^^^^^^^^^
 
-.. code-block:: yaml
+.. code-block:: openapi2
 
    swagger: "2.0"
    info:
@@ -265,7 +265,7 @@ OpenAPI 2 Example
 
 Imagine we have a simple workflow described:
 
-.. code-block:: yaml
+.. code-block:: openapi2
 
    swagger: "2.0"
    info:
@@ -736,7 +736,7 @@ While example values are natural part of the API Blueprint format, the OpenAPI 2
 
 However, Dredd needs to know what values to use when testing described API, so it supports ``x-example`` :openapi2:`vendor extension property <vendorextensions>` to overcome the OpenAPI 2 limitation:
 
-.. code-block:: yaml
+.. code-block:: openapi2
 
    ...
    paths:

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -11,6 +11,8 @@ Dredd itself is a `command-line <https://en.wikipedia.org/wiki/Command-line_inte
    :depth: 1
 
 
+.. _maintainers:
+
 Maintainers
 -----------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -42,7 +42,7 @@ First, let’s design the API we are about to build and test. That means you wil
 
       If you choose OpenAPI 2, create a file called ``api-description.yml``:
 
-      .. code-block:: yaml
+      .. code-block:: openapi2
 
          swagger: "2.0"
          info:

--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -16,12 +16,16 @@ redirects:
   "/usage.html": "/usage-cli.html"
   "/contributing.html": "/internals.html"
 
+  # 'Node.js to JavaScript' migration
+  "/hooks/nodejs.html": "/hooks/js.html"
+  "/hooks-nodejs.html": "/hooks/js.html"
+  "/hooks-nodejs/": "/hooks/js.html"
+
   # 'Hooks to a directory' migration
   "/hooks.html": "/hooks/index.html"
   "/hooks-go.html": "/hooks/go.html"
   "/hooks-new-language.html": "/hooks/new-language.html"
   "/hooks-perl.html": "/hooks/perl.html"
-  "/hooks-nodejs.html": "/hooks/nodejs.html"
   "/hooks-ruby.html": "/hooks/ruby.html"
   "/hooks-php.html": "/hooks/php.html"
   "/hooks-python.html": "/hooks/python.html"
@@ -40,7 +44,6 @@ redirects:
   "/hooks-go/": "/hooks/go.html"
   "/hooks-new-language/": "/hooks/new-language.html"
   "/hooks-perl/": "/hooks/perl.html"
-  "/hooks-nodejs/": "/hooks/nodejs.html"
   "/hooks-ruby/": "/hooks/ruby.html"
   "/hooks-php/": "/hooks/php.html"
   "/hooks-python/": "/hooks/python.html"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ sphinx==1.8.1
 jinja2==2.10
 git+https://github.com/jhermann/pygments-markdown-lexer.git@e651a9a3f664285b01451eb39232b1ad9af65956#egg=pygments-markdown-lexer
 pygments-apiblueprint==0.1.0
-sphinx-tabs==1.1.9
+sphinx-tabs==1.1.10
 
 # dev dependencies
 doc8==0.8.0

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -50,7 +50,7 @@ Dredd offers interactive wizard to setup your ``dredd.yml`` file:
 
 See below how sample configuration file could look like. The structure is the same as of the :ref:`Dredd Class configuration object <configuration-object-for-dredd-class>`.
 
-.. code-block:: yaml
+.. code-block:: openapi2
 
    reporter: apiary
    custom:

--- a/lib/options.json
+++ b/lib/options.json
@@ -6,7 +6,7 @@
   },
   "hookfiles": {
     "alias": "f",
-    "description": "Specifies a pattern to match files with before/after hooks for running tests. Files are executed in alphabetical order.",
+    "description": "Path to hook files. Can be used multiple times, supports glob patterns. Hook files are executed in alphabetical order.",
     "default": null
   },
   "language": {

--- a/test/fixtures/blog/api.apib
+++ b/test/fixtures/blog/api.apib
@@ -1,0 +1,32 @@
+FORMAT: 1A
+
+# Blog API
+## Articles [/articles]
+### List articles [GET]
+
++ Response 200 (application/json)
+
+        [
+          {
+            "id": 1,
+            "title": "Creamy cucumber salad",
+            "text": "Slice cucumbers…"
+          }
+        ]
+
+### Publish an article [POST]
+
++ Request (application/json)
+
+        {
+          "title": "Crispy schnitzel",
+          "text": "Prepare eggs…"
+        }
+
++ Response 201 (application/json)
+
+        {
+          "id": 2,
+          "title": "Crispy schnitzel",
+          "text": "Prepare eggs…"
+        }

--- a/test/fixtures/blog/api.yaml
+++ b/test/fixtures/blog/api.yaml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  title: "Blog API"
+  version: "1.0"
+consumes:
+  - "application/json"
+produces:
+  - "application/json"
+paths:
+  "/articles":
+    x-summary: "Articles"
+    get:
+      summary: "List articles"
+      description: "Retrieve a list of all articles"
+      responses:
+        200:
+          description: "Articles list"
+          examples:
+            "application/json":
+              - id: 1
+                title: "Creamy cucumber salad"
+                text: "Slice cucumbers…"
+    post:
+      summary: "Publish an article"
+      description: "Create and publish a new article"
+      parameters:
+        - name: "body"
+          in: "body"
+          schema:
+            example:
+              title: "Crispy schnitzel"
+              text: "Prepare eggs…"
+      responses:
+        201:
+          description: "New article"
+          examples:
+            "application/json":
+              id: 2
+              title: "Crispy schnitzel"
+              text: "Prepare eggs…"

--- a/test/fixtures/blog/hooks-apib.js
+++ b/test/fixtures/blog/hooks-apib.js
@@ -1,0 +1,5 @@
+const hooks = require('hooks');
+
+hooks.before('Articles > Publish an article', (transaction) => {
+  transaction.request.headers.Authorization = 'Basic: YWxhZGRpbjpvcGVuc2VzYW1l';
+});

--- a/test/fixtures/blog/hooks-openapi2.js
+++ b/test/fixtures/blog/hooks-openapi2.js
@@ -1,0 +1,5 @@
+const hooks = require('hooks');
+
+hooks.before('Articles > Publish an article > 201 > application/json', (transaction) => {
+  transaction.request.headers.Authorization = 'Basic: YWxhZGRpbjpvcGVuc2VzYW1l';
+});


### PR DESCRIPTION
#### :rocket: Why this change?

I wanted to add something about Docker to the hooks docs and I couldn't hold myself to rewrite them.

#### :memo: Related issues and Pull Requests

- Closes https://github.com/apiaryio/dredd/issues/918 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
