### PR TITLE
Fix the example code of OpenAPI 2 (api-description.yml) in Quickstart…

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -44,31 +44,31 @@ First, let’s design the API we are about to build and test. That means you wil
 
       .. code-block:: openapi2
 
-         swagger: "2.0"
+         swagger: '2.0'
          info:
-         version: "1.0"
-         title: Example API
-         license:
-            name: MIT
+           version: '1.0'
+           title: Example API
+           license:
+             name: MIT
          host: www.example.com
          basePath: /
          schemes:
-         - http
+           - http
          paths:
-         /:
-            get:
+           /:
+             get:
                produces:
-               - application/json; charset=utf-8
+                 - application/json; charset=utf-8
                responses:
-               200:
-                  description: ""
-                  schema:
+                 '200':
+                   description: ''
+                   schema:
                      type: object
                      properties:
-                     message:
-                        type: string
+                       message:
+                         type: string
                      required:
-                     - message
+                       - message
 
 Implement Your API
 ------------------


### PR DESCRIPTION
#### :rocket: Why this change?

Dredd cannot parse the api-description.yml on the Quickstart page currently.

```
> dredd .\api-description.yml http://localhost:3000
error: Parser error in file './api-description.yml': Cannot read property 'version' of null on line 1
error: Error when processing API description.
```

The problem is caused by the grammatical error of yaml file. Therefore I update it using Swagger Editor.

