### PR TITLE
Add experimental OpenAPI 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ documentation.
 
 - [API Blueprint][]
 - [OpenAPI 2][] (formerly known as Swagger)
+- [OpenAPI 3][] ([experimental](https://github.com/apiaryio/api-elements.js/blob/master/packages/fury-adapter-oas3-parser/STATUS.md), contributions welcome!)
 
 ### Supported Hooks Languages
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Supported API Description Formats
 
 -  `API Blueprint`_
 -  `OpenAPI 2`_ (formerly known as Swagger)
+-  `OpenAPI 3`_ (`experimental <https://github.com/apiaryio/api-elements.js/blob/master/packages/fury-adapter-oas3-parser/STATUS.md>`__, contributions welcome!)
 
 Supported Hooks Languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "4.1.2",
     "clone": "2.1.2",
     "cross-spawn": "6.0.5",
-    "dredd-transactions": "6.2.6",
+    "dredd-transactions": "6.3.0",
     "gavel": "2.2.1",
     "glob": "7.1.3",
     "html": "1.0.0",


### PR DESCRIPTION
#### :rocket: Why this change?

Because we want to support OAS3 😄 

#### :memo: Related issues and Pull Requests

Closes https://github.com/apiaryio/dredd/issues/894

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
