### PR TITLE
Announce sandboxed JS hooks as deprecated

### DIFF
--- a/docs/hooks/js-sandbox.rst
+++ b/docs/hooks/js-sandbox.rst
@@ -3,6 +3,9 @@
 JavaScript Hooks In Sandbox Mode
 ================================
 
+.. warning::
+   The sandboxed JavaScript hooks are deprecated. Use :ref:`JavaScript hooks <hooks-js>` as a replacement. See :ghissue:`#1178` for more details.
+
 Usage
 -----
 

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -150,6 +150,7 @@ Stack: ${error.stack}
     // Loading files in sandboxed mode
   }
   // Load sandbox files from fs
+  logger.warn('DEPRECATION WARNING: The sandboxed JavaScript hooks are deprecated. Use JavaScript hooks instead. See https://github.com/apiaryio/dredd/issues/1178');
   logger.info('Loading hook files in sandboxed context:', files);
 
   async.eachSeries(files, (resolvedPath, nextFile) => {


### PR DESCRIPTION
#### :rocket: Why this change?

Puts https://github.com/apiaryio/dredd/issues/1178 in action. Small step for Dredd users, big step for Dredd's codebase!

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/dredd/issues/1178

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
