### PR TITLE
Remove redundant 'tests' structure

### DIFF
--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -29,7 +29,6 @@ class Dredd {
   init(config) {
     this.configuration = applyConfiguration(config);
     this.configuration.http = {};
-    this.tests = [];
     this.stats = {
       tests: 0,
       failures: 0,
@@ -44,8 +43,6 @@ class Dredd {
     this.transactions = [];
     this.runner = new Runner(this.configuration);
     this.logger = logger;
-    configureReporters(this.configuration, this.stats, this.tests, this.runner);
-    this.logProxySettings();
   }
 
   logProxySettings() {
@@ -58,17 +55,21 @@ class Dredd {
     }
 
     if (proxySettings.length) {
-      const message = `
+      const message = `\
 HTTP(S) proxy specified by environment variables: \
-${proxySettings.join(', ')}. Please read documentation on how
-Dredd works with proxies:
-https://dredd.org/en/latest/how-it-works/#using-https-proxy
-`;
+${proxySettings.join(', ')}. Please read documentation on how \
+Dredd works with proxies: \
+https://dredd.org/en/latest/how-it-works/#using-https-proxy`;
       this.logger.debug(message);
     }
   }
 
   run(callback) {
+    this.logProxySettings();
+
+    this.logger.debug('Configuring reporters');
+    configureReporters(this.configuration, this.stats, this.runner);
+
     this.logger.debug('Resolving --require');
     if (this.configuration.options.require) {
       let mod = this.configuration.options.require;

--- a/lib/configureReporters.js
+++ b/lib/configureReporters.js
@@ -23,8 +23,8 @@ function intersection(a, b) {
   return Array.from(a).filter(value => Array.from(b).includes(value));
 }
 
-function configureReporters(config, stats, tests, runner) {
-  addReporter('base', config.emitter, stats, tests);
+function configureReporters(config, stats, runner) {
+  addReporter('base', config.emitter, stats);
 
   const reporters = config.options.reporter;
   const outputs = config.options.output;
@@ -36,34 +36,34 @@ function configureReporters(config, stats, tests, runner) {
       const usedCliReporters = intersection(reportersArr, cliReporters);
       if (usedCliReporters.length === 0) {
         return new CLIReporter(
-          config.emitter, stats, tests, config.options['inline-errors'], config.options.details
+          config.emitter, stats, config.options['inline-errors'], config.options.details
         );
       }
-      return addReporter(usedCliReporters[0], config.emitter, stats, tests);
+      return addReporter(usedCliReporters[0], config.emitter, stats);
     }
     return new CLIReporter(
-      config.emitter, stats, tests, config.options['inline-errors'], config.options.details
+      config.emitter, stats, config.options['inline-errors'], config.options.details
     );
   }
 
-  function addReporter(reporter, emitter, statistics, testsArg, path) {
+  function addReporter(reporter, emitter, statistics, path) {
     switch (reporter) {
       case 'xunit':
-        return new XUnitReporter(emitter, statistics, testsArg, path, config.options.details);
+        return new XUnitReporter(emitter, statistics, path, config.options.details);
       case 'dot':
-        return new DotReporter(emitter, statistics, testsArg);
+        return new DotReporter(emitter, statistics);
       case 'nyan':
-        return new NyanCatReporter(emitter, statistics, testsArg);
+        return new NyanCatReporter(emitter, statistics);
       case 'html':
-        return new HTMLReporter(emitter, statistics, testsArg, path, config.options.details);
+        return new HTMLReporter(emitter, statistics, path, config.options.details);
       case 'markdown':
-        return new MarkdownReporter(emitter, statistics, testsArg, path, config.options.details);
+        return new MarkdownReporter(emitter, statistics, path, config.options.details);
       case 'apiary':
-        return new ApiaryReporter(emitter, statistics, testsArg, config, runner);
+        return new ApiaryReporter(emitter, statistics, config, runner);
       default:
         // I don't even know where to begin...
         // TODO: DESIGN / REFACTOR WHOLE REPORTER(S) API FROM SCRATCH, THIS IS MADNESS!!1
-        (new BaseReporter(emitter, stats, tests));
+        (new BaseReporter(emitter, stats));
     }
   }
 
@@ -88,7 +88,7 @@ provided. Using default paths for additional file-based reporters.
 
     return usedFileReporters.map((usedFileReporter, index) => {
       const path = outputs[index] ? outputs[index] : undefined;
-      return addReporter(usedFileReporter, config.emitter, stats, tests, path);
+      return addReporter(usedFileReporter, config.emitter, stats, path);
     });
   }
 }

--- a/lib/reporters/ApiaryReporter.js
+++ b/lib/reporters/ApiaryReporter.js
@@ -19,10 +19,9 @@ const CONNECTION_ERRORS = [
 ];
 
 
-function ApiaryReporter(emitter, stats, tests, config, runner) {
+function ApiaryReporter(emitter, stats, config, runner) {
   this.type = 'apiary';
   this.stats = stats;
-  this.tests = tests;
   this.uuid = null;
   this.startedAt = null;
   this.endedAt = null;

--- a/lib/reporters/BaseReporter.js
+++ b/lib/reporters/BaseReporter.js
@@ -1,9 +1,8 @@
 const logger = require('../logger');
 
-function BaseReporter(emitter, stats, tests) {
+function BaseReporter(emitter, stats) {
   this.type = 'base';
   this.stats = stats;
-  this.tests = tests;
   this.configureEmitter(emitter);
   logger.debug(`Using '${this.type}' reporter.`);
 }
@@ -21,7 +20,6 @@ BaseReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   });
 
   emitter.on('test start', (test) => {
-    this.tests.push(test);
     this.stats.tests += 1;
     test.start = new Date();
   });

--- a/lib/reporters/CLIReporter.js
+++ b/lib/reporters/CLIReporter.js
@@ -14,10 +14,9 @@ const CONNECTION_ERRORS = [
 ];
 
 
-function CLIReporter(emitter, stats, tests, inlineErrors, details) {
+function CLIReporter(emitter, stats, inlineErrors, details) {
   this.type = 'cli';
   this.stats = stats;
-  this.tests = tests;
   this.inlineErrors = inlineErrors;
   this.details = details;
   this.errors = [];

--- a/lib/reporters/DotReporter.js
+++ b/lib/reporters/DotReporter.js
@@ -2,10 +2,9 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const prettifyResponse = require('../prettifyResponse');
 
-function DotReporter(emitter, stats, tests) {
+function DotReporter(emitter, stats) {
   this.type = 'dot';
   this.stats = stats;
-  this.tests = tests;
   this.errors = [];
 
   this.configureEmitter(emitter);

--- a/lib/reporters/HTMLReporter.js
+++ b/lib/reporters/HTMLReporter.js
@@ -11,12 +11,11 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const prettifyResponse = require('../prettifyResponse');
 
-function HTMLReporter(emitter, stats, tests, path, details) {
+function HTMLReporter(emitter, stats, path, details) {
   EventEmitter.call(this);
 
   this.type = 'html';
   this.stats = stats;
-  this.tests = tests;
   this.buf = '';
   this.level = 1;
   this.details = details;

--- a/lib/reporters/MarkdownReporter.js
+++ b/lib/reporters/MarkdownReporter.js
@@ -10,12 +10,11 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const prettifyResponse = require('../prettifyResponse');
 
-function MarkdownReporter(emitter, stats, tests, path, details) {
+function MarkdownReporter(emitter, stats, path, details) {
   EventEmitter.call(this);
 
   this.type = 'markdown';
   this.stats = stats;
-  this.tests = tests;
   this.buf = '';
   this.level = 1;
   this.details = details;

--- a/lib/reporters/NyanReporter.js
+++ b/lib/reporters/NyanReporter.js
@@ -4,12 +4,11 @@ const logger = require('../logger');
 const prettifyResponse = require('../prettifyResponse');
 const reporterOutputLogger = require('./reporterOutputLogger');
 
-function NyanCatReporter(emitter, stats, tests) {
+function NyanCatReporter(emitter, stats) {
   let windowWidth;
 
   this.type = 'nyan';
   this.stats = stats;
-  this.tests = tests;
   this.isatty = tty.isatty(1) && tty.isatty(2);
 
   if (this.isatty) {

--- a/lib/reporters/XUnitReporter.js
+++ b/lib/reporters/XUnitReporter.js
@@ -11,12 +11,11 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const prettifyResponse = require('../prettifyResponse');
 
-function XUnitReporter(emitter, stats, tests, path, details) {
+function XUnitReporter(emitter, stats, path, details) {
   EventEmitter.call(this);
 
   this.type = 'xunit';
   this.stats = stats;
-  this.tests = tests;
   this.details = details;
   this.path = this.sanitizedPath(path);
 

--- a/test/unit/configureReporters-test.js
+++ b/test/unit/configureReporters-test.js
@@ -46,7 +46,7 @@ function resetStubs() {
 }
 
 
-describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
+describe('configureReporters()', () => {
   const configuration = {
     emitter: emitterStub,
     options: {
@@ -64,7 +64,7 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
     beforeEach(() => resetStubs());
 
     it('should only add a CLIReporter', (done) => {
-      configureReporters(configuration, {}, {}, null);
+      configureReporters(configuration, {}, null);
       assert.isOk(CliReporterStub.called);
       return done();
     });
@@ -77,7 +77,7 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       beforeEach(() => resetStubs());
 
       it('should still add reporters', (done) => {
-        configureReporters(configuration, {}, {}, null);
+        configureReporters(configuration, {}, null);
         assert.ok(CliReporterStub.called);
         return done();
       });
@@ -92,13 +92,13 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
     beforeEach(() => resetStubs());
 
     it('should add a cli-based reporter', (done) => {
-      configureReporters(configuration, {}, {}, null);
+      configureReporters(configuration, {}, null);
       assert.isOk(DotReporterStub.called);
       return done();
     });
 
     it('should not add more than one cli-based reporters', (done) => {
-      configureReporters(configuration, {}, {}, null);
+      configureReporters(configuration, {}, null);
       assert.notOk(CliReporterStub.called);
       return done();
     });
@@ -113,7 +113,7 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
     beforeEach(() => resetStubs());
 
     it('should add a CLIReporter', (done) => {
-      configureReporters(configuration, {}, {}, () => {});
+      configureReporters(configuration, {}, () => {});
       assert.isOk(CliReporterStub.called);
       return done();
     });
@@ -126,9 +126,9 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       beforeEach(() => resetStubs());
 
       it('should use the output paths in the order provided', (done) => {
-        configureReporters(configuration, {}, {}, () => {});
-        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file1'));
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file2'));
+        configureReporters(configuration, {}, () => {});
+        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
+        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file2'));
         return done();
       });
     });
@@ -141,9 +141,9 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       beforeEach(() => resetStubs());
 
       it('should use the default output paths for the additional reporters', (done) => {
-        configureReporters(configuration, {}, {}, () => {});
-        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file1'));
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, undefined));
+        configureReporters(configuration, {}, () => {});
+        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
+        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, undefined));
         return done();
       });
     });
@@ -157,13 +157,13 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
     beforeEach(() => resetStubs());
 
     it('should add a cli-based reporter', (done) => {
-      configureReporters(configuration, {}, {}, () => {});
+      configureReporters(configuration, {}, () => {});
       assert.isOk(NyanCatReporterStub.called);
       return done();
     });
 
     it('should not add more than one cli-based reporters', (done) => {
-      configureReporters(configuration, {}, {}, () => {});
+      configureReporters(configuration, {}, () => {});
       assert.notOk(CliReporterStub.called);
       assert.notOk(DotReporterStub.called);
       return done();
@@ -177,9 +177,9 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       beforeEach(() => resetStubs());
 
       it('should use the output paths in the order provided', (done) => {
-        configureReporters(configuration, {}, {}, () => {});
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file1'));
-        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file2'));
+        configureReporters(configuration, {}, () => {});
+        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
+        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file2'));
         return done();
       });
     });
@@ -192,9 +192,9 @@ describe('configureReporters(config, stats, tests, onSaveCallback)', () => {
       beforeEach(() => resetStubs());
 
       it('should use the default output paths for the additional reporters', (done) => {
-        configureReporters(configuration, {}, {}, () => {});
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, 'file1'));
-        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, {}, undefined));
+        configureReporters(configuration, {}, () => {});
+        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
+        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, undefined));
         return done();
       });
     });

--- a/test/unit/reporters/ApiaryReporter-test.js
+++ b/test/unit/reporters/ApiaryReporter-test.js
@@ -163,7 +163,7 @@ describe('ApiaryReporter', () => {
 
         it('uses the provided API URL in configuration', () => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           assert.equal(
             apiaryReporter.configuration.apiUrl,
             'https://api.example.com:1234'
@@ -179,7 +179,7 @@ describe('ApiaryReporter', () => {
 
         it('uses the provided API URL in configuration, without trailing slash', () => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           assert.equal(
             apiaryReporter.configuration.apiUrl,
             'https://api.example.com:1234'
@@ -197,7 +197,7 @@ describe('ApiaryReporter', () => {
 
         it('should use API URL without double slashes', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           apiaryReporter._performRequestAsync('/', 'POST', '', () => {
             assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/ (without body)'));
             done();
@@ -213,7 +213,7 @@ describe('ApiaryReporter', () => {
 
         describe('when provided with root path', () => it('should use API URL without double slashes', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           apiaryReporter._performRequestAsync('/', 'POST', '', () => {
             assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/ (without body)'));
             done();
@@ -222,7 +222,7 @@ describe('ApiaryReporter', () => {
 
         describe('when provided with non-root path', () => it('should use API URL without double slashes', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           apiaryReporter._performRequestAsync('/hello?q=1', 'POST', '', () => {
             assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/hello?q=1 (without body)'));
             done();
@@ -238,7 +238,7 @@ describe('ApiaryReporter', () => {
 
         it('should log human readable message', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
           apiaryReporter._performRequestAsync('/', 'POST', '', (error) => {
             assert.isNotNull(error);
             done();
@@ -247,7 +247,7 @@ describe('ApiaryReporter', () => {
 
         it('should set server error to true', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
           apiaryReporter._performRequestAsync('/', 'POST', '', () => {
             assert.isTrue(apiaryReporter.serverError);
             done();
@@ -280,7 +280,7 @@ describe('ApiaryReporter', () => {
 
       it('should set uuid', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         return emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.uuid);
           return done();
@@ -289,7 +289,7 @@ describe('ApiaryReporter', () => {
 
       it('should set start time', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.startedAt);
           done();
@@ -298,7 +298,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test run" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           assert.isTrue(call.isDone());
           done();
@@ -307,7 +307,7 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run ID back to the reporter as remoteId', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.remoteId);
           done();
@@ -316,7 +316,7 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run reportUrl to the reporter as reportUrl', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.reportUrl);
           done();
@@ -325,7 +325,7 @@ describe('ApiaryReporter', () => {
 
       it('should have blueprints key in the request and it should be an array and members should have proper structure', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.isArray(parsedBody.blueprints);
@@ -344,7 +344,7 @@ describe('ApiaryReporter', () => {
 
       it('should have various needed keys in test-run payload sent to apiary', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.propertyVal(parsedBody, 'endpoint', 'http://my.server.co:8080');
@@ -354,7 +354,7 @@ describe('ApiaryReporter', () => {
 
       it('should send the test-run as public one', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.strictEqual(parsedBody.public, true);
@@ -364,7 +364,7 @@ describe('ApiaryReporter', () => {
 
       describe('serverError is true', () => it('should not do anything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.serverError = true;
         emitter.emit('start', apiDescriptions, () => {
           assert.isFalse(call.isDone());
@@ -397,7 +397,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           assert.isTrue(call.isDone());
@@ -407,7 +407,7 @@ describe('ApiaryReporter', () => {
 
       it('should have origin with filename in the request', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           const parsedBody = JSON.parse(requestBody);
@@ -418,7 +418,7 @@ describe('ApiaryReporter', () => {
 
       it('should have startedAt timestamp in the request', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           const parsedBody = JSON.parse(requestBody);
@@ -429,7 +429,7 @@ describe('ApiaryReporter', () => {
 
       describe('serverError is true', () => it('should not do anything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.serverError = true;
         emitter.emit('test pass', test, () => {
@@ -453,7 +453,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test fail', test, () => {
           assert.isTrue(call.isDone());
@@ -463,7 +463,7 @@ describe('ApiaryReporter', () => {
 
       describe('when serverError is true', () => it('should not do anything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.serverError = true;
         emitter.emit('test fail', test, () => {
@@ -500,7 +500,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test skip', clonedTest, () => {
           assert.isTrue(call.isDone());
@@ -510,7 +510,7 @@ describe('ApiaryReporter', () => {
 
       it('should send status skipped', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test skip', clonedTest, () => {
           assert.equal(JSON.parse(requestBody).result, 'skip');
@@ -520,7 +520,7 @@ describe('ApiaryReporter', () => {
 
       describe('when serverError is true', () => it('should not do anything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.serverError = true;
         emitter.emit('test skip', clonedTest, () => {
@@ -561,7 +561,7 @@ describe('ApiaryReporter', () => {
         describe(`when error type is ${errType}`, () => {
           it('should call "create new test step" HTTP resource', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
@@ -573,7 +573,7 @@ describe('ApiaryReporter', () => {
 
           it('should set result to error', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
@@ -586,7 +586,7 @@ describe('ApiaryReporter', () => {
 
           it('should set error message', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
@@ -603,7 +603,7 @@ describe('ApiaryReporter', () => {
       describe('when any other error', () => {
         it('should call "create new test step" HTTP resource', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
@@ -614,7 +614,7 @@ describe('ApiaryReporter', () => {
 
         it('should set result to error', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
@@ -625,7 +625,7 @@ describe('ApiaryReporter', () => {
 
         it('should set descriptive error', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
@@ -640,7 +640,7 @@ describe('ApiaryReporter', () => {
 
       describe('when serverError is true', () => it('should not do anything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.serverError = true;
         const error = new Error('some error');
@@ -673,7 +673,7 @@ describe('ApiaryReporter', () => {
 
       it('should update "test run" resource with result data', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isTrue(call.isDone());
@@ -683,7 +683,7 @@ describe('ApiaryReporter', () => {
 
       it('should return generated url if no reportUrl is available', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://app.apiary.io/public/tests/run/507f1f77bcf86cd799439011'));
@@ -693,7 +693,7 @@ describe('ApiaryReporter', () => {
 
       it('should return reportUrl from testRun entity', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.reportUrl = 'https://absolutely.fancy.url/wich-can-change/some/id';
         emitter.emit('end', () => {
@@ -705,7 +705,7 @@ describe('ApiaryReporter', () => {
       it('should send runner.logs to Apiary at the end of testRun', (done) => {
         emitter = new EventEmitter();
         const logMessages = ['a', 'b'];
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } }, { logs: clone(logMessages) });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }, { logs: clone(logMessages) });
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isString(requestBody);
@@ -719,7 +719,7 @@ describe('ApiaryReporter', () => {
 
       describe('serverError is true', () => it('should not do enything', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.serverError = true;
         emitter.emit('end', () => {
@@ -866,7 +866,7 @@ describe('ApiaryReporter', () => {
 
       it('should set uuid', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.uuid);
           done();
@@ -875,7 +875,7 @@ describe('ApiaryReporter', () => {
 
       it('should set start time', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.startedAt);
           done();
@@ -884,7 +884,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test run" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           assert.isTrue(call.isDone());
           done();
@@ -893,7 +893,7 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run ID back to the reporter as remoteId', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.remoteId);
           done();
@@ -902,7 +902,7 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run reportUrl to the reporter as reportUrl', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.reportUrl);
           done();
@@ -911,7 +911,7 @@ describe('ApiaryReporter', () => {
 
       it('should send the test-run as non-public', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.strictEqual(parsedBody.public, false);
@@ -935,7 +935,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           assert.isTrue(call.isDone());
@@ -959,7 +959,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('test fail', test, () => {
           assert.isTrue(call.isDone());
@@ -983,7 +983,7 @@ describe('ApiaryReporter', () => {
 
       it('should update "test run" resource with result data', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isTrue(call.isDone());
@@ -993,7 +993,7 @@ describe('ApiaryReporter', () => {
 
       it('should return generated url if reportUrl is not available', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://app.apiary.io/jakubtest/tests/run/507f1f77bcf86cd799439011'));
@@ -1003,7 +1003,7 @@ describe('ApiaryReporter', () => {
 
       it('should return reportUrl from testRun entity', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         apiaryReporter.remoteId = runId;
         apiaryReporter.reportUrl = 'https://absolutely.fancy.url/wich-can-change/some/id';
         emitter.emit('end', () => {

--- a/test/unit/reporters/BaseReporter-test.js
+++ b/test/unit/reporters/BaseReporter-test.js
@@ -10,7 +10,6 @@ const BaseReporter = proxyquire('../../../lib/reporters/BaseReporter', {
 
 describe('BaseReporter', () => {
   let stats = {};
-  let tests = [];
   let test = {};
   let emitter = {};
 
@@ -25,9 +24,8 @@ describe('BaseReporter', () => {
       end: 0,
       duration: 0,
     };
-    tests = [];
     emitter = new EventEmitter();
-    (new BaseReporter(emitter, stats, tests));
+    (new BaseReporter(emitter, stats));
   });
 
   describe('when starting', () => {
@@ -53,17 +51,17 @@ describe('BaseReporter', () => {
   });
 
   describe('when test starts', () => {
-    before(() => {
+    beforeEach(() => {
       test = {
         status: 'pass',
         title: 'Passing Test',
       };
+      emitter.emit('test start', test);
     });
 
-    it('should add the test', () => {
-      emitter.emit('test start', test);
-      assert.isOk(tests.length === 1);
-    });
+    it('should increment the counter', () => assert.equal(stats.tests, 1));
+
+    it('should set the start time', () => assert.isOk(test.start));
   });
 
   describe('when test passes', () => {
@@ -78,7 +76,7 @@ describe('BaseReporter', () => {
 
     it('should increment the counter', () => assert.equal(stats.passes, 1));
 
-    it('should set the end time', () => assert.isOk(tests[0].end));
+    it('should set the end time', () => assert.isOk(test.end));
   });
 
   describe('when test is skipped', () => {
@@ -106,7 +104,7 @@ describe('BaseReporter', () => {
 
     it('should increment the counter', () => assert.isOk(stats.failures === 1));
 
-    it('should set the end time', () => assert.isOk(tests[0].end));
+    it('should set the end time', () => assert.isOk(test.end));
   });
 
   describe('when test errors', () => {
@@ -121,7 +119,7 @@ describe('BaseReporter', () => {
 
     it('should increment the counter', () => assert.isOk(stats.errors === 1));
 
-    it('should set the end time', () => assert.isOk(tests[0].end));
+    it('should set the end time', () => assert.isOk(test.end));
   });
 
   describe('when passing test start is UTC string', () => {
@@ -135,7 +133,7 @@ describe('BaseReporter', () => {
       emitter.emit('test pass', test);
     });
 
-    it('should set the duration', () => assert.isNotNaN(tests[0].duration));
+    it('should set the duration', () => assert.isNotNaN(test.duration));
   });
 
   describe('when failed test start is UTC string', () => {
@@ -149,7 +147,7 @@ describe('BaseReporter', () => {
       emitter.emit('test fail', test);
     });
 
-    it('should set the duration', () => assert.isNotNaN(tests[0].duration));
+    it('should set the duration', () => assert.isNotNaN(test.duration));
   });
 
   describe('when errored test start is UTC string', () => {
@@ -163,6 +161,6 @@ describe('BaseReporter', () => {
       emitter.emit('test error', new Error('Error'), test);
     });
 
-    it('should set the duration', () => assert.isNotNaN(tests[0].duration));
+    it('should set the duration', () => assert.isNotNaN(test.duration));
   });
 });

--- a/test/unit/reporters/CLIReporter-test.js
+++ b/test/unit/reporters/CLIReporter-test.js
@@ -31,7 +31,7 @@ describe('CLIReporter', () => {
 
     it('should write starting to the console', (done) => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, true));
+      (new CLIReporter(emitter, {}, true));
       loggerStub.debug.resetHistory();
       emitter.emit('start', '', () => {
         assert.isOk(loggerStub.debug.calledOnce);
@@ -54,7 +54,7 @@ describe('CLIReporter', () => {
 
     it('should write pass to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, true));
+      (new CLIReporter(emitter, {}, true));
       emitter.emit('test pass', test);
       assert.isOk(reporterOutputLoggerStub.pass.calledOnce);
     });
@@ -66,7 +66,7 @@ describe('CLIReporter', () => {
 
       it('should write details for passing tests', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, {}, true, true));
+        (new CLIReporter(emitter, {}, true, true));
         emitter.emit('test pass', test);
         assert.isOk(reporterOutputLoggerStub.request.calledOnce);
       });
@@ -88,7 +88,7 @@ describe('CLIReporter', () => {
 
       it('should write fail to the console', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, {}, true));
+        (new CLIReporter(emitter, {}, true));
         emitter.emit('test fail', test);
         assert.isOk(reporterOutputLoggerStub.fail.calledTwice);
       });
@@ -101,14 +101,14 @@ describe('CLIReporter', () => {
 
       it('should not write full failure to the console at the time of failure', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, {}, false));
+        (new CLIReporter(emitter, {}, false));
         emitter.emit('test fail', test);
         assert.isOk(reporterOutputLoggerStub.fail.calledOnce);
       });
 
       it('should write full failure to the console after execution is complete', (done) => {
         const emitter = new EventEmitter();
-        const cliReporter = new CLIReporter(emitter, {}, {}, false);
+        const cliReporter = new CLIReporter(emitter, {}, false);
         cliReporter.errors = [test];
         emitter.emit('end', () => {
           assert.isOk(reporterOutputLoggerStub.fail.calledTwice);
@@ -132,7 +132,7 @@ describe('CLIReporter', () => {
 
     it('should write error to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, false));
+      (new CLIReporter(emitter, {}, false));
       emitter.emit('test error', new Error('Error'), test);
       assert.isOk(reporterOutputLoggerStub.error.calledTwice);
     });
@@ -155,7 +155,7 @@ describe('CLIReporter', () => {
 
     Array.from(connectionErrors).forEach(errType => describe(`when error type ${errType}`, () => it('should write error to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, false));
+      (new CLIReporter(emitter, {}, false));
       const error = new Error('connect');
       error.code = errType;
       emitter.emit('test error', error, test);
@@ -180,7 +180,7 @@ describe('CLIReporter', () => {
 
     it('should write skip to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, false));
+      (new CLIReporter(emitter, {}, false));
       emitter.emit('test skip', test);
       assert.isOk(reporterOutputLoggerStub.skip.calledOnce);
     });
@@ -201,8 +201,7 @@ describe('CLIReporter', () => {
 
     describe('when there is at least one test', () => it('should write to the console', (done) => {
       const emitter = new EventEmitter();
-      const cliReporter = new CLIReporter(emitter, {}, {}, false);
-      cliReporter.tests = [test];
+      const cliReporter = new CLIReporter(emitter, {}, false);
       cliReporter.stats.tests = 1;
       emitter.emit('end', () => {
         assert.isOk(reporterOutputLoggerStub.complete.calledTwice);
@@ -212,7 +211,7 @@ describe('CLIReporter', () => {
 
     describe('when there are no tests', () => it('should write to the console', (done) => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, {}, false));
+      (new CLIReporter(emitter, {}, false));
       emitter.emit('end', () => {
         assert.isOk(reporterOutputLoggerStub.complete.calledOnce);
         done();

--- a/test/unit/reporters/DotReporter-test.js
+++ b/test/unit/reporters/DotReporter-test.js
@@ -14,7 +14,6 @@ const DotReporter = proxyquire('../../../lib/reporters/DotReporter', {
 describe('DotReporter', () => {
   let stats = {};
   let test = [];
-  let tests;
   let emitter;
   let dotReporter;
 
@@ -33,9 +32,8 @@ describe('DotReporter', () => {
       end: 0,
       duration: 0,
     };
-    tests = [];
     emitter = new EventEmitter();
-    dotReporter = new DotReporter(emitter, stats, tests);
+    dotReporter = new DotReporter(emitter, stats);
   });
 
   describe('when starting', () => {

--- a/test/unit/reporters/HTMLReporter-test.js
+++ b/test/unit/reporters/HTMLReporter-test.js
@@ -24,7 +24,6 @@ describe('HTMLReporter', () => {
   let htmlReporter;
   let stats;
   let test = {};
-  let tests;
 
   before(() => {
     loggerStub.transports.console.silent = true;
@@ -48,8 +47,7 @@ describe('HTMLReporter', () => {
       end: 0,
       duration: 0,
     };
-    tests = [];
-    htmlReporter = new HTMLReporter(emitter, stats, tests, 'test.html');
+    htmlReporter = new HTMLReporter(emitter, stats, 'test.html');
   });
 
   describe('when starting', () => {

--- a/test/unit/reporters/MarkdownReporter-test.js
+++ b/test/unit/reporters/MarkdownReporter-test.js
@@ -24,7 +24,6 @@ describe('MarkdownReporter', () => {
   let emitter;
   let stats;
   let test = {};
-  let tests;
 
   before(() => {
     loggerStub.transports.console.silent = true;
@@ -48,8 +47,7 @@ describe('MarkdownReporter', () => {
       end: 0,
       duration: 0,
     };
-    tests = [];
-    mdReporter = new MarkdownReporter(emitter, stats, tests, 'test.md');
+    mdReporter = new MarkdownReporter(emitter, stats, 'test.md');
   });
 
 

--- a/test/unit/reporters/NyanReporter-test.js
+++ b/test/unit/reporters/NyanReporter-test.js
@@ -13,7 +13,6 @@ const NyanCatReporter = proxyquire('../../../lib/reporters/NyanReporter', {
 describe('NyanCatReporter', () => {
   let emitter;
   let stats;
-  let tests;
   let nyanReporter;
 
   before(() => {
@@ -36,8 +35,7 @@ describe('NyanCatReporter', () => {
       end: 0,
       duration: 0,
     };
-    tests = [];
-    nyanReporter = new NyanCatReporter(emitter, stats, tests);
+    nyanReporter = new NyanCatReporter(emitter, stats);
   });
 
   describe('when starting', () => {

--- a/test/unit/reporters/XUnitReporter-test.js
+++ b/test/unit/reporters/XUnitReporter-test.js
@@ -48,7 +48,7 @@ describe('XUnitReporter', () => {
 
       it('should warn about the existing file', () => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+        (new XUnitReporter(emitter, {}, 'test.xml'));
         assert.isOk(loggerStub.warn.called);
       });
     });
@@ -66,7 +66,7 @@ describe('XUnitReporter', () => {
 
       it('should create the file', () => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+        (new XUnitReporter(emitter, {}, 'test.xml'));
         assert.isOk(fsStub.unlinkSync.notCalled);
       });
     });
@@ -86,7 +86,7 @@ describe('XUnitReporter', () => {
 
       it('should write opening to file', (done) => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+        (new XUnitReporter(emitter, {}, 'test.xml'));
         emitter.emit('start', '', () => {
           assert.isOk(makeDirStubImpl.called);
           assert.isOk(fsStub.appendFileSync.called);
@@ -110,7 +110,7 @@ describe('XUnitReporter', () => {
 
       it('should write to log', (done) => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+        (new XUnitReporter(emitter, {}, 'test.xml'));
         emitter.emit('start', '', () => {
           assert.isOk(makeDirStubImpl.called);
           assert.isOk(fsStub.appendFileSync.notCalled);
@@ -139,8 +139,7 @@ describe('XUnitReporter', () => {
     describe('when there is one test', () => {
       it('should write tests to file', () => {
         const emitter = new EventEmitter();
-        const xUnitReporter = new XUnitReporter(emitter, {}, {});
-        xUnitReporter.tests = [test];
+        const xUnitReporter = new XUnitReporter(emitter, {});
         xUnitReporter.stats.tests = 1;
         emitter.emit('test pass', test);
         assert.isOk(fsStub.appendFileSync.called);
@@ -148,8 +147,7 @@ describe('XUnitReporter', () => {
 
       describe('when the file writes successfully', () => it('should read the file and update the stats', (done) => {
         const emitter = new EventEmitter();
-        const xUnitReporter = new XUnitReporter(emitter, {}, {});
-        xUnitReporter.tests = [test];
+        const xUnitReporter = new XUnitReporter(emitter, {});
         xUnitReporter.stats.tests = 1;
 
         emitter.emit('end', () => {
@@ -161,7 +159,7 @@ describe('XUnitReporter', () => {
 
     describe('when there are no tests', () => it('should write empty suite', (done) => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}));
+      (new XUnitReporter(emitter, {}));
       emitter.emit('end', () => {
         assert.isOk(fsStub.writeFile.called);
         done();
@@ -203,7 +201,7 @@ describe('XUnitReporter', () => {
 
     it('should write a passing test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+      (new XUnitReporter(emitter, {}, 'test.xml'));
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -211,7 +209,7 @@ describe('XUnitReporter', () => {
 
     describe('when details=true', () => it('should write details for passing tests', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}, 'test.xml', true));
+      (new XUnitReporter(emitter, {}, 'test.xml', true));
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -232,7 +230,7 @@ describe('XUnitReporter', () => {
 
     it('should write a skipped test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+      (new XUnitReporter(emitter, {}, 'test.xml'));
       emitter.emit('test start', test);
       emitter.emit('test skip', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -253,7 +251,7 @@ describe('XUnitReporter', () => {
 
     it('should write a failed test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+      (new XUnitReporter(emitter, {}, 'test.xml'));
       emitter.emit('test start', test);
       emitter.emit('test fail', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -274,7 +272,7 @@ describe('XUnitReporter', () => {
 
     it('should write an error test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, {}, 'test.xml'));
+      (new XUnitReporter(emitter, {}, 'test.xml'));
       emitter.emit('test start', test);
       emitter.emit('test error', new Error('Error'), test);
       assert.isOk(fsStub.appendFileSync.called);


### PR DESCRIPTION
#### :rocket: Why this change?

The `this.tests` structure in Dredd.js is unused and unnecessary. This PR removes it from the codebase and all interfaces, mainly the reporters.

The change is a part of cleaning up Dredd class'es constructor, and there are also two additional changes. The reporters get configured and the proxy settings get logged in the `.run()` method, to keep the constructor without side effects. I had to fix Dredd.js unit tests because of that.

#### :memo: Related issues and Pull Requests

Factored out from https://github.com/apiaryio/dredd/pull/1289

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
