### PR TITLE
Use the same code for resolving globs in paths

### DIFF
--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -1,6 +1,5 @@
 const async = require('async');
 const clone = require('clone');
-const glob = require('glob');
 const fs = require('fs');
 const path = require('path');
 const request = require('request');
@@ -10,6 +9,7 @@ const compile = require('dredd-transactions/compile');
 
 const configureReporters = require('./configureReporters');
 const handleRuntimeProblems = require('./handleRuntimeProblems');
+const resolveHookfiles = require('./resolveHookfiles');
 const logger = require('./logger');
 const Runner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
@@ -22,6 +22,11 @@ const FILE_DOWNLOAD_TIMEOUT = 5000;
 
 function unique(array) {
   return Array.from(new Set(array));
+}
+
+
+function isURL(string) {
+  return /^http(s)?:\/\//.test(string);
 }
 
 
@@ -122,41 +127,23 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
   }
 
   // Expand all globs
-  // TODO use the same mechanism as in 'resolveHookfiles', this is unnecessary,
-  // duplicate work
   expandGlobs(callback) {
-    async.each(this.configuration.options.path, (globToExpand, globCallback) => {
-      if (/^http(s)?:\/\//.test(globToExpand)) {
-        this.files = this.files.concat(globToExpand);
-        return globCallback();
+    process.nextTick(() => {
+      const cwd = (this.configuration.custom && this.configuration.custom.cwd)
+        || process.cwd();
+
+      const paths = this.configuration.options.path;
+      const { urls, files } = paths.reduce((arrays, p) => {
+        arrays[isURL(p) ? 'urls' : 'files'].push(p);
+        return arrays;
+      }, { urls: [], files: [] });
+
+      try {
+        this.files = unique(urls.concat(resolveHookfiles(cwd, files)));
+      } catch (err) {
+        callback(err, this.stats);
+        return;
       }
-
-      glob(globToExpand, (err, match) => {
-        if (err) { return globCallback(err); }
-        this.files = this.files.concat(match);
-        if (match.length === 0) {
-          err = new Error(`
-            API description document(s) not found on path:
-            '${globToExpand}'
-         `);
-          return globCallback(err);
-        }
-        globCallback();
-      });
-    },
-    (err) => {
-      if (err) { return callback(err, this.stats); }
-
-      if (this.configuration.apiDescriptions.length === 0 && this.files.length === 0) {
-        err = new Error(`
-API description document (or documents) not found on path:
-'${this.configuration.options.path}'
-`);
-        return callback(err, this.stats);
-      }
-
-      // Remove duplicate filenames
-      this.files = unique(this.files);
       callback(null, this.stats);
     });
   }

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -129,10 +129,9 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
   // Expand all globs
   expandGlobs(callback) {
     process.nextTick(() => {
-      const cwd = (this.configuration.custom && this.configuration.custom.cwd)
-        || process.cwd();
-
+      const cwd = this.configuration.custom.cwd;
       const paths = this.configuration.options.path;
+
       const { urls, files } = paths.reduce((arrays, p) => {
         arrays[isURL(p) ? 'urls' : 'files'].push(p);
         return arrays;

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -9,7 +9,7 @@ const compile = require('dredd-transactions/compile');
 
 const configureReporters = require('./configureReporters');
 const handleRuntimeProblems = require('./handleRuntimeProblems');
-const resolvePaths = require('./resolvePaths');
+const resolveLocations = require('./resolveLocations');
 const logger = require('./logger');
 const Runner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
@@ -18,16 +18,6 @@ const options = require('./options.json');
 
 const PROXY_ENV_VARIABLES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 const FILE_DOWNLOAD_TIMEOUT = 5000;
-
-
-function unique(array) {
-  return Array.from(new Set(array));
-}
-
-
-function isURL(string) {
-  return /^http(s)?:\/\//.test(string);
-}
 
 
 class Dredd {
@@ -79,7 +69,7 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
   }
 
   run(callback) {
-    // Take care of --require
+    this.logger.debug('Resolving --require');
     if (this.configuration.options.require) {
       let mod = this.configuration.options.require;
       const abs = fs.existsSync(mod) || fs.existsSync(`${mod}.js`);
@@ -96,54 +86,36 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
       }
     }
 
+    this.logger.debug('Resolving API descriptions locations');
+    try {
+      this.files = resolveLocations(this.configuration.custom.cwd, this.configuration.options.path);
+    } catch (err) {
+      callback(err, this.stats);
+      return;
+    }
+
     // Spin that merry-go-round
-    this.logger.debug('Expanding glob patterns.');
-    this.expandGlobs((globsErr) => {
-      if (globsErr) { return callback(globsErr, this.stats); }
+    this.logger.debug('Reading API description files.');
+    this.loadFiles((loadErr) => {
+      if (loadErr) { return callback(loadErr, this.stats); }
 
-      this.logger.debug('Reading API description files.');
-      this.loadFiles((loadErr) => {
-        if (loadErr) { return callback(loadErr, this.stats); }
+      this.logger.debug('Parsing API description files and compiling a list of HTTP transactions to test.');
+      this.compileTransactions((compileErr) => {
+        if (compileErr) { return callback(compileErr, this.stats); }
 
-        this.logger.debug('Parsing API description files and compiling a list of HTTP transactions to test.');
-        this.compileTransactions((compileErr) => {
-          if (compileErr) { return callback(compileErr, this.stats); }
+        this.logger.debug('Starting reporters and waiting until all of them are ready.');
+        this.emitStart((emitStartErr) => {
+          if (emitStartErr) { return callback(emitStartErr, this.stats); }
 
-          this.logger.debug('Starting reporters and waiting until all of them are ready.');
-          this.emitStart((emitStartErr) => {
-            if (emitStartErr) { return callback(emitStartErr, this.stats); }
+          this.logger.debug('Starting transaction runner.');
+          this.startRunner((runnerErr) => {
+            if (runnerErr) { return callback(runnerErr, this.stats); }
 
-            this.logger.debug('Starting transaction runner.');
-            this.startRunner((runnerErr) => {
-              if (runnerErr) { return callback(runnerErr, this.stats); }
-
-              this.logger.debug('Wrapping up testing.');
-              this.transactionsComplete(callback);
-            });
+            this.logger.debug('Wrapping up testing.');
+            this.transactionsComplete(callback);
           });
         });
       });
-    });
-  }
-
-  // Expand all globs
-  expandGlobs(callback) {
-    process.nextTick(() => {
-      const cwd = this.configuration.custom.cwd;
-      const paths = this.configuration.options.path;
-
-      const { urls, files } = paths.reduce((arrays, p) => {
-        arrays[isURL(p) ? 'urls' : 'files'].push(p);
-        return arrays;
-      }, { urls: [], files: [] });
-
-      try {
-        this.files = unique(urls.concat(resolvePaths(cwd, files)));
-      } catch (err) {
-        callback(err, this.stats);
-        return;
-      }
-      callback(null, this.stats);
     });
   }
 

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -9,7 +9,7 @@ const compile = require('dredd-transactions/compile');
 
 const configureReporters = require('./configureReporters');
 const handleRuntimeProblems = require('./handleRuntimeProblems');
-const resolveHookfiles = require('./resolveHookfiles');
+const resolvePaths = require('./resolvePaths');
 const logger = require('./logger');
 const Runner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
@@ -139,7 +139,7 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
       }, { urls: [], files: [] });
 
       try {
-        this.files = unique(urls.concat(resolveHookfiles(cwd, files)));
+        this.files = unique(urls.concat(resolvePaths(cwd, files)));
       } catch (err) {
         callback(err, this.stats);
         return;

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -45,7 +45,7 @@ class Dredd {
       end: 0,
       duration: 0,
     };
-    this.configuration.files = [];
+    this.files = [];
     this.transactions = [];
     this.runner = new Runner(this.configuration);
     this.logger = logger;
@@ -127,13 +127,13 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
   expandGlobs(callback) {
     async.each(this.configuration.options.path, (globToExpand, globCallback) => {
       if (/^http(s)?:\/\//.test(globToExpand)) {
-        this.configuration.files = this.configuration.files.concat(globToExpand);
+        this.files = this.files.concat(globToExpand);
         return globCallback();
       }
 
       glob(globToExpand, (err, match) => {
         if (err) { return globCallback(err); }
-        this.configuration.files = this.configuration.files.concat(match);
+        this.files = this.files.concat(match);
         if (match.length === 0) {
           err = new Error(`
             API description document(s) not found on path:
@@ -147,7 +147,7 @@ https://dredd.org/en/latest/how-it-works/#using-https-proxy
     (err) => {
       if (err) { return callback(err, this.stats); }
 
-      if (this.configuration.apiDescriptions.length === 0 && this.configuration.files.length === 0) {
+      if (this.configuration.apiDescriptions.length === 0 && this.files.length === 0) {
         err = new Error(`
 API description document (or documents) not found on path:
 '${this.configuration.options.path}'
@@ -156,7 +156,7 @@ API description document (or documents) not found on path:
       }
 
       // Remove duplicate filenames
-      this.configuration.files = unique(this.configuration.files);
+      this.files = unique(this.files);
       callback(null, this.stats);
     });
   }
@@ -165,7 +165,7 @@ API description document (or documents) not found on path:
   loadFiles(callback) {
     // 6 parallel connections is a standard limit when connecting to one hostname,
     // use the same limit of parallel connections for reading/downloading files
-    async.eachLimit(this.configuration.files, 6, (fileUrlOrPath, loadCallback) => {
+    async.eachLimit(this.files, 6, (fileUrlOrPath, loadCallback) => {
       const { protocol, host } = url.parse(fileUrlOrPath);
       if (host && ['http:', 'https:'].includes(protocol)) {
         this.logger.debug('Downloading remote file:', fileUrlOrPath);

--- a/lib/HooksWorkerClient.js
+++ b/lib/HooksWorkerClient.js
@@ -180,7 +180,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
   }
 
   spawnHandler(callback) {
-    const pathGlobs = [].concat(this.runner.hooks.configuration.options.hookfiles);
+    const pathGlobs = this.runner.hooks.configuration.options.hookfiles;
     const handlerCommandArgs = this.handlerCommandArgs.concat(pathGlobs);
 
     logger.debug(`Spawning '${this.language}' hooks handler process.`);

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -5,7 +5,7 @@ const Hooks = require('./Hooks');
 const HooksWorkerClient = require('./HooksWorkerClient');
 const logger = require('./logger');
 const reporterOutputLogger = require('./reporters/reporterOutputLogger');
-const resolveHookfiles = require('./resolveHookfiles');
+const resolvePaths = require('./resolvePaths');
 
 // Note: runner.configuration.options must be defined
 function addHooks(runner, transactions, callback) {
@@ -39,7 +39,7 @@ Stack: ${error.stack}
     || process.cwd();
   let files;
   try {
-    files = resolveHookfiles(cwd, hookfiles);
+    files = resolvePaths(cwd, hookfiles);
   } catch (err) {
     return callback(err);
   }

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -35,9 +35,8 @@ Stack: ${error.stack}
 
   // Loading hookfiles from fs
   const hookfiles = [].concat(runner.configuration.options.hookfiles || []);
-  const cwd = runner.configuration.custom
-    ? runner.configuration.custom.cwd
-    : process.cwd();
+  const cwd = (runner.configuration.custom && runner.configuration.custom.cwd)
+    || process.cwd();
   let files;
   try {
     files = resolveHookfiles(cwd, hookfiles);

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -34,9 +34,9 @@ Stack: ${error.stack}
   });
 
   // Loading hookfiles from fs
-  const hookfiles = [].concat(runner.configuration.options.hookfiles || []);
-  const cwd = (runner.configuration.custom && runner.configuration.custom.cwd)
-    || process.cwd();
+  const hookfiles = runner.configuration.options.hookfiles;
+  const cwd = runner.configuration.custom.cwd;
+
   let files;
   try {
     files = resolvePaths(cwd, hookfiles);

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -35,10 +35,12 @@ Stack: ${error.stack}
 
   // Loading hookfiles from fs
   const hookfiles = [].concat(runner.configuration.options.hookfiles || []);
-  const cwd = runner.configuration.custom ? runner.configuration.custom.cwd : null;
+  const cwd = runner.configuration.custom
+    ? runner.configuration.custom.cwd
+    : process.cwd();
   let files;
   try {
-    files = resolveHookfiles(hookfiles, cwd);
+    files = resolveHookfiles(cwd, hookfiles);
   } catch (err) {
     return callback(err);
   }

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -24,12 +24,10 @@ function loadHookFile(hookfile, hooks) {
   try {
     proxyquire(hookfile, { hooks });
   } catch (error) {
-    logger.warn(`
-Skipping hook loading. Error reading hook file '${hookfile}'.
-This probably means one or more of your hook files are invalid.
-Message: ${error.message}
-Stack: ${error.stack}
-`);
+    logger.warn(`Skipping hook loading. Error reading hook file '${hookfile}'. `
+      + 'This probably means one or more of your hook files are invalid.\n'
+      + `Message: ${error.message}\n`
+      + `Stack: \n${error.stack}\n`);
   }
 }
 

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -7,23 +7,35 @@ const logger = require('./logger');
 const reporterOutputLogger = require('./reporters/reporterOutputLogger');
 const resolvePaths = require('./resolvePaths');
 
-// Note: runner.configuration.options must be defined
-function addHooks(runner, transactions, callback) {
-  function loadHookFile(filePath) {
-    try {
-      proxyquire(filePath, {
-        hooks: runner.hooks,
-      });
-    } catch (error) {
-      logger.warn(`
-Skipping hook loading. Error reading hook file '${filePath}'.
+
+// The 'addHooks()' function is a strange glue code responsible for various
+// side effects needed as a preparation for loading Node.js hooks. It is
+// asynchronous only because as the last thing, it spawns the hooks handler
+// process if it figures out the hooks are not JavaScript hooks.
+//
+// In the future we should get rid of this code. Hooks should get a nice,
+// separate logical component, which takes care of their loading and running
+// regardless the language used, and either delegates to the hooks handler
+// or not. Side effects should get eliminated as much as possible in favor
+// of decoupling.
+
+
+function loadHookFile(hookfile, hooks) {
+  try {
+    proxyquire(hookfile, { hooks });
+  } catch (error) {
+    logger.warn(`
+Skipping hook loading. Error reading hook file '${hookfile}'.
 This probably means one or more of your hook files are invalid.
 Message: ${error.message}
 Stack: ${error.stack}
 `);
-    }
   }
+}
 
+
+// Note: runner.configuration.options must be defined
+module.exports = function addHooks(runner, transactions, callback) {
   if (!runner.logs) { runner.logs = []; }
   runner.hooks = new Hooks({ logs: runner.logs, logger: reporterOutputLogger });
 
@@ -34,40 +46,32 @@ Stack: ${error.stack}
   });
 
   // Loading hookfiles from fs
-  const hookfiles = runner.configuration.options.hookfiles;
-  const cwd = runner.configuration.custom.cwd;
-
-  let files;
+  let hookfiles;
   try {
-    files = resolvePaths(cwd, hookfiles);
+    hookfiles = resolvePaths(runner.configuration.custom.cwd, runner.configuration.options.hookfiles);
   } catch (err) {
     return callback(err);
   }
-  logger.debug('Found Hookfiles:', files);
+  logger.debug('Found Hookfiles:', hookfiles);
+
+  // Override hookfiles option in configuration object with
+  // sorted and resolved files
+  runner.configuration.options.hookfiles = hookfiles;
 
   // Clone the configuration object to hooks.configuration to make it
   // accessible in the node.js hooks API
   runner.hooks.configuration = clone(runner.configuration);
 
-  // Override hookfiles option in configuration object with
-  // sorted and resolved files
-  runner.hooks.configuration.options.hookfiles = files;
-
   // If the language is empty or it is nodejs
-  if (!runner.configuration.options.language
-          || runner.configuration.options.language === 'nodejs') {
-    // Load regular files from fs
-    for (const file of files) {
-      loadHookFile(file);
-    }
-
+  if (
+    !runner.configuration.options.language
+    || runner.configuration.options.language === 'nodejs'
+  ) {
+    hookfiles.forEach(hookfile => loadHookFile(hookfile, runner.hooks));
     return callback();
   }
 
   // If other language than nodejs, run hooks worker client
   // Worker client will start the worker server and pass the "hookfiles" options as CLI arguments to it
   return (new HooksWorkerClient(runner)).start(callback);
-}
-
-
-module.exports = addHooks;
+};

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -21,11 +21,6 @@ function coerceToBoolean(value) {
 }
 
 
-function unique(array) {
-  return Array.from(new Set(array));
-}
-
-
 function applyLoggingOptions(options) {
   if (options.color === false) {
     logger.transports.console.colorize = false;
@@ -161,9 +156,8 @@ function applyConfiguration(inConfig) {
   const outConfig = {
     server: null,
     emitter: new EventEmitter(),
-    custom: { // Used for custom settings of various APIs or reporters
-      // Keep commented-out, so these values are actually set by CLI
-      // cwd: process.cwd()
+    custom: {
+      cwd: process.cwd(),
     },
     apiDescriptions: [],
     options: {
@@ -180,7 +174,7 @@ function applyConfiguration(inConfig) {
       loglevel: 'warning',
       sorted: false,
       names: false,
-      hookfiles: null,
+      hookfiles: [],
       language: 'nodejs',
       'hooks-worker-timeout': 5000,
       'hooks-worker-connect-timeout': 1500,
@@ -222,7 +216,8 @@ function applyConfiguration(inConfig) {
   outConfig.options.header = coerceToArray(outConfig.options.header);
   outConfig.options.method = coerceToArray(outConfig.options.method);
   outConfig.options.only = coerceToArray(outConfig.options.only);
-  outConfig.options.path = unique(coerceToArray(outConfig.options.path));
+  outConfig.options.path = coerceToArray(outConfig.options.path);
+  outConfig.options.hookfiles = coerceToArray(outConfig.options.hookfiles);
 
   outConfig.options.method = outConfig.options.method
     .map(method => method.toUpperCase());

--- a/lib/resolveHookfiles.js
+++ b/lib/resolveHookfiles.js
@@ -2,31 +2,40 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 
-// Ensure platform agnostic path.basename function
+
+// Ensure platform-agnostic 'path.basename' function
 const basename = process.platform === 'win32' ? path.win32.basename : path.basename;
 
-// Expand hookfiles - sort files alphabetically and resolve their paths
-module.exports = function resolveHookfiles(hookfiles, cwd = null) {
+
+function resolveGlob(pattern, workingDirectory = null) {
+  const cwd = workingDirectory || process.cwd();
+
+  // 'glob.sync()' does not resolve paths, only glob patterns
+  if (glob.hasMagic(pattern)) {
+    return glob.sync(pattern, { cwd })
+      .map(matchingPath => path.resolve(cwd, matchingPath));
+  }
+  const resolvedPath = path.resolve(cwd, pattern);
+  return fs.existsSync(resolvedPath) ? [resolvedPath] : [];
+}
+
+
+/**
+ * Resolve paths to hookfiles
+ *
+ * Resolves glob patterns and sorts the files alphabetically by their basename.
+ * Throws in case there's a pattern which doesn't resolve to any existing files.
+ */
+module.exports = function resolveHookfiles(hookfiles, workingDirectory = null) {
   if (!hookfiles || !hookfiles.length) { return []; }
-
-  cwd = cwd || process.cwd();
-
-  return hookfiles.map((hookfile) => {
-    // glob.sync does not resolve paths, only glob patterns
-    let resolvedPaths;
-    if (glob.hasMagic(hookfile)) {
-      resolvedPaths = glob.sync(hookfile, { cwd }).map(p => path.resolve(cwd, p));
-    } else {
-      const resolvedPath = path.resolve(cwd, hookfile);
-      resolvedPaths = fs.existsSync(resolvedPath) ? [resolvedPath] : [];
-    }
-
-    if (!resolvedPaths.length) {
-      throw new Error(`Could not find any hook file(s) on path: '${hookfile}'`);
-    }
-
-    return resolvedPaths;
-  })
+  return hookfiles
+    .map((hookfile) => {
+      const resolvedPaths = resolveGlob(hookfile, workingDirectory);
+      if (resolvedPaths.length < 1) {
+        throw new Error(`Could not find any hook files on path: '${hookfile}'`);
+      }
+      return resolvedPaths;
+    })
     .reduce((flatResolvedPaths, resolvedPaths) => flatResolvedPaths.concat(resolvedPaths), [])
     .sort((p1, p2) => {
       const [basename1, basename2] = [basename(p1), basename(p2)];

--- a/lib/resolveHookfiles.js
+++ b/lib/resolveHookfiles.js
@@ -7,9 +7,7 @@ const glob = require('glob');
 const basename = process.platform === 'win32' ? path.win32.basename : path.basename;
 
 
-function resolveGlob(pattern, workingDirectory = null) {
-  const cwd = workingDirectory || process.cwd();
-
+function resolveGlob(cwd, pattern) {
   // 'glob.sync()' does not resolve paths, only glob patterns
   if (glob.hasMagic(pattern)) {
     return glob.sync(pattern, { cwd })
@@ -26,11 +24,11 @@ function resolveGlob(pattern, workingDirectory = null) {
  * Resolves glob patterns and sorts the files alphabetically by their basename.
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  */
-module.exports = function resolveHookfiles(hookfiles, workingDirectory = null) {
+module.exports = function resolveHookfiles(cwd, hookfiles) {
   if (!hookfiles || !hookfiles.length) { return []; }
   return hookfiles
     .map((hookfile) => {
-      const resolvedPaths = resolveGlob(hookfile, workingDirectory);
+      const resolvedPaths = resolveGlob(cwd, hookfile);
       if (resolvedPaths.length < 1) {
         throw new Error(`Could not find any hook files on path: '${hookfile}'`);
       }

--- a/lib/resolveLocations.js
+++ b/lib/resolveLocations.js
@@ -1,0 +1,24 @@
+const resolvePaths = require('./resolvePaths');
+
+
+function isURL(string) {
+  return /^http(s)?:\/\//.test(string);
+}
+
+
+/**
+ * Resolve locations to API description documents
+ *
+ * Resolves glob patterns and sorts the files alphabetically by their basename.
+ * Throws in case there's a pattern which doesn't resolve to any existing files.
+ * Keeps URLs as they are.
+ */
+module.exports = function resolveLocations(cwd, locations) {
+  const { urls, paths } = locations.reduce((arrays, location) => {
+    arrays[isURL(location) ? 'urls' : 'paths'].push(location);
+    return arrays;
+  }, { urls: [], paths: [] });
+
+  const resolvedLocations = urls.concat(resolvePaths(cwd, paths));
+  return Array.from(new Set(resolvedLocations)); // keep only unique items
+};

--- a/lib/resolveLocations.js
+++ b/lib/resolveLocations.js
@@ -13,12 +13,12 @@ function isURL(string) {
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  * Keeps URLs as they are.
  */
-module.exports = function resolveLocations(cwd, locations) {
+module.exports = function resolveLocations(workingDirectory, locations) {
   const { urls, paths } = locations.reduce((arrays, location) => {
     arrays[isURL(location) ? 'urls' : 'paths'].push(location);
     return arrays;
   }, { urls: [], paths: [] });
 
-  const resolvedLocations = urls.concat(resolvePaths(cwd, paths));
+  const resolvedLocations = urls.concat(resolvePaths(workingDirectory, paths));
   return Array.from(new Set(resolvedLocations)); // keep only unique items
 };

--- a/lib/resolvePaths.js
+++ b/lib/resolvePaths.js
@@ -19,18 +19,18 @@ function resolveGlob(cwd, pattern) {
 
 
 /**
- * Resolve paths to hookfiles
+ * Resolve paths to files
  *
  * Resolves glob patterns and sorts the files alphabetically by their basename.
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  */
-module.exports = function resolveHookfiles(cwd, hookfiles) {
-  if (!hookfiles || !hookfiles.length) { return []; }
-  return hookfiles
-    .map((hookfile) => {
-      const resolvedPaths = resolveGlob(cwd, hookfile);
+module.exports = function resolvePaths(cwd, paths) {
+  if (!paths || !paths.length) { return []; }
+  return paths
+    .map((pattern) => {
+      const resolvedPaths = resolveGlob(cwd, pattern);
       if (resolvedPaths.length < 1) {
-        throw new Error(`Could not find any hook files on path: '${hookfile}'`);
+        throw new Error(`Could not find any files on path: '${pattern}'`);
       }
       return resolvedPaths;
     })

--- a/lib/resolvePaths.js
+++ b/lib/resolvePaths.js
@@ -24,21 +24,24 @@ function resolveGlob(cwd, pattern) {
  * Resolves glob patterns and sorts the files alphabetically by their basename.
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  */
-module.exports = function resolvePaths(cwd, paths) {
-  if (!paths || !paths.length) { return []; }
-  return paths
+module.exports = function resolvePaths(cwd, patterns) {
+  if (!patterns || patterns.length < 1) { return []; }
+
+  const resolvedPaths = patterns
     .map((pattern) => {
-      const resolvedPaths = resolveGlob(cwd, pattern);
-      if (resolvedPaths.length < 1) {
+      const paths = resolveGlob(cwd, pattern);
+      if (paths.length < 1) {
         throw new Error(`Could not find any files on path: '${pattern}'`);
       }
-      return resolvedPaths;
+      return paths;
     })
-    .reduce((flatResolvedPaths, resolvedPaths) => flatResolvedPaths.concat(resolvedPaths), [])
+    .reduce((flatPaths, paths) => flatPaths.concat(paths), [])
     .sort((p1, p2) => {
       const [basename1, basename2] = [basename(p1), basename(p2)];
       if (basename1 < basename2) return -1;
       if (basename1 > basename2) return 1;
       return 0;
     });
+
+  return Array.from(new Set(resolvedPaths)); // keep only unique items
 };

--- a/lib/resolvePaths.js
+++ b/lib/resolvePaths.js
@@ -7,13 +7,13 @@ const glob = require('glob');
 const basename = process.platform === 'win32' ? path.win32.basename : path.basename;
 
 
-function resolveGlob(cwd, pattern) {
+function resolveGlob(workingDirectory, pattern) {
   // 'glob.sync()' does not resolve paths, only glob patterns
   if (glob.hasMagic(pattern)) {
-    return glob.sync(pattern, { cwd })
-      .map(matchingPath => path.resolve(cwd, matchingPath));
+    return glob.sync(pattern, { cwd: workingDirectory })
+      .map(matchingPath => path.resolve(workingDirectory, matchingPath));
   }
-  const resolvedPath = path.resolve(cwd, pattern);
+  const resolvedPath = path.resolve(workingDirectory, pattern);
   return fs.existsSync(resolvedPath) ? [resolvedPath] : [];
 }
 
@@ -24,12 +24,12 @@ function resolveGlob(cwd, pattern) {
  * Resolves glob patterns and sorts the files alphabetically by their basename.
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  */
-module.exports = function resolvePaths(cwd, patterns) {
+module.exports = function resolvePaths(workingDirectory, patterns) {
   if (!patterns || patterns.length < 1) { return []; }
 
   const resolvedPaths = patterns
     .map((pattern) => {
-      const paths = resolveGlob(cwd, pattern);
+      const paths = resolveGlob(workingDirectory, pattern);
       if (paths.length < 1) {
         throw new Error(`Could not find any files on path: '${pattern}'`);
       }

--- a/test/integration/cli/api-description-cli-test.js
+++ b/test/integration/cli/api-description-cli-test.js
@@ -42,7 +42,7 @@ describe('CLI - API Description Document', () => {
       });
 
       it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr, 'not found'));
+      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr.toLowerCase(), 'could not find'));
     });
 
     describe('when given path exists, but can\'t be read', () => {
@@ -265,7 +265,7 @@ describe('CLI - API Description Document', () => {
 
       it('should not request server', () => assert.isFalse(runtimeInfo.server.requested));
       it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr, 'not found'));
+      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr.toLowerCase(), 'could not find'));
     });
   });
 });

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -4,6 +4,7 @@ const fsStub = require('fs');
 const proxyquire = require('proxyquire').noCallThru();
 const requestStub = require('request');
 const sinon = require('sinon');
+const path = require('path');
 const { assert } = require('chai');
 const parse = require('dredd-transactions/parse');
 const compile = require('dredd-transactions/compile');
@@ -64,7 +65,7 @@ describe('Dredd class', () => {
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
       dredd.run(() => {
-        assert.isOk(fsStub.readFile.calledWith(`${CWD}/test/fixtures/apiary.apib`));
+        assert.isOk(fsStub.readFile.calledWith(path.join(CWD, '/test/fixtures/apiary.apib')));
         dredd.runner.executeTransaction.restore();
         done();
       });
@@ -120,9 +121,9 @@ describe('Dredd class', () => {
         if (error) { return done(error); }
         assert.lengthOf(dredd.files, 3);
         assert.deepEqual(dredd.files, [
-          `${CWD}/test/fixtures/multifile/greeting.apib`,
-          `${CWD}/test/fixtures/multifile/message.apib`,
-          `${CWD}/test/fixtures/multifile/name.apib`,
+          path.join(CWD, '/test/fixtures/multifile/greeting.apib'),
+          path.join(CWD, '/test/fixtures/multifile/message.apib'),
+          path.join(CWD, '/test/fixtures/multifile/name.apib'),
         ]);
         done();
       }));
@@ -139,15 +140,15 @@ describe('Dredd class', () => {
         dredd.configuration.apiDescriptions.sort(compareLocation);
 
         assert.isObject(dredd.configuration.apiDescriptions[0]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', `${CWD}/test/fixtures/multifile/greeting.apib`);
+        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(CWD, '/test/fixtures/multifile/greeting.apib'));
         assert.property(dredd.configuration.apiDescriptions[0], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[1]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', `${CWD}/test/fixtures/multifile/message.apib`);
+        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(CWD, '/test/fixtures/multifile/message.apib'));
         assert.property(dredd.configuration.apiDescriptions[1], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[2]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/multifile/name.apib`);
+        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/multifile/name.apib'));
         assert.property(dredd.configuration.apiDescriptions[2], 'content');
         done();
       }));
@@ -296,7 +297,7 @@ GET /url
           assert.property(localdredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(localdredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/apiary.apib`);
+          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/apiary.apib'));
           assert.property(localdredd.configuration.apiDescriptions[2], 'content');
           assert.property(localdredd.configuration.apiDescriptions[2], 'annotations');
           done();
@@ -339,9 +340,9 @@ GET /url
           assert.deepEqual(dredd.files, [
             'http://some.path.to/file.apib',
             'https://another.path.to/apiary.apib',
-            `${CWD}/test/fixtures/multifile/greeting.apib`,
-            `${CWD}/test/fixtures/multifile/message.apib`,
-            `${CWD}/test/fixtures/multifile/name.apib`,
+            path.join(CWD, '/test/fixtures/multifile/greeting.apib'),
+            path.join(CWD, '/test/fixtures/multifile/message.apib'),
+            path.join(CWD, '/test/fixtures/multifile/name.apib'),
           ]);
           done();
         }));
@@ -354,22 +355,21 @@ GET /url
 
         it('should load file contents on paths to config and parse these files', done => dredd.run((error) => {
           if (error) { return done(error); }
-
           assert.lengthOf(dredd.configuration.apiDescriptions, 5);
           dredd.configuration.apiDescriptions.sort(compareLocation);
 
           assert.isObject(dredd.configuration.apiDescriptions[0]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', `${CWD}/test/fixtures/multifile/greeting.apib`);
+          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(CWD, '/test/fixtures/multifile/greeting.apib'));
           assert.property(dredd.configuration.apiDescriptions[0], 'content');
           assert.property(dredd.configuration.apiDescriptions[0], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[1]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', `${CWD}/test/fixtures/multifile/message.apib`);
+          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(CWD, '/test/fixtures/multifile/message.apib'));
           assert.property(dredd.configuration.apiDescriptions[1], 'content');
           assert.property(dredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/multifile/name.apib`);
+          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/multifile/name.apib'));
           assert.property(dredd.configuration.apiDescriptions[2], 'content');
           assert.property(dredd.configuration.apiDescriptions[2], 'annotations');
 

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -23,9 +23,6 @@ const Dredd = proxyquire('../../lib/Dredd', {
 });
 
 
-const CWD = process.cwd();
-
-
 function compareLocation(ad1, ad2) {
   if (ad1.location < ad2.location) { return -1; }
   if (ad1.location > ad2.location) { return 1; }
@@ -34,6 +31,7 @@ function compareLocation(ad1, ad2) {
 
 
 describe('Dredd class', () => {
+  const workingDirectory = process.cwd();
   let configuration = {};
   let dredd = {};
 
@@ -65,7 +63,7 @@ describe('Dredd class', () => {
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
       dredd.run(() => {
-        assert.isOk(fsStub.readFile.calledWith(path.join(CWD, '/test/fixtures/apiary.apib')));
+        assert.isOk(fsStub.readFile.calledWith(path.join(workingDirectory, '/test/fixtures/apiary.apib')));
         dredd.runner.executeTransaction.restore();
         done();
       });
@@ -121,9 +119,9 @@ describe('Dredd class', () => {
         if (error) { return done(error); }
         assert.lengthOf(dredd.files, 3);
         assert.deepEqual(dredd.files, [
-          path.join(CWD, '/test/fixtures/multifile/greeting.apib'),
-          path.join(CWD, '/test/fixtures/multifile/message.apib'),
-          path.join(CWD, '/test/fixtures/multifile/name.apib'),
+          path.join(workingDirectory, '/test/fixtures/multifile/greeting.apib'),
+          path.join(workingDirectory, '/test/fixtures/multifile/message.apib'),
+          path.join(workingDirectory, '/test/fixtures/multifile/name.apib'),
         ]);
         done();
       }));
@@ -140,15 +138,15 @@ describe('Dredd class', () => {
         dredd.configuration.apiDescriptions.sort(compareLocation);
 
         assert.isObject(dredd.configuration.apiDescriptions[0]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(CWD, '/test/fixtures/multifile/greeting.apib'));
+        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(workingDirectory, '/test/fixtures/multifile/greeting.apib'));
         assert.property(dredd.configuration.apiDescriptions[0], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[1]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(CWD, '/test/fixtures/multifile/message.apib'));
+        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(workingDirectory, '/test/fixtures/multifile/message.apib'));
         assert.property(dredd.configuration.apiDescriptions[1], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[2]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/multifile/name.apib'));
+        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(workingDirectory, '/test/fixtures/multifile/name.apib'));
         assert.property(dredd.configuration.apiDescriptions[2], 'content');
         done();
       }));
@@ -297,7 +295,7 @@ GET /url
           assert.property(localdredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(localdredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/apiary.apib'));
+          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', path.join(workingDirectory, '/test/fixtures/apiary.apib'));
           assert.property(localdredd.configuration.apiDescriptions[2], 'content');
           assert.property(localdredd.configuration.apiDescriptions[2], 'annotations');
           done();
@@ -340,9 +338,9 @@ GET /url
           assert.deepEqual(dredd.files, [
             'http://some.path.to/file.apib',
             'https://another.path.to/apiary.apib',
-            path.join(CWD, '/test/fixtures/multifile/greeting.apib'),
-            path.join(CWD, '/test/fixtures/multifile/message.apib'),
-            path.join(CWD, '/test/fixtures/multifile/name.apib'),
+            path.join(workingDirectory, '/test/fixtures/multifile/greeting.apib'),
+            path.join(workingDirectory, '/test/fixtures/multifile/message.apib'),
+            path.join(workingDirectory, '/test/fixtures/multifile/name.apib'),
           ]);
           done();
         }));
@@ -359,17 +357,17 @@ GET /url
           dredd.configuration.apiDescriptions.sort(compareLocation);
 
           assert.isObject(dredd.configuration.apiDescriptions[0]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(CWD, '/test/fixtures/multifile/greeting.apib'));
+          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', path.join(workingDirectory, '/test/fixtures/multifile/greeting.apib'));
           assert.property(dredd.configuration.apiDescriptions[0], 'content');
           assert.property(dredd.configuration.apiDescriptions[0], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[1]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(CWD, '/test/fixtures/multifile/message.apib'));
+          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', path.join(workingDirectory, '/test/fixtures/multifile/message.apib'));
           assert.property(dredd.configuration.apiDescriptions[1], 'content');
           assert.property(dredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(CWD, '/test/fixtures/multifile/name.apib'));
+          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', path.join(workingDirectory, '/test/fixtures/multifile/name.apib'));
           assert.property(dredd.configuration.apiDescriptions[2], 'content');
           assert.property(dredd.configuration.apiDescriptions[2], 'annotations');
 

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -22,6 +22,9 @@ const Dredd = proxyquire('../../lib/Dredd', {
 });
 
 
+const CWD = process.cwd();
+
+
 function compareLocation(ad1, ad2) {
   if (ad1.location < ad2.location) { return -1; }
   if (ad1.location > ad2.location) { return 1; }
@@ -61,7 +64,7 @@ describe('Dredd class', () => {
       dredd = new Dredd(configuration);
       sinon.stub(dredd.runner, 'executeTransaction').callsFake((transaction, hooks, callback) => callback());
       dredd.run(() => {
-        assert.isOk(fsStub.readFile.calledWith(configuration.options.path[0]));
+        assert.isOk(fsStub.readFile.calledWith(`${CWD}/test/fixtures/apiary.apib`));
         dredd.runner.executeTransaction.restore();
         done();
       });
@@ -117,16 +120,16 @@ describe('Dredd class', () => {
         if (error) { return done(error); }
         assert.lengthOf(dredd.files, 3);
         assert.deepEqual(dredd.files, [
-          './test/fixtures/multifile/greeting.apib',
-          './test/fixtures/multifile/message.apib',
-          './test/fixtures/multifile/name.apib',
+          `${CWD}/test/fixtures/multifile/greeting.apib`,
+          `${CWD}/test/fixtures/multifile/message.apib`,
+          `${CWD}/test/fixtures/multifile/name.apib`,
         ]);
         done();
       }));
 
       it('should remove globs from config', done => dredd.run((error) => {
         if (error) { return done(error); }
-        assert.notInclude(dredd.files, './test/fixtures/multifile/*.apib');
+        assert.notInclude(dredd.files, 'test/fixtures/multifile/*.apib');
         done();
       }));
 
@@ -136,15 +139,15 @@ describe('Dredd class', () => {
         dredd.configuration.apiDescriptions.sort(compareLocation);
 
         assert.isObject(dredd.configuration.apiDescriptions[0]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', './test/fixtures/multifile/greeting.apib');
+        assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', `${CWD}/test/fixtures/multifile/greeting.apib`);
         assert.property(dredd.configuration.apiDescriptions[0], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[1]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', './test/fixtures/multifile/message.apib');
+        assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', `${CWD}/test/fixtures/multifile/message.apib`);
         assert.property(dredd.configuration.apiDescriptions[1], 'content');
 
         assert.isObject(dredd.configuration.apiDescriptions[2]);
-        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', './test/fixtures/multifile/name.apib');
+        assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/multifile/name.apib`);
         assert.property(dredd.configuration.apiDescriptions[2], 'content');
         done();
       }));
@@ -293,7 +296,7 @@ GET /url
           assert.property(localdredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(localdredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', './test/fixtures/apiary.apib');
+          assert.propertyVal(localdredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/apiary.apib`);
           assert.property(localdredd.configuration.apiDescriptions[2], 'content');
           assert.property(localdredd.configuration.apiDescriptions[2], 'annotations');
           done();
@@ -336,16 +339,16 @@ GET /url
           assert.deepEqual(dredd.files, [
             'http://some.path.to/file.apib',
             'https://another.path.to/apiary.apib',
-            './test/fixtures/multifile/greeting.apib',
-            './test/fixtures/multifile/message.apib',
-            './test/fixtures/multifile/name.apib',
+            `${CWD}/test/fixtures/multifile/greeting.apib`,
+            `${CWD}/test/fixtures/multifile/message.apib`,
+            `${CWD}/test/fixtures/multifile/name.apib`,
           ]);
           done();
         }));
 
         it('should remove globs from config', done => dredd.run((error) => {
           if (error) { return done(error); }
-          assert.notInclude(dredd.files, './test/fixtures/multifile/*.apib');
+          assert.notInclude(dredd.files, 'test/fixtures/multifile/*.apib');
           done();
         }));
 
@@ -356,17 +359,17 @@ GET /url
           dredd.configuration.apiDescriptions.sort(compareLocation);
 
           assert.isObject(dredd.configuration.apiDescriptions[0]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', './test/fixtures/multifile/greeting.apib');
+          assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', `${CWD}/test/fixtures/multifile/greeting.apib`);
           assert.property(dredd.configuration.apiDescriptions[0], 'content');
           assert.property(dredd.configuration.apiDescriptions[0], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[1]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', './test/fixtures/multifile/message.apib');
+          assert.propertyVal(dredd.configuration.apiDescriptions[1], 'location', `${CWD}/test/fixtures/multifile/message.apib`);
           assert.property(dredd.configuration.apiDescriptions[1], 'content');
           assert.property(dredd.configuration.apiDescriptions[1], 'annotations');
 
           assert.isObject(dredd.configuration.apiDescriptions[2]);
-          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', './test/fixtures/multifile/name.apib');
+          assert.propertyVal(dredd.configuration.apiDescriptions[2], 'location', `${CWD}/test/fixtures/multifile/name.apib`);
           assert.property(dredd.configuration.apiDescriptions[2], 'content');
           assert.property(dredd.configuration.apiDescriptions[2], 'annotations');
 

--- a/test/unit/Dredd-test.js
+++ b/test/unit/Dredd-test.js
@@ -115,8 +115,8 @@ describe('Dredd class', () => {
 
       it('should expand all glob patterns and resolved paths should be unique', done => dredd.run((error) => {
         if (error) { return done(error); }
-        assert.lengthOf(dredd.configuration.files, 3);
-        assert.deepEqual(dredd.configuration.files, [
+        assert.lengthOf(dredd.files, 3);
+        assert.deepEqual(dredd.files, [
           './test/fixtures/multifile/greeting.apib',
           './test/fixtures/multifile/message.apib',
           './test/fixtures/multifile/name.apib',
@@ -126,7 +126,7 @@ describe('Dredd class', () => {
 
       it('should remove globs from config', done => dredd.run((error) => {
         if (error) { return done(error); }
-        assert.notInclude(dredd.configuration.files, './test/fixtures/multifile/*.apib');
+        assert.notInclude(dredd.files, './test/fixtures/multifile/*.apib');
         done();
       }));
 
@@ -245,7 +245,7 @@ GET /url
 
       it('should not expand any glob patterns', done => dredd.run((error) => {
         if (error) { return done(error); }
-        assert.lengthOf(dredd.configuration.files, 0);
+        assert.lengthOf(dredd.files, 0);
         done();
       }));
 
@@ -279,7 +279,7 @@ GET /url
 
         it('should fill configuration data with data and one file at that path', done => localdredd.run((error) => {
           if (error) { return done(error); }
-          assert.lengthOf(localdredd.configuration.files, 1);
+          assert.lengthOf(localdredd.files, 1);
           assert.lengthOf(localdredd.configuration.apiDescriptions, 3);
 
           assert.isObject(localdredd.configuration.apiDescriptions[0]);
@@ -332,8 +332,8 @@ GET /url
 
         it('should expand glob pattern and resolved paths should be unique', done => dredd.run((error) => {
           if (error) { return done(error); }
-          assert.lengthOf(dredd.configuration.files, 5);
-          assert.deepEqual(dredd.configuration.files, [
+          assert.lengthOf(dredd.files, 5);
+          assert.deepEqual(dredd.files, [
             'http://some.path.to/file.apib',
             'https://another.path.to/apiary.apib',
             './test/fixtures/multifile/greeting.apib',
@@ -345,7 +345,7 @@ GET /url
 
         it('should remove globs from config', done => dredd.run((error) => {
           if (error) { return done(error); }
-          assert.notInclude(dredd.configuration.files, './test/fixtures/multifile/*.apib');
+          assert.notInclude(dredd.files, './test/fixtures/multifile/*.apib');
           done();
         }));
 

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -5,12 +5,13 @@ const Hooks = require('../../lib/Hooks');
 const addHooks = require('../../lib/addHooks');
 
 
-const CWD = path.join(__dirname, '..', 'fixtures');
+const WORKING_DIRECTORY = path.join(__dirname, '..', 'fixtures');
+
 
 function createTransactionRunner() {
   return {
     configuration: {
-      custom: { cwd: CWD },
+      custom: { cwd: WORKING_DIRECTORY },
       options: {},
     },
   };
@@ -50,10 +51,10 @@ describe('addHooks()', () => {
 
     addHooks(transactionRunner, [], (err) => {
       assert.deepEqual(transactionRunner.configuration.options.hookfiles, [
-        path.join(CWD, 'hooks-glob/foo/a.js'),
-        path.join(CWD, 'hooks.js'),
-        path.join(CWD, 'hooks-glob/foo/o.js'),
-        path.join(CWD, 'hooks-glob/foo/y.js'),
+        path.join(WORKING_DIRECTORY, 'hooks-glob/foo/a.js'),
+        path.join(WORKING_DIRECTORY, 'hooks.js'),
+        path.join(WORKING_DIRECTORY, 'hooks-glob/foo/o.js'),
+        path.join(WORKING_DIRECTORY, 'hooks-glob/foo/y.js'),
       ]);
       done(err);
     });

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -1,182 +1,86 @@
-const fsStub = require('fs');
-const globStub = require('glob');
-const sinon = require('sinon');
-const pathStub = require('path');
-const proxyquire = require('proxyquire');
-const proxyquireStub = require('proxyquire');
+const path = require('path');
 const { assert } = require('chai');
 
-const loggerStub = require('../../lib/logger');
-const hooksStub = require('../../lib/Hooks');
-const hooksWorkerClientStub = require('../../lib/HooksWorkerClient');
-
-const proxyquireSpy = sinon.spy(proxyquireStub.noCallThru());
-proxyquireStub.noCallThru = () => proxyquireSpy;
+const Hooks = require('../../lib/Hooks');
+const addHooks = require('../../lib/addHooks');
 
 
-const addHooks = proxyquire('../../lib/addHooks', {
-  logger: loggerStub,
-  glob: globStub,
-  pathStub,
-  hooks: hooksStub,
-  proxyquire: proxyquireStub,
-  './HooksWorkerClient': hooksWorkerClientStub,
-  fs: fsStub,
-});
+const CWD = path.join(__dirname, '..', 'fixtures');
 
-describe('addHooks(runner, transactions, callback)', () => {
-  const transactions = {};
-
-  before(() => { loggerStub.transports.console.silent = true; });
-
-  after(() => { loggerStub.transports.console.silent = false; });
-
-  describe('constructor', () => {
-    const runner = {
-      logs: ['item'],
-      configuration: {
-        options: {
-          hookfiles: [],
-        },
-      },
-    };
-
-    it('should create hooks instance at runner.hooks', done => addHooks(runner, transactions, (err) => {
-      if (err) { return err; }
-      assert.isDefined(runner.hooks);
-      assert.instanceOf(runner.hooks, hooksStub);
-      assert.strictEqual(runner.hooks, runner.hooks);
-      assert.nestedProperty(runner, 'hooks.transactions');
-      done();
-    }));
+function createTransactionRunner() {
+  return {
+    configuration: {
+      custom: { cwd: CWD },
+      options: {},
+    },
+  };
+}
 
 
-    it('should pass runner.logs to runner.hooks.logs', done => addHooks(runner, transactions, (err) => {
-      if (err) { return err; }
-      assert.isDefined(runner.hooks);
-      assert.instanceOf(runner.hooks, hooksStub);
-      assert.nestedProperty(runner, 'hooks.logs');
-      assert.isDefined(runner.hooks.logs);
-      assert.strictEqual(runner.hooks.logs, runner.logs);
-      done();
-    }));
+describe('addHooks()', () => {
+  it('sets transactionRunner.hooks', (done) => {
+    const transactionRunner = createTransactionRunner();
+
+    addHooks(transactionRunner, [], (err) => {
+      assert.instanceOf(transactionRunner.hooks, Hooks);
+      done(err);
+    });
   });
 
+  it('sets transactionRunner.hooks.transactions', (done) => {
+    const transactionRunner = createTransactionRunner();
+    const transaction1 = { name: 'My API > /resource/{id} > GET' };
+    const transaction2 = { name: 'My API > /resources > POST' };
 
-  describe('with no pattern', () => {
-    let runner = null;
-
-    before(() => {
-      runner = {
-        configuration: {
-          options: {
-            hookfiles: null,
-          },
-        },
-      };
-
-      sinon.spy(globStub, 'sync');
-    });
-
-    after(() => globStub.sync.restore());
-
-    it('should not expand any glob', done => addHooks(runner, transactions, () => {
-      assert.isOk(globStub.sync.notCalled);
-      done();
-    }));
-  });
-
-  describe('with non `nodejs` language option', () => {
-    let runner = null;
-
-    before(() => {
-      runner = {
-        configuration: {
-          options: {
-            language: 'ruby',
-            hookfiles: './test/fixtures/non-js-hooks.rb',
-          },
-        },
-      };
-
-      sinon.stub(hooksWorkerClientStub.prototype, 'start').callsFake(cb => cb());
-    });
-
-    after(() => hooksWorkerClientStub.prototype.start.restore());
-
-    it('should start the hooks worker client', done => addHooks(runner, transactions, (err) => {
-      if (err) { return done(err); }
-      assert.isTrue(hooksWorkerClientStub.prototype.start.called);
-      done();
-    }));
-  });
-
-
-  describe('with valid pattern', () => {
-    let runner = null;
-    before(() => {
-      runner = {
-        configuration: {
-          options: {
-            hookfiles: './test/**/*_hooks.*',
-          },
-        },
-      };
-    });
-
-    it('should return files', (done) => {
-      sinon.spy(globStub, 'sync');
-      addHooks(runner, transactions, (err) => {
-        if (err) { return done(err); }
-        assert.isOk(globStub.sync.called);
-        globStub.sync.restore();
-        done();
+    addHooks(transactionRunner, [transaction1, transaction2], (err) => {
+      assert.deepEqual(transactionRunner.hooks.transactions, {
+        'My API > /resource/{id} > GET': transaction1,
+        'My API > /resources > POST': transaction2,
       });
+      done(err);
     });
+  });
 
-    it('should return files with resolved paths', done => addHooks(runner, transactions, (err) => {
-      if (err) { return done(err); }
+  it('sets transactionRunner.configuation.options.hookfiles', (done) => {
+    const transactionRunner = createTransactionRunner();
+    transactionRunner.configuration.options.hookfiles = [
+      './multifile/*.apib',
+      './apiary.apib',
+    ];
 
-      assert.deepEqual(runner.hooks.configuration.options.hookfiles, [
-        pathStub.resolve(process.cwd(), './test/fixtures/multifile/multifile_hooks.coffee'),
-        pathStub.resolve(process.cwd(), './test/fixtures/test2_hooks.js'),
-        pathStub.resolve(process.cwd(), './test/fixtures/test_hooks.coffee'),
+    addHooks(transactionRunner, [], (err) => {
+      assert.deepEqual(transactionRunner.configuration.options.hookfiles, [
+        path.join(CWD, 'apiary.apib'),
+        path.join(CWD, 'multifile/greeting.apib'),
+        path.join(CWD, 'multifile/message.apib'),
+        path.join(CWD, 'multifile/name.apib'),
       ]);
+      done(err);
+    });
+  });
+
+  it('propagates errors when resolving hookfiles is not possible', (done) => {
+    const transactionRunner = createTransactionRunner();
+    transactionRunner.configuration.options.hookfiles = [
+      './__non-existing-directory__/non-existing-file.yml',
+    ];
+
+    addHooks(transactionRunner, [], (err) => {
+      assert.instanceOf(err, Error);
+      assert.match(err.message, /non-existing-file\.yml/);
       done();
-    }));
+    });
+  });
 
-    describe('when files are valid js/coffeescript', () => {
-      runner = null;
-      before(() => {
-        runner = {
-          configuration: {
-            options: {
-              hookfiles: './test/**/*_hooks.*',
-            },
-          },
-        };
-        sinon.stub(globStub, 'sync').callsFake(() => ['file1.js', 'file2.coffee']);
-        sinon.stub(pathStub, 'resolve').callsFake(() => '/Users/netmilk/projects/dredd/file2.coffee');
-      });
+  it('sets transactionRunner.hooks.configuation', (done) => {
+    const transactionRunner = createTransactionRunner();
 
-      after(() => {
-        globStub.sync.restore();
-        pathStub.resolve.restore();
-      });
-
-      it('should load the files', done => addHooks(runner, transactions, (err) => {
-        if (err) { return done(err); }
-        assert.isOk(pathStub.resolve.called);
-        done();
-      }));
-
-      it('should add configuration object to the hooks object proxyquired to the each hookfile', done => addHooks(runner, transactions, (err) => {
-        if (err) { return done(err); }
-        const call = proxyquireSpy.getCall(0);
-        const hooksObject = call.args[1].hooks;
-        assert.property(hooksObject, 'configuration');
-        done();
-      }));
+    addHooks(transactionRunner, [], (err) => {
+      assert.deepEqual(
+        transactionRunner.hooks.configuration,
+        transactionRunner.configuration
+      );
+      done(err);
     });
   });
 });

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -44,16 +44,16 @@ describe('addHooks()', () => {
   it('sets transactionRunner.configuation.options.hookfiles', (done) => {
     const transactionRunner = createTransactionRunner();
     transactionRunner.configuration.options.hookfiles = [
-      './multifile/*.apib',
-      './apiary.apib',
+      './hooks-glob/f*/*.js',
+      './hooks.js',
     ];
 
     addHooks(transactionRunner, [], (err) => {
       assert.deepEqual(transactionRunner.configuration.options.hookfiles, [
-        path.join(CWD, 'apiary.apib'),
-        path.join(CWD, 'multifile/greeting.apib'),
-        path.join(CWD, 'multifile/message.apib'),
-        path.join(CWD, 'multifile/name.apib'),
+        path.join(CWD, 'hooks-glob/foo/a.js'),
+        path.join(CWD, 'hooks.js'),
+        path.join(CWD, 'hooks-glob/foo/o.js'),
+        path.join(CWD, 'hooks-glob/foo/y.js'),
       ]);
       done(err);
     });
@@ -62,12 +62,12 @@ describe('addHooks()', () => {
   it('propagates errors when resolving hookfiles is not possible', (done) => {
     const transactionRunner = createTransactionRunner();
     transactionRunner.configuration.options.hookfiles = [
-      './__non-existing-directory__/non-existing-file.yml',
+      './__non-existing-directory__/non-existing-file.js',
     ];
 
     addHooks(transactionRunner, [], (err) => {
       assert.instanceOf(err, Error);
-      assert.match(err.message, /non-existing-file\.yml/);
+      assert.match(err.message, /non-existing-file\.js/);
       done();
     });
   });

--- a/test/unit/resolveHookfiles-test.js
+++ b/test/unit/resolveHookfiles-test.js
@@ -9,7 +9,7 @@ describe('resolveHookfiles()', () => {
 
   describe('when given no paths', () => {
     it('produces no results', () => {
-      const paths = resolveHookfiles([], cwd);
+      const paths = resolveHookfiles(cwd, []);
       assert.deepEqual(paths, []);
     });
   });
@@ -20,14 +20,14 @@ describe('resolveHookfiles()', () => {
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
       ];
-      const paths = resolveHookfiles(hookfiles, cwd);
+      const paths = resolveHookfiles(cwd, hookfiles);
       assert.deepEqual(paths, hookfiles);
     });
   });
 
   describe('when given existing relative filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(['./hooks.js', './non-js-hooks.rb'], cwd);
+      const paths = resolveHookfiles(cwd, ['./hooks.js', './non-js-hooks.rb']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
@@ -38,14 +38,14 @@ describe('resolveHookfiles()', () => {
   describe('when given non-existing filenames', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolveHookfiles(['./hooks.js', './foo/bar/42'], cwd);
+        resolveHookfiles(cwd, ['./hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
   });
 
   describe('when given glob pattern resolving to existing files', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(['./**/hooks.js'], cwd);
+      const paths = resolveHookfiles(cwd, ['./**/hooks.js']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
       ]);
@@ -55,14 +55,14 @@ describe('resolveHookfiles()', () => {
   describe('when given glob pattern resolving to no files', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolveHookfiles(['./**/hooks.js', './**/foo/bar/foobar.js'], cwd);
+        resolveHookfiles(cwd, ['./**/hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
   });
 
   describe('when given both globs and filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(['./non-js-hooks.rb', './**/hooks.js'], cwd);
+      const paths = resolveHookfiles(cwd, ['./non-js-hooks.rb', './**/hooks.js']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
@@ -71,18 +71,18 @@ describe('resolveHookfiles()', () => {
 
     it('throws an error on non-existing filenams', () => {
       assert.throws(() => {
-        resolveHookfiles(['./**/hooks.js', './foo/bar/42'], cwd);
+        resolveHookfiles(cwd, ['./**/hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
 
     it('throws an error on globs resolving to no files', () => {
       assert.throws(() => {
-        resolveHookfiles(['./hooks.js', './**/foo/bar/foobar.js'], cwd);
+        resolveHookfiles(cwd, ['./hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
 
     it('returns the absolute paths alphabetically sorted by their basename', () => {
-      const paths = resolveHookfiles([
+      const paths = resolveHookfiles(cwd, [
         './**/*_hooks.*',
         './hooks-glob/baz/x.js',
         './hooks-glob/foo/y.js',
@@ -92,7 +92,7 @@ describe('resolveHookfiles()', () => {
         './hooks-glob/baz/c.js',
         './hooks-glob/foo/o.js',
         './hooks-glob/bar/p.js',
-      ], cwd);
+      ]);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks-glob/foo/a.js'),
         path.join(cwd, 'hooks-glob/bar/b.js'),

--- a/test/unit/resolveHookfiles-test.js
+++ b/test/unit/resolveHookfiles-test.js
@@ -3,47 +3,62 @@ const { assert } = require('chai');
 
 const resolveHookfiles = require('../../lib/resolveHookfiles');
 
+
 describe('resolveHookfiles()', () => {
   const cwd = path.join(__filename, '..', '..', 'fixtures');
 
-  describe('when given no paths', () => it('produces no results', () => {
-    const paths = resolveHookfiles([], cwd);
-    assert.deepEqual(paths, []);
-  }));
+  describe('when given no paths', () => {
+    it('produces no results', () => {
+      const paths = resolveHookfiles([], cwd);
+      assert.deepEqual(paths, []);
+    });
+  });
 
-  describe('when given existing absolute filenames', () => it('resolves them into absolute paths', () => {
-    const hookfiles = [
-      path.join(cwd, 'hooks.js'),
-      path.join(cwd, 'non-js-hooks.rb'),
-    ];
-    const paths = resolveHookfiles(hookfiles, cwd);
-    assert.deepEqual(paths, hookfiles);
-  }));
+  describe('when given existing absolute filenames', () => {
+    it('resolves them into absolute paths', () => {
+      const hookfiles = [
+        path.join(cwd, 'hooks.js'),
+        path.join(cwd, 'non-js-hooks.rb'),
+      ];
+      const paths = resolveHookfiles(hookfiles, cwd);
+      assert.deepEqual(paths, hookfiles);
+    });
+  });
 
-  describe('when given existing relative filenames', () => it('resolves them into absolute paths', () => {
-    const paths = resolveHookfiles(['./hooks.js', './non-js-hooks.rb'], cwd);
-    assert.deepEqual(paths, [
-      path.join(cwd, 'hooks.js'),
-      path.join(cwd, 'non-js-hooks.rb'),
-    ]);
-  }));
+  describe('when given existing relative filenames', () => {
+    it('resolves them into absolute paths', () => {
+      const paths = resolveHookfiles(['./hooks.js', './non-js-hooks.rb'], cwd);
+      assert.deepEqual(paths, [
+        path.join(cwd, 'hooks.js'),
+        path.join(cwd, 'non-js-hooks.rb'),
+      ]);
+    });
+  });
 
-  describe('when given non-existing filenames', () => it('throws an error', () => assert.throws(
-    () => resolveHookfiles(['./hooks.js', './foo/bar/42'], cwd),
-    './foo/bar/42'
-  )));
+  describe('when given non-existing filenames', () => {
+    it('throws an error', () => {
+      assert.throws(() => {
+        resolveHookfiles(['./hooks.js', './foo/bar/42'], cwd);
+      }, './foo/bar/42');
+    });
+  });
 
-  describe('when given glob pattern resolving to existing files', () => it('resolves them into absolute paths', () => {
-    const paths = resolveHookfiles(['./**/hooks.js'], cwd);
-    assert.deepEqual(paths, [
-      path.join(cwd, 'hooks.js'),
-    ]);
-  }));
+  describe('when given glob pattern resolving to existing files', () => {
+    it('resolves them into absolute paths', () => {
+      const paths = resolveHookfiles(['./**/hooks.js'], cwd);
+      assert.deepEqual(paths, [
+        path.join(cwd, 'hooks.js'),
+      ]);
+    });
+  });
 
-  describe('when given glob pattern resolving to no files', () => it('throws an error', () => assert.throws(
-    () => resolveHookfiles(['./**/hooks.js', './**/foo/bar/foobar.js'], cwd),
-    './**/foo/bar/foobar.js'
-  )));
+  describe('when given glob pattern resolving to no files', () => {
+    it('throws an error', () => {
+      assert.throws(() => {
+        resolveHookfiles(['./**/hooks.js', './**/foo/bar/foobar.js'], cwd);
+      }, './**/foo/bar/foobar.js');
+    });
+  });
 
   describe('when given both globs and filenames', () => {
     it('resolves them into absolute paths', () => {
@@ -54,17 +69,19 @@ describe('resolveHookfiles()', () => {
       ]);
     });
 
-    it('throws an error on non-existing filenams', () => assert.throws(
-      () => resolveHookfiles(['./**/hooks.js', './foo/bar/42'], cwd),
-      './foo/bar/42'
-    ));
+    it('throws an error on non-existing filenams', () => {
+      assert.throws(() => {
+        resolveHookfiles(['./**/hooks.js', './foo/bar/42'], cwd);
+      }, './foo/bar/42');
+    });
 
-    it('throws an error on globs resolving to no files', () => assert.throws(
-      () => resolveHookfiles(['./hooks.js', './**/foo/bar/foobar.js'], cwd),
-      './**/foo/bar/foobar.js'
-    ));
+    it('throws an error on globs resolving to no files', () => {
+      assert.throws(() => {
+        resolveHookfiles(['./hooks.js', './**/foo/bar/foobar.js'], cwd);
+      }, './**/foo/bar/foobar.js');
+    });
 
-    it('returns the absolute paths alphabetically sorted', () => {
+    it('returns the absolute paths alphabetically sorted by their basename', () => {
       const paths = resolveHookfiles([
         './**/*_hooks.*',
         './hooks-glob/baz/x.js',

--- a/test/unit/resolveLocations-test.js
+++ b/test/unit/resolveLocations-test.js
@@ -1,0 +1,72 @@
+const path = require('path');
+const { assert } = require('chai');
+
+const resolveLocations = require('../../lib/resolveLocations');
+
+
+describe('resolveLocations()', () => {
+  const cwd = path.join(__filename, '..', '..', 'fixtures');
+
+  describe('when given no locations', () => {
+    it('produces no results', () => {
+      const locations = resolveLocations(cwd, []);
+      assert.deepEqual(locations, []);
+    });
+  });
+
+  describe('when given filenames', () => {
+    it('resolves them into absolute locations', () => {
+      const locations = resolveLocations(cwd, [
+        './multifile/*.apib',
+        './apiary.apib',
+      ]);
+      assert.deepEqual(locations, [
+        path.join(cwd, 'apiary.apib'),
+        path.join(cwd, '/multifile/greeting.apib'),
+        path.join(cwd, '/multifile/message.apib'),
+        path.join(cwd, '/multifile/name.apib'),
+      ]);
+    });
+  });
+
+  describe('when given HTTP URLs', () => {
+    it('keeps them as they are', () => {
+      const locations = resolveLocations(cwd, [
+        'http://example.com/foo.yaml',
+        './apiary.apib',
+      ]);
+      assert.deepEqual(locations, [
+        'http://example.com/foo.yaml',
+        path.join(cwd, 'apiary.apib'),
+      ]);
+    });
+  });
+
+  describe('when given HTTPS URLs', () => {
+    it('keeps them as they are', () => {
+      const locations = resolveLocations(cwd, [
+        'https://example.com/foo.yaml',
+        './apiary.apib',
+      ]);
+      assert.deepEqual(locations, [
+        'https://example.com/foo.yaml',
+        path.join(cwd, 'apiary.apib'),
+      ]);
+    });
+  });
+
+  describe('when given duplicate locations', () => {
+    it('returns only the distinct ones', () => {
+      const locations = resolveLocations(cwd, [
+        'http://example.com/foo.yaml',
+        './apiary.apib',
+        'http://example.com/foo.yaml',
+        './apiar*.apib',
+      ]);
+      assert.deepEqual(locations, [
+        'http://example.com/foo.yaml',
+        path.join(cwd, 'apiary.apib'),
+      ]);
+    });
+  });
+});

--- a/test/unit/resolveLocations-test.js
+++ b/test/unit/resolveLocations-test.js
@@ -5,59 +5,59 @@ const resolveLocations = require('../../lib/resolveLocations');
 
 
 describe('resolveLocations()', () => {
-  const cwd = path.join(__filename, '..', '..', 'fixtures');
+  const workingDirectory = path.join(__filename, '..', '..', 'fixtures');
 
   describe('when given no locations', () => {
     it('produces no results', () => {
-      const locations = resolveLocations(cwd, []);
+      const locations = resolveLocations(workingDirectory, []);
       assert.deepEqual(locations, []);
     });
   });
 
   describe('when given filenames', () => {
     it('resolves them into absolute locations', () => {
-      const locations = resolveLocations(cwd, [
+      const locations = resolveLocations(workingDirectory, [
         './multifile/*.apib',
         './apiary.apib',
       ]);
       assert.deepEqual(locations, [
-        path.join(cwd, 'apiary.apib'),
-        path.join(cwd, '/multifile/greeting.apib'),
-        path.join(cwd, '/multifile/message.apib'),
-        path.join(cwd, '/multifile/name.apib'),
+        path.join(workingDirectory, 'apiary.apib'),
+        path.join(workingDirectory, '/multifile/greeting.apib'),
+        path.join(workingDirectory, '/multifile/message.apib'),
+        path.join(workingDirectory, '/multifile/name.apib'),
       ]);
     });
   });
 
   describe('when given HTTP URLs', () => {
     it('keeps them as they are', () => {
-      const locations = resolveLocations(cwd, [
+      const locations = resolveLocations(workingDirectory, [
         'http://example.com/foo.yaml',
         './apiary.apib',
       ]);
       assert.deepEqual(locations, [
         'http://example.com/foo.yaml',
-        path.join(cwd, 'apiary.apib'),
+        path.join(workingDirectory, 'apiary.apib'),
       ]);
     });
   });
 
   describe('when given HTTPS URLs', () => {
     it('keeps them as they are', () => {
-      const locations = resolveLocations(cwd, [
+      const locations = resolveLocations(workingDirectory, [
         'https://example.com/foo.yaml',
         './apiary.apib',
       ]);
       assert.deepEqual(locations, [
         'https://example.com/foo.yaml',
-        path.join(cwd, 'apiary.apib'),
+        path.join(workingDirectory, 'apiary.apib'),
       ]);
     });
   });
 
   describe('when given duplicate locations', () => {
     it('returns only the distinct ones', () => {
-      const locations = resolveLocations(cwd, [
+      const locations = resolveLocations(workingDirectory, [
         'http://example.com/foo.yaml',
         './apiary.apib',
         'http://example.com/foo.yaml',
@@ -65,7 +65,7 @@ describe('resolveLocations()', () => {
       ]);
       assert.deepEqual(locations, [
         'http://example.com/foo.yaml',
-        path.join(cwd, 'apiary.apib'),
+        path.join(workingDirectory, 'apiary.apib'),
       ]);
     });
   });

--- a/test/unit/resolvePaths-test.js
+++ b/test/unit/resolvePaths-test.js
@@ -108,4 +108,19 @@ describe('resolvePaths()', () => {
       ]);
     });
   });
+
+  describe('when given duplicate paths', () => {
+    it('returns only the distinct ones', () => {
+      const paths = resolvePaths(cwd, [
+        './test2_hooks.js',
+        './**/*_hooks.*',
+        'multifile/multifile_hooks.coffee',
+      ]);
+      assert.deepEqual(paths, [
+        path.join(cwd, 'multifile/multifile_hooks.coffee'),
+        path.join(cwd, 'test2_hooks.js'),
+        path.join(cwd, 'test_hooks.coffee'),
+      ]);
+    });
+  });
 });

--- a/test/unit/resolvePaths-test.js
+++ b/test/unit/resolvePaths-test.js
@@ -1,15 +1,15 @@
 const path = require('path');
 const { assert } = require('chai');
 
-const resolveHookfiles = require('../../lib/resolveHookfiles');
+const resolvePaths = require('../../lib/resolvePaths');
 
 
-describe('resolveHookfiles()', () => {
+describe('resolvePaths()', () => {
   const cwd = path.join(__filename, '..', '..', 'fixtures');
 
   describe('when given no paths', () => {
     it('produces no results', () => {
-      const paths = resolveHookfiles(cwd, []);
+      const paths = resolvePaths(cwd, []);
       assert.deepEqual(paths, []);
     });
   });
@@ -20,14 +20,14 @@ describe('resolveHookfiles()', () => {
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
       ];
-      const paths = resolveHookfiles(cwd, hookfiles);
+      const paths = resolvePaths(cwd, hookfiles);
       assert.deepEqual(paths, hookfiles);
     });
   });
 
   describe('when given existing relative filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(cwd, ['./hooks.js', './non-js-hooks.rb']);
+      const paths = resolvePaths(cwd, ['./hooks.js', './non-js-hooks.rb']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
@@ -38,14 +38,14 @@ describe('resolveHookfiles()', () => {
   describe('when given non-existing filenames', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolveHookfiles(cwd, ['./hooks.js', './foo/bar/42']);
+        resolvePaths(cwd, ['./hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
   });
 
   describe('when given glob pattern resolving to existing files', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(cwd, ['./**/hooks.js']);
+      const paths = resolvePaths(cwd, ['./**/hooks.js']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
       ]);
@@ -55,14 +55,14 @@ describe('resolveHookfiles()', () => {
   describe('when given glob pattern resolving to no files', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolveHookfiles(cwd, ['./**/hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(cwd, ['./**/hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
   });
 
   describe('when given both globs and filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolveHookfiles(cwd, ['./non-js-hooks.rb', './**/hooks.js']);
+      const paths = resolvePaths(cwd, ['./non-js-hooks.rb', './**/hooks.js']);
       assert.deepEqual(paths, [
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
@@ -71,18 +71,18 @@ describe('resolveHookfiles()', () => {
 
     it('throws an error on non-existing filenams', () => {
       assert.throws(() => {
-        resolveHookfiles(cwd, ['./**/hooks.js', './foo/bar/42']);
+        resolvePaths(cwd, ['./**/hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
 
     it('throws an error on globs resolving to no files', () => {
       assert.throws(() => {
-        resolveHookfiles(cwd, ['./hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(cwd, ['./hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
 
     it('returns the absolute paths alphabetically sorted by their basename', () => {
-      const paths = resolveHookfiles(cwd, [
+      const paths = resolvePaths(cwd, [
         './**/*_hooks.*',
         './hooks-glob/baz/x.js',
         './hooks-glob/foo/y.js',

--- a/test/unit/resolvePaths-test.js
+++ b/test/unit/resolvePaths-test.js
@@ -16,12 +16,14 @@ describe('resolvePaths()', () => {
 
   describe('when given existing absolute filenames', () => {
     it('resolves them into absolute paths', () => {
-      const hookfiles = [
+      const paths = resolvePaths(cwd, [
         path.join(cwd, 'hooks.js'),
         path.join(cwd, 'non-js-hooks.rb'),
-      ];
-      const paths = resolvePaths(cwd, hookfiles);
-      assert.deepEqual(paths, hookfiles);
+      ]);
+      assert.deepEqual(paths, [
+        path.join(cwd, 'hooks.js'),
+        path.join(cwd, 'non-js-hooks.rb'),
+      ]);
     });
   });
 

--- a/test/unit/resolvePaths-test.js
+++ b/test/unit/resolvePaths-test.js
@@ -5,34 +5,34 @@ const resolvePaths = require('../../lib/resolvePaths');
 
 
 describe('resolvePaths()', () => {
-  const cwd = path.join(__filename, '..', '..', 'fixtures');
+  const workingDirectory = path.join(__filename, '..', '..', 'fixtures');
 
   describe('when given no paths', () => {
     it('produces no results', () => {
-      const paths = resolvePaths(cwd, []);
+      const paths = resolvePaths(workingDirectory, []);
       assert.deepEqual(paths, []);
     });
   });
 
   describe('when given existing absolute filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(cwd, [
-        path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb'),
+      const paths = resolvePaths(workingDirectory, [
+        path.join(workingDirectory, 'hooks.js'),
+        path.join(workingDirectory, 'non-js-hooks.rb'),
       ]);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb'),
+        path.join(workingDirectory, 'hooks.js'),
+        path.join(workingDirectory, 'non-js-hooks.rb'),
       ]);
     });
   });
 
   describe('when given existing relative filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(cwd, ['./hooks.js', './non-js-hooks.rb']);
+      const paths = resolvePaths(workingDirectory, ['./hooks.js', './non-js-hooks.rb']);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb'),
+        path.join(workingDirectory, 'hooks.js'),
+        path.join(workingDirectory, 'non-js-hooks.rb'),
       ]);
     });
   });
@@ -40,16 +40,16 @@ describe('resolvePaths()', () => {
   describe('when given non-existing filenames', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolvePaths(cwd, ['./hooks.js', './foo/bar/42']);
+        resolvePaths(workingDirectory, ['./hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
   });
 
   describe('when given glob pattern resolving to existing files', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(cwd, ['./**/hooks.js']);
+      const paths = resolvePaths(workingDirectory, ['./**/hooks.js']);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks.js'),
+        path.join(workingDirectory, 'hooks.js'),
       ]);
     });
   });
@@ -57,34 +57,34 @@ describe('resolvePaths()', () => {
   describe('when given glob pattern resolving to no files', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolvePaths(cwd, ['./**/hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(workingDirectory, ['./**/hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
   });
 
   describe('when given both globs and filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(cwd, ['./non-js-hooks.rb', './**/hooks.js']);
+      const paths = resolvePaths(workingDirectory, ['./non-js-hooks.rb', './**/hooks.js']);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks.js'),
-        path.join(cwd, 'non-js-hooks.rb'),
+        path.join(workingDirectory, 'hooks.js'),
+        path.join(workingDirectory, 'non-js-hooks.rb'),
       ]);
     });
 
     it('throws an error on non-existing filenams', () => {
       assert.throws(() => {
-        resolvePaths(cwd, ['./**/hooks.js', './foo/bar/42']);
+        resolvePaths(workingDirectory, ['./**/hooks.js', './foo/bar/42']);
       }, './foo/bar/42');
     });
 
     it('throws an error on globs resolving to no files', () => {
       assert.throws(() => {
-        resolvePaths(cwd, ['./hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(workingDirectory, ['./hooks.js', './**/foo/bar/foobar.js']);
       }, './**/foo/bar/foobar.js');
     });
 
     it('returns the absolute paths alphabetically sorted by their basename', () => {
-      const paths = resolvePaths(cwd, [
+      const paths = resolvePaths(workingDirectory, [
         './**/*_hooks.*',
         './hooks-glob/baz/x.js',
         './hooks-glob/foo/y.js',
@@ -96,32 +96,32 @@ describe('resolvePaths()', () => {
         './hooks-glob/bar/p.js',
       ]);
       assert.deepEqual(paths, [
-        path.join(cwd, 'hooks-glob/foo/a.js'),
-        path.join(cwd, 'hooks-glob/bar/b.js'),
-        path.join(cwd, 'hooks-glob/baz/c.js'),
-        path.join(cwd, 'multifile/multifile_hooks.coffee'),
-        path.join(cwd, 'hooks-glob/foo/o.js'),
-        path.join(cwd, 'hooks-glob/bar/p.js'),
-        path.join(cwd, 'test2_hooks.js'),
-        path.join(cwd, 'test_hooks.coffee'),
-        path.join(cwd, 'hooks-glob/baz/x.js'),
-        path.join(cwd, 'hooks-glob/foo/y.js'),
-        path.join(cwd, 'hooks-glob/bar/z.js'),
+        path.join(workingDirectory, 'hooks-glob/foo/a.js'),
+        path.join(workingDirectory, 'hooks-glob/bar/b.js'),
+        path.join(workingDirectory, 'hooks-glob/baz/c.js'),
+        path.join(workingDirectory, 'multifile/multifile_hooks.coffee'),
+        path.join(workingDirectory, 'hooks-glob/foo/o.js'),
+        path.join(workingDirectory, 'hooks-glob/bar/p.js'),
+        path.join(workingDirectory, 'test2_hooks.js'),
+        path.join(workingDirectory, 'test_hooks.coffee'),
+        path.join(workingDirectory, 'hooks-glob/baz/x.js'),
+        path.join(workingDirectory, 'hooks-glob/foo/y.js'),
+        path.join(workingDirectory, 'hooks-glob/bar/z.js'),
       ]);
     });
   });
 
   describe('when given duplicate paths', () => {
     it('returns only the distinct ones', () => {
-      const paths = resolvePaths(cwd, [
+      const paths = resolvePaths(workingDirectory, [
         './test2_hooks.js',
         './**/*_hooks.*',
         'multifile/multifile_hooks.coffee',
       ]);
       assert.deepEqual(paths, [
-        path.join(cwd, 'multifile/multifile_hooks.coffee'),
-        path.join(cwd, 'test2_hooks.js'),
-        path.join(cwd, 'test_hooks.coffee'),
+        path.join(workingDirectory, 'multifile/multifile_hooks.coffee'),
+        path.join(workingDirectory, 'test2_hooks.js'),
+        path.join(workingDirectory, 'test_hooks.coffee'),
       ]);
     });
   });

--- a/test/unit/transactionRunner-test.js
+++ b/test/unit/transactionRunner-test.js
@@ -25,6 +25,7 @@ describe('TransactionRunner', () => {
   let configuration = {
     server: 'http://127.0.0.1:3000',
     emitter: new EventEmitter(),
+    custom: { cwd: process.cwd() },
     options: {
       'dry-run': false,
       method: [],
@@ -63,6 +64,7 @@ describe('TransactionRunner', () => {
         server: 'http://127.0.0.1:3000',
         emitter: new EventEmitter(),
         apiDescriptions: [{ location: 'filename.api', content: '...' }],
+        custom: { cwd: process.cwd() },
         options: {
           'dry-run': false,
           method: [],
@@ -86,6 +88,7 @@ describe('TransactionRunner', () => {
           { location: 'filename1.api', content: '...' },
           { location: 'filename2.api', content: '...' },
         ],
+        custom: { cwd: process.cwd() },
         options: {
           'dry-run': false,
           method: [],
@@ -1195,6 +1198,7 @@ describe('TransactionRunner', () => {
     configuration = {
       server: 'http://127.0.0.1:3000',
       emitter: new EventEmitter(),
+      custom: { cwd: process.cwd() },
       options: {
         'dry-run': false,
         method: [],


### PR DESCRIPTION
#### :rocket: Why this change?

Dredd now resolves globs for both hookfiles and API descriptions paths. The logic of resolving them is the same, so I think the code taking care of it should be the same as well.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
