### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "README.md"
   ],
   "dependencies": {
-    "async": "2.6.1",
+    "async": "2.6.2",
     "caseless": "0.12.0",
     "chai": "4.2.0",
     "clone": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "htmlencode": "0.0.4",
     "inquirer": "6.2.2",
     "js-yaml": "3.12.1",
-    "make-dir": "1.3.0",
+    "make-dir": "2.0.0",
     "markdown-it": "8.4.2",
     "optimist": "0.6.1",
     "proxyquire": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "glob": "7.1.3",
     "html": "1.0.0",
     "htmlencode": "0.0.4",
-    "inquirer": "6.2.1",
+    "inquirer": "6.2.2",
     "js-yaml": "3.12.1",
     "make-dir": "1.3.0",
     "markdown-it": "8.4.2",


### PR DESCRIPTION
#### :rocket: Why this change?

For some reason these updates where not picked up by Greenkeeper.

`make-dir` is the most interesting one of these updates, as it will use the native Node.js API to recursively create directories, if that API is available.

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`