### PR TITLE
fix(documentation): invalid struct field in go hooks example

### DIFF
--- a/docs/hooks/go.rst
+++ b/docs/hooks/go.rst
@@ -214,7 +214,7 @@ Modifying the Request Body Prior to Execution
            body["someKey"] = "new value"
 
            newBody, _ := json.Marshal(body)
-           t.Request.body = string(newBody)
+           t.Request.Body = string(newBody)
        })
        server.Serve()
        defer server.Listener.Close()


### PR DESCRIPTION
#### :rocket: Why this change?

#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
