### PR TITLE
Require options where they're used

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -13,7 +13,9 @@ const logger = require('./logger');
 const { applyLoggingOptions } = require('./configuration');
 const { spawn } = require('./childProcess');
 
+const dreddOptions = require('./options.json');
 const packageData = require('../package.json');
+
 
 class CLI {
   constructor(options = {}, cb) {
@@ -47,7 +49,7 @@ Or:
 Example:
   $ dredd ./api-description.apib http://127.0.0.1:3000 --dry-run\
 `)
-      .options(Dredd.options)
+      .options(dreddOptions)
       .wrap(80);
 
     this.argv = this.optimist.argv;

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -13,7 +13,7 @@ const logger = require('./logger');
 const { applyLoggingOptions } = require('./configuration');
 const { spawn } = require('./childProcess');
 
-const dreddOptions = require('./options.json');
+const dreddOptions = require('./options');
 const packageData = require('../package.json');
 
 

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -13,7 +13,6 @@ const resolveLocations = require('./resolveLocations');
 const logger = require('./logger');
 const Runner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
-const options = require('./options.json');
 
 
 const PROXY_ENV_VARIABLES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
@@ -250,5 +249,5 @@ Is the provided path correct?
   }
 }
 
+
 module.exports = Dredd;
-module.exports.options = options;


### PR DESCRIPTION
#### :rocket: Why this change?

Streamlining how the codebase is written.

#### :memo: Related issues and Pull Requests

Factored out from https://github.com/apiaryio/dredd/pull/1289/

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
