### PR TITLE
Fix the JS API path for case-sensitive systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dredd",
   "version": "0.0.0-semantically-released",
   "description": "HTTP API Testing Framework",
-  "main": "lib/dredd.js",
+  "main": "lib/Dredd.js",
   "bin": {
     "dredd": "bin/dredd"
   },


### PR DESCRIPTION
#### :rocket: Why this change?

After recent renaming of files to conform to JS Airbnb style guide, we forgot to change `package.json` as well.

#### :memo: Related issues and Pull Requests

Fix https://github.com/apiaryio/dredd/issues/1187

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
