### PR TITLE
Speedup tests

### DIFF
--- a/test/integration/cli/api-blueprint-cli-test.js
+++ b/test/integration/cli/api-blueprint-cli-test.js
@@ -8,7 +8,7 @@ describe('CLI - API Blueprint Document', () => {
       let runtimeInfo;
       const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
 
@@ -29,7 +29,7 @@ describe('CLI - API Blueprint Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -49,7 +49,7 @@ describe('CLI - API Blueprint Document', () => {
         '--no-color',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;

--- a/test/integration/cli/api-description-cli-test.js
+++ b/test/integration/cli/api-description-cli-test.js
@@ -12,7 +12,7 @@ describe('CLI - API Description Document', () => {
       let runtimeInfo;
       const args = ['./test/fixtures/single-g*t.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
 
@@ -33,7 +33,7 @@ describe('CLI - API Description Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -52,7 +52,7 @@ describe('CLI - API Description Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -74,7 +74,7 @@ describe('CLI - API Description Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/single-get.apib', (req, res) => {
           res.type('text/vnd.apiblueprint');
@@ -100,7 +100,7 @@ describe('CLI - API Description Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -124,7 +124,7 @@ describe('CLI - API Description Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/__non-existent__.apib', (req, res) => res.sendStatus(404));
 
@@ -154,7 +154,7 @@ describe('CLI - API Description Document', () => {
         '--path=./test/fixtures/single-get-uri-template.apib',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
         app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
@@ -177,7 +177,7 @@ describe('CLI - API Description Document', () => {
         `--path=http://127.0.0.1:${DEFAULT_SERVER_PORT}/single-get.yaml`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/single-get.yaml', (req, res) => {
           res.type('application/yaml');
@@ -206,7 +206,7 @@ describe('CLI - API Description Document', () => {
         '--path=./test/fixtures/single-get-path.apib',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
         app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
@@ -230,7 +230,7 @@ describe('CLI - API Description Document', () => {
         '--path=./test/fixtures/single-get-uri-temp*.apib',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
         app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
@@ -253,7 +253,7 @@ describe('CLI - API Description Document', () => {
         '--path=./test/fixtures/__non-existent__.apib',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
 

--- a/test/integration/cli/openapi2-cli-test.js
+++ b/test/integration/cli/openapi2-cli-test.js
@@ -8,7 +8,7 @@ describe('CLI - OpenAPI 2 Document', () => {
       let runtimeInfo;
       const args = ['./test/fixtures/single-get.yaml', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
 
@@ -29,7 +29,7 @@ describe('CLI - OpenAPI 2 Document', () => {
         `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -49,7 +49,7 @@ describe('CLI - OpenAPI 2 Document', () => {
         '--no-color',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
         const app = createServer();
         app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
 

--- a/test/integration/cli/reporters-cli-test.js
+++ b/test/integration/cli/reporters-cli-test.js
@@ -9,7 +9,7 @@ const APIARY_PORT = DEFAULT_SERVER_PORT + 1;
 describe('CLI - Reporters', () => {
   let server;
 
-  beforeEach((done) => {
+  before((done) => {
     const app = createServer();
 
     app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
@@ -19,7 +19,7 @@ describe('CLI - Reporters', () => {
     });
   });
 
-  afterEach(done => server.close(done));
+  after(done => server.close(done));
 
 
   describe('when -r/--reporter is provided to use additional reporters', () => {
@@ -30,7 +30,7 @@ describe('CLI - Reporters', () => {
       '--reporter=nyan',
     ];
 
-    beforeEach((done) => {
+    before((done) => {
       runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
@@ -51,7 +51,7 @@ describe('CLI - Reporters', () => {
     const env = clone(process.env);
     env.APIARY_API_URL = `http://127.0.0.1:${APIARY_PORT}`;
 
-    beforeEach((done) => {
+    before((done) => {
       const app = createServer();
 
       app.post('/apis/*', (req, res) => {
@@ -70,7 +70,7 @@ describe('CLI - Reporters', () => {
       });
     });
 
-    afterEach(done => apiary.close(done));
+    after(done => apiary.close(done));
 
     describe('when Dredd successfully performs requests to Apiary', () => {
       let cliInfo;
@@ -81,11 +81,14 @@ describe('CLI - Reporters', () => {
         '--reporter=apiary',
       ];
 
-      beforeEach(done => runCLI(args, { env }, (err, info) => {
-        cliInfo = info;
-        stepRequest = apiaryRuntimeInfo.requests['/apis/public/tests/steps?testRunId=1234_id'][0];
-        done(err);
-      }));
+      before((done) => {
+        apiaryRuntimeInfo.reset();
+        runCLI(args, { env }, (err, info) => {
+          cliInfo = info;
+          stepRequest = apiaryRuntimeInfo.requests['/apis/public/tests/steps?testRunId=1234_id'][0];
+          done(err);
+        });
+      });
 
       it('should print URL of the test report', () => assert.include(cliInfo.stdout, 'http://example.com/test/run/1234_id'));
       it('should print warning about missing Apiary API settings', () => assert.include(cliInfo.stdout, 'Apiary API Key or API Project Subdomain were not provided.'));
@@ -120,7 +123,8 @@ describe('CLI - Reporters', () => {
         '--hookfiles=./test/fixtures/hooks-log.coffee',
       ];
 
-      beforeEach((done) => {
+      before((done) => {
+        apiaryRuntimeInfo.reset();
         runCLI(args, { env }, (err, info) => {
           cliInfo = info;
           updateRequest = apiaryRuntimeInfo.requests['/apis/public/tests/run/1234_id'][0];
@@ -193,11 +197,11 @@ describe('CLI - Reporters', () => {
       '--output=__test_file_output__.xml',
     ];
 
-    beforeEach(done => runCLI(args, (err) => {
+    before(done => runCLI(args, (err) => {
       done(err);
     }));
 
-    afterEach(() => fs.unlinkSync(`${process.cwd()}/__test_file_output__.xml`));
+    after(() => fs.unlinkSync(`${process.cwd()}/__test_file_output__.xml`));
 
     it('should create given file', () => assert.isOk(fs.existsSync(`${process.cwd()}/__test_file_output__.xml`)));
   });
@@ -212,11 +216,11 @@ describe('CLI - Reporters', () => {
       '--output=__test_file_output2__.xml',
     ];
 
-    beforeEach(done => runCLI(args, (err) => {
+    before(done => runCLI(args, (err) => {
       done(err);
     }));
 
-    afterEach(() => {
+    after(() => {
       fs.unlinkSync(`${process.cwd()}/__test_file_output1__.xml`);
       fs.unlinkSync(`${process.cwd()}/__test_file_output2__.xml`);
     });
@@ -235,7 +239,7 @@ describe('CLI - Reporters', () => {
       '--output=./__test_directory/__test_file_output__.xml',
     ];
 
-    beforeEach((done) => {
+    before((done) => {
       try {
         fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`);
       } catch (error) {
@@ -247,7 +251,7 @@ describe('CLI - Reporters', () => {
       });
     });
 
-    afterEach(() => {
+    after(() => {
       fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`);
       fs.rmdirSync(`${process.cwd()}/__test_directory`);
     });
@@ -264,7 +268,7 @@ describe('CLI - Reporters', () => {
       '--reporter=apiary',
     ];
 
-    beforeEach((done) => {
+    before((done) => {
       apiaryApiUrl = process.env.APIARY_API_URL;
 
       const nonExistentPort = DEFAULT_SERVER_PORT + 42;
@@ -275,7 +279,7 @@ describe('CLI - Reporters', () => {
         done(err);
       });
     });
-    afterEach(() => { process.env.APIARY_API_URL = apiaryApiUrl; });
+    after(() => { process.env.APIARY_API_URL = apiaryApiUrl; });
 
     it('ends successfully', () => assert.equal(cliInfo.exitStatus, 0));
     it('prints error about Apiary API connection issues', () => assert.include(cliInfo.stderr, 'Apiary reporter could not connect to Apiary API'));

--- a/test/integration/cli/server-process-cli-test.js
+++ b/test/integration/cli/server-process-cli-test.js
@@ -10,7 +10,7 @@ describe('CLI - Server Process', () => {
     let server;
     let serverRuntimeInfo;
 
-    beforeEach((done) => {
+    before((done) => {
       const app = createServer();
 
       app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
@@ -23,14 +23,14 @@ describe('CLI - Server Process', () => {
       });
     });
 
-    afterEach(done => server.close(done));
+    after(done => server.close(done));
 
 
     describe('when is running', () => {
       let cliInfo;
       const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
 
-      beforeEach(done => runCLI(args, (err, info) => {
+      before(done => runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
       }));
@@ -43,7 +43,7 @@ describe('CLI - Server Process', () => {
       let cliInfo;
       const args = ['./test/fixtures/apiary.apib', `http://127.0.0.1:${NON_EXISTENT_PORT}`];
 
-      beforeEach(done => runCLI(args, (err, info) => {
+      before(done => runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
       }));
@@ -71,7 +71,7 @@ describe('CLI - Server Process', () => {
         '--server-wait=1',
       ];
 
-      beforeEach(done => runCLI(args, (err, info) => {
+      before(done => runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
       }));
@@ -90,7 +90,7 @@ describe('CLI - Server Process', () => {
         '--server-wait=1',
       ];
 
-      beforeEach(done => runCLI(args, (err, info) => {
+      before(done => runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
       }));
@@ -134,7 +134,7 @@ describe('CLI - Server Process', () => {
           '--server-wait=1',
         ];
 
-        beforeEach(done => runCLI(args, (err, info) => {
+        before(done => runCLI(args, (err, info) => {
           cliInfo = info;
           done(err);
         }));
@@ -162,7 +162,7 @@ describe('CLI - Server Process', () => {
         '--level=verbose',
       ];
 
-      beforeEach(done => runCLI(args, (err, info) => {
+      before(done => runCLI(args, (err, info) => {
         cliInfo = info;
         done(err);
       }));

--- a/test/integration/dredd-test.js
+++ b/test/integration/dredd-test.js
@@ -542,7 +542,7 @@ describe('Dredd class Integration', () => {
     const reTransactionName = /hook: (.+)/g;
     let matches;
 
-    beforeEach(done => execCommand({
+    before(done => execCommand({
       options: {
         path: './test/fixtures/multiple-responses.yaml',
         hookfiles: './test/fixtures/openapi2-transaction-names.js',

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -96,6 +96,13 @@ function createServer(options = {}) {
     lastRequest: null,
     requests: {},
     requestCounts: {},
+    reset: function reset() {
+      this.requestedOnce = false;
+      this.requested = false;
+      this.lastRequest = null;
+      this.requests = {};
+      this.requestCounts = {};
+    },
   };
 
   let app = express();

--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -86,11 +86,11 @@ function test(scenario) {
   let proxy;
   let proxyRequestInfo = {};
 
-  beforeEach((done) => {
+  before((done) => {
     const app = createProxyServer(scenario.protocol, proxyRequestInfo);
     proxy = app.listen(PROXY_PORT, done);
   });
-  afterEach((done) => {
+  after((done) => {
     proxyRequestInfo = {};
     proxy.close(done);
   });
@@ -99,14 +99,14 @@ function test(scenario) {
   let server;
   let serverRuntimeInfo;
 
-  beforeEach((done) => {
+  before((done) => {
     const app = createServer({ protocol: scenario.protocol });
     server = app.listen(DEFAULT_SERVER_PORT, (err, info) => {
       serverRuntimeInfo = info;
       done(err);
     });
   });
-  afterEach((done) => {
+  after((done) => {
     serverRuntimeInfo = undefined;
     server.close(done);
   });
@@ -114,7 +114,7 @@ function test(scenario) {
   // Setup and run Dredd
   let dreddLogging;
 
-  beforeEach((done) => {
+  before((done) => {
     const configuration = { options: {} };
     scenario.configureDredd(configuration);
 
@@ -166,8 +166,8 @@ proxy specified by environment variables: \
 ${protocol}_proxy=${PROXY_URL}\
 `;
 
-    beforeEach(() => { process.env[`${protocol}_proxy`] = PROXY_URL; });
-    afterEach(() => delete process.env[`${protocol}_proxy`]);
+    before(() => { process.env[`${protocol}_proxy`] = PROXY_URL; });
+    after(() => delete process.env[`${protocol}_proxy`]);
 
     describe('Requesting Server Under Test', () => test({
       protocol,
@@ -181,8 +181,8 @@ ${protocol}_proxy=${PROXY_URL}\
     }));
 
     describe('Using Apiary Reporter', () => {
-      beforeEach(() => { process.env.APIARY_API_URL = serverUrl; });
-      afterEach(() => delete process.env.APIARY_API_URL);
+      before(() => { process.env.APIARY_API_URL = serverUrl; });
+      after(() => delete process.env.APIARY_API_URL);
 
       test({
         protocol,
@@ -218,11 +218,11 @@ proxy specified by environment variables: \
 http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
 `;
 
-  beforeEach(() => {
+  before(() => {
     process.env.http_proxy = PROXY_URL;
     process.env.no_proxy = SERVER_HOST;
   });
-  afterEach(() => {
+  after(() => {
     delete process.env.http_proxy;
     delete process.env.no_proxy;
   });
@@ -239,8 +239,8 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
   }));
 
   describe('Using Apiary Reporter', () => {
-    beforeEach(() => { process.env.APIARY_API_URL = serverUrl; });
-    afterEach(() => delete process.env.APIARY_API_URL);
+    before(() => { process.env.APIARY_API_URL = serverUrl; });
+    after(() => delete process.env.APIARY_API_URL);
 
     test({
       protocol: 'http',

--- a/test/integration/regressions/regression-319-354-test.js
+++ b/test/integration/regressions/regression-319-354-test.js
@@ -151,7 +151,7 @@ describe('Regression: Issues #319 and #354', () => {
   };
 
   describe('Tested app is consistent with the API description', () => {
-    beforeEach((done) => {
+    before((done) => {
       const app = createServer();
 
       // Attaching endpoint for each testing scenario
@@ -224,7 +224,7 @@ describe('Regression: Issues #319 and #354', () => {
       items: [incorrectUserPayload],
     };
 
-    beforeEach((done) => {
+    before((done) => {
       const app = createServer();
 
       // Attaching endpoint for each testing scenario

--- a/test/integration/require-test.js
+++ b/test/integration/require-test.js
@@ -12,7 +12,7 @@ const API_DESCRIPTION = './test/fixtures/single-get.apib';
 describe('Dredd requiring language compilers', () => {
   let apiary;
 
-  beforeEach((done) => {
+  before((done) => {
     const app = createServer();
 
     app.post('/apis/*', (req, res) => res.json({
@@ -28,7 +28,7 @@ describe('Dredd requiring language compilers', () => {
     });
   });
 
-  afterEach(done => apiary.close(done));
+  after(done => apiary.close(done));
 
   it('should work with CoffeScript', (done) => {
     const dredd = new Dredd({

--- a/test/unit/CLI-test.js
+++ b/test/unit/CLI-test.js
@@ -367,7 +367,7 @@ describe('CLI class', () => {
   });
 
   describe('when using --server', () => {
-    beforeEach((done) => {
+    before((done) => {
       sinon.stub(crossSpawnStub, 'spawn').callsFake();
       sinon.stub(transactionRunner.prototype, 'executeAllTransactions').callsFake((transactions, hooks, cb) => cb());
       execCommand({
@@ -380,7 +380,7 @@ describe('CLI class', () => {
       }, () => done());
     });
 
-    afterEach(() => crossSpawnStub.spawn.restore());
+    after(() => crossSpawnStub.spawn.restore());
 
     it('should run child process', () => assert.isTrue(crossSpawnStub.spawn.called));
   });

--- a/test/unit/Hooks-test.js
+++ b/test/unit/Hooks-test.js
@@ -29,7 +29,7 @@ describe('Hooks', () => {
   describe('#log', () => {
     let options = null;
 
-    beforeEach(() => {
+    before(() => {
       options = {
         logs: [{ content: 'message1' }, { content: 'message2' }],
         logger: {
@@ -41,7 +41,7 @@ describe('Hooks', () => {
       sinon.spy(options.logger, 'error');
     });
 
-    afterEach(() => {
+    after(() => {
       options.logger.hook.restore();
       options.logger.error.restore();
     });

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -89,7 +89,7 @@ describe('addHooks(runner, transactions, callback)', () => {
   describe('with non `nodejs` language option', () => {
     let runner = null;
 
-    beforeEach(() => {
+    before(() => {
       runner = {
         configuration: {
           options: {
@@ -102,7 +102,7 @@ describe('addHooks(runner, transactions, callback)', () => {
       sinon.stub(hooksWorkerClientStub.prototype, 'start').callsFake(cb => cb());
     });
 
-    afterEach(() => hooksWorkerClientStub.prototype.start.restore());
+    after(() => hooksWorkerClientStub.prototype.start.restore());
 
     it('should start the hooks worker client', done => addHooks(runner, transactions, (err) => {
       if (err) { return done(err); }
@@ -114,7 +114,7 @@ describe('addHooks(runner, transactions, callback)', () => {
 
   describe('with valid pattern', () => {
     let runner = null;
-    beforeEach(() => {
+    before(() => {
       runner = {
         configuration: {
           options: {

--- a/test/unit/getGoBinary-test.js
+++ b/test/unit/getGoBinary-test.js
@@ -74,7 +74,7 @@ describe('getGoBinary()', () => {
         done();
       });
     });
-    afterEach(() => childProcess.exec.restore());
+    after(() => childProcess.exec.restore());
 
     it('calls \'go env GOPATH\' + /bin', () => assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gopath', 'path', 'bin')]));
   });
@@ -90,7 +90,7 @@ describe('getGoBinary()', () => {
         done();
       });
     });
-    afterEach(() => childProcess.exec.restore());
+    after(() => childProcess.exec.restore());
 
     it('propagates the error', () => assert.deepEqual(callbackArgs, [error]));
   });


### PR DESCRIPTION
#### :rocket: Why this change?

In the pursuit of extreme test isolation, the test suite is extremely slow compared to what's in there. Sure, integration tests with process spawning etc. are destined to be slow, but otherwise there's a lot of room for improvement if we agree `beforeEach()` really isn't needed everywhere.

------------

Before:

<img width="902" alt="image" src="https://user-images.githubusercontent.com/283441/52124249-eee45700-2628-11e9-801f-19a15c865585.png">

After:

<img width="908" alt="image" src="https://user-images.githubusercontent.com/283441/52127812-83ec4d80-2633-11e9-8db1-850cc76a367f.png">

#### :memo: Related issues and Pull Requests

Close https://github.com/apiaryio/dredd/issues/1217

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
