### PR TITLE
fix: (dredd.yml) Uses default "language" value when not prompted

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -180,7 +180,7 @@ function applyAnswers(config, answers, options = {}) {
   config._[1] = answers.apiHost;
 
   config.server = answers.server || null;
-  config.language = answers.language;
+  config.language = answers.language || 'nodejs';
 
   if (answers.apiary) { config.reporter = 'apiary'; }
   if (answers.apiaryApiKey) { config.custom.apiaryApiKey = answers.apiaryApiKey; }

--- a/test/unit/init/applyAnswers-test.js
+++ b/test/unit/init/applyAnswers-test.js
@@ -38,9 +38,9 @@ describe('init._applyAnswers()', () => {
     const config = applyAnswers(createConfig(), { language: 'python' });
     assert.equal(config.language, 'python');
   });
-  it('sets the language when not prompted', () => {
-    const config = applyAnswers(createConfig({ language: 'python' }), {});
-    assert.equal(config.language, 'python');
+  it('uses default language (nodejs) when none is prompted', () => {
+    const config = applyAnswers(createConfig(), { language: undefined });
+    assert.equal(config.language, 'nodejs');
   });
   it('sets no reporter by default', () => {
     const config = applyAnswers(createConfig(), {});

--- a/test/unit/init/applyAnswers-test.js
+++ b/test/unit/init/applyAnswers-test.js
@@ -38,6 +38,10 @@ describe('init._applyAnswers()', () => {
     const config = applyAnswers(createConfig(), { language: 'python' });
     assert.equal(config.language, 'python');
   });
+  it('sets the language when not prompted', () => {
+    const config = applyAnswers(createConfig({ language: 'python' }), {});
+    assert.equal(config.language, 'python');
+  });
   it('sets no reporter by default', () => {
     const config = applyAnswers(createConfig(), {});
     assert.isUndefined(config.reporter);


### PR DESCRIPTION
#### :rocket: Why this change?

Aims to set a proper value for the `language` key in the generated `dredd.yml` after running the following command:

```bash
dredd init
```

Please refer to the mentioned GitHub issue for the reproduction steps.

#### :memo: Related issues and Pull Requests

- Fixes #1239 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs (not applicable? I assume current docs cover the use case)
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
