### PR TITLE
Fix JSON syntax in options to be consistent

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -113,8 +113,12 @@
     "default": []
   },
   "help": {
-    "description": "Show usage information."  }, "version": {
-    "description": "Show version number."  }, "hooks-worker-timeout": {
+    "description": "Show usage information."
+  },
+  "version": {
+    "description": "Show version number."
+  },
+  "hooks-worker-timeout": {
     "description": "How long to wait for hooks worker to start. [ms]",
     "default": 5000
   },


### PR DESCRIPTION
#### :rocket: Why this change?

I opened the file and it was hard to read.

#### :memo: Related issues and Pull Requests

Nupe.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
