### PR TITLE
chore: Require Node.js 6.9; disallow Node.js 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dredd": "bin/dredd"
   },
   "engines": {
-    "node": ">= 6"
+    "node": "^6.9 || >=8"
   },
   "scripts": {
     "docs:lint": "doc8 ./docs && sphinx-build -nW -b linkcheck ./docs ./docs/_build",


### PR DESCRIPTION
BREAKING CHANGE: Node.js < 6.9 and Node.js 7 are  no longer supported

#### :rocket: Why this change?

Since there are a couple of breaking changes in the pipeline, I'd like to propose one more.

Node.js 6.9 was the first LTS release for Node.js 6. Node.js 6.5 came with a newer v8 version that adds some minor features and is generally more consistent with ES2015 and newer features. It's a modest increase since not many folks will still be running non-LTS Node.js 6 versions. Since all CI tests by default run on the _newest_ Node.js 6 version, this also helps prevent accidental breakage.

Disallowing Node.js 7 (for which support ended 2017-06-30) unblocks upgrading `fs-extra` to version 7.

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
