### PR TITLE
Upgrade Dredd Transactions to v7

### DIFF
--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -5,18 +5,20 @@ const fs = require('fs');
 const path = require('path');
 const request = require('request');
 const url = require('url');
+const parse = require('dredd-transactions/parse');
+const compile = require('dredd-transactions/compile');
 
-const dreddTransactions = require('dredd-transactions');
 const configureReporters = require('./configureReporters');
 const handleRuntimeProblems = require('./handleRuntimeProblems');
 const logger = require('./logger');
 const Runner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
-
 const options = require('./options.json');
+
 
 const PROXY_ENV_VARIABLES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 const FILE_DOWNLOAD_TIMEOUT = 5000;
+
 
 function removeDuplicates(arr) {
   return arr.reduce((alreadyProcessed, currentItem) => {
@@ -256,13 +258,21 @@ Is the provided path correct?
       const fileData = this.configuration.data[filename];
       if (!fileData.annotations) { fileData.annotations = []; }
 
-      this.logger.debug('Compiling HTTP transactions from API description file:', filename);
-      dreddTransactions.compile(fileData.raw, filename, (compilationError, compilationResult) => {
-        if (compilationError) { return next(compilationError); }
+      this.logger.debug(`Parsing API description: ${filename}`);
+      parse(fileData.raw, (parseErr, parseResult) => {
+        if (parseErr) { next(parseErr); return; }
 
-        fileData.mediaType = compilationResult.mediaType;
-        fileData.annotations = fileData.annotations.concat(compilationResult.annotations);
-        this.transactions = this.transactions.concat(compilationResult.transactions);
+        this.logger.debug(`Compiling HTTP transactions from API description: ${filename}`);
+        let compileResult;
+        try {
+          compileResult = compile(parseResult.mediaType, parseResult.apiElements, filename);
+        } catch (compileErr) {
+          next(compileErr);
+          return;
+        }
+        fileData.mediaType = compileResult.mediaType;
+        fileData.annotations = fileData.annotations.concat(compileResult.annotations);
+        this.transactions = this.transactions.concat(compileResult.transactions);
         next();
       });
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "4.2.0",
     "clone": "2.1.2",
     "cross-spawn": "6.0.5",
-    "dredd-transactions": "6.5.2",
+    "dredd-transactions": "7.0.0",
     "gavel": "2.2.1",
     "glob": "7.1.3",
     "html": "1.0.0",

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -5,13 +5,18 @@ const proxyquire = require('proxyquire').noCallThru();
 const requestStub = require('request');
 const sinon = require('sinon');
 const { assert } = require('chai');
+const parse = require('dredd-transactions/parse');
+const compile = require('dredd-transactions/compile');
 
-const dreddTransactionsStub = require('dredd-transactions');
 const loggerStub = require('../../lib/logger');
+
+const parseStub = sinon.spy(parse);
+const compileStub = sinon.spy(compile);
 
 const Dredd = proxyquire('../../lib/Dredd', {
   request: requestStub,
-  'dredd-transactions': dreddTransactionsStub,
+  'dredd-transactions/parse': parseStub,
+  'dredd-transactions/compile': compileStub,
   fs: fsStub,
   './logger': loggerStub,
 });
@@ -75,11 +80,11 @@ describe('Dredd class', () => {
     });
 
     it('should convert ast to runtime', (done) => {
-      sinon.spy(dreddTransactionsStub, 'compile');
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
       dredd.run(() => {
-        assert.isOk(dreddTransactionsStub.compile.called);
+        assert.isOk(parseStub.called);
+        assert.isOk(compileStub.called);
         dredd.runner.executeTransaction.restore();
         done();
       });

--- a/test/unit/handleRuntimeProblems-test.js
+++ b/test/unit/handleRuntimeProblems-test.js
@@ -2,7 +2,8 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const { assert } = require('chai');
 
-const dreddTransactions = require('dredd-transactions');
+const parse = require('dredd-transactions/parse');
+const compile = require('dredd-transactions/compile');
 
 const logger = require('../../lib/logger');
 
@@ -10,13 +11,13 @@ const handleRuntimeProblems = proxyquire('../../lib/handleRuntimeProblems',
   { './logger': logger });
 
 function prepareData(apiDescriptionDocument, filename, done) {
-  dreddTransactions.compile(apiDescriptionDocument, filename, (err, { annotations }) => {
-    if (err) { return done(err); }
+  parse(apiDescriptionDocument, (err, parseResult) => {
+    if (err) { done(err); return; }
 
-    const data = {};
-    data[filename] = { raw: apiDescriptionDocument, filename, annotations };
-
-    done(null, data);
+    const { annotations } = compile(parseResult.mediaType, parseResult.apiElements, filename);
+    done(null, {
+      [filename]: { raw: apiDescriptionDocument, filename, annotations },
+    });
   });
 }
 


### PR DESCRIPTION
Depends on https://github.com/apiaryio/dredd/pull/1258

-------

#### :rocket: Why this change?

This upgrades Dredd Transactions and uses their new public interface. The `compileTransactions` function is a mess, but refactoring that is a challenge for another day.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
