### PR TITLE
Ensure that bin/dredd conforms to style guide

### DIFF
--- a/bin/dredd
+++ b/bin/dredd
@@ -1,44 +1,44 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var path = require('path');
+/* eslint-disable global-require */
 
+const fs = require('fs');
+const path = require('path');
 
 // Ignore this block, it's pure magic, temporary fix
 // for https://github.com/nodejs/node/issues/6456
-[process.stdout, process.stderr].forEach(function (s) {
-  s && s.isTTY && s._handle && s._handle.setBlocking && s._handle.setBlocking(true);
-});
-
-
-var CLI = require('../lib/CLI');
-
-
-var dreddCli = new CLI({
-  custom: {
-    cwd: process.cwd(),
-    argv: process.argv.slice(2)
+[process.stdout, process.stderr].forEach((s) => {
+  if (s && s.isTTY && s._handle && s._handle.setBlocking) {
+    s._handle.setBlocking(true);
   }
 });
 
+const CLI = require('../lib/CLI');
+
+const dreddCli = new CLI({
+  custom: {
+    cwd: process.cwd(),
+    argv: process.argv.slice(2),
+  },
+});
 
 if (process.env.COVERAGE_DIR) {
-  process.on('exit', function () {
+  process.on('exit', () => {
     // Before Dredd exits, we need to collect coverage stats and save them to
     // a file. We abuse 'mocha-lcov-reporter' to do this.
-    var LCov = require('mocha-lcov-reporter');
+    const LCov = require('mocha-lcov-reporter');
 
     // Pretending there is Mocha runner
-    var EventEmitter = require('events').EventEmitter;
-    var runner = new EventEmitter();
+    const EventEmitter = require('events').EventEmitter;
+    const runner = new EventEmitter();
 
     // Monkey-patching 'LCov.prototype.write' to catch all output to a variable
-    var content = '';
-    var write = LCov.prototype.write;
+    let content = '';
+    const write = LCov.prototype.write;
 
-    LCov.prototype.write = function(string) {
+    LCov.prototype.write = (string) => {
       content += string;
-    }
+    };
 
     // Collecting the stats
     new LCov(runner);
@@ -48,10 +48,9 @@ if (process.env.COVERAGE_DIR) {
     LCov.prototype.write = write;
 
     // Save stats as lcov file
-    var file = path.join(process.env.COVERAGE_DIR, 'dredd-bin.info');
+    const file = path.join(process.env.COVERAGE_DIR, 'dredd-bin.info');
     fs.appendFileSync(file, content);
-  })
+  });
 }
-
 
 dreddCli.run();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:test-extensions": "python -m unittest docs/_extensions/*.py --verbose",
     "docs:build": "sphinx-build -nW -b html ./docs ./docs/_build",
     "docs:serve": "sphinx-autobuild ./docs ./docs/_build",
-    "lint": "./scripts/commitlint.sh && eslint .",
+    "lint": "./scripts/commitlint.sh && eslint . bin/dredd",
     "test": "mocha \"./test/**/*-test.js\"",
     "test:coverage": "bash ./scripts/coverage.sh",
     "test:debug": "mocha --debug-brk \"./test/**/*-test.js\"",


### PR DESCRIPTION
#### :rocket: Why this change?

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
