### PR TITLE
refactor: upgrades "winston" package, adjusts loggers

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,17 +1,19 @@
-const winston = require('winston');
+const { createLogger, transports, format } = require('winston');
 
-module.exports = new (winston.Logger)({
+module.exports = createLogger({
   transports: [
-    new (winston.transports.Console)({ colorize: true }),
+    new transports.Console({ colorize: true }),
   ],
   levels: {
     debug: 2,
     warn: 1,
     error: 0,
   },
-  colors: {
-    debug: 'cyan',
-    warn: 'yellow',
-    error: 'red',
-  },
+  format: format.colorize({
+    colors: {
+      debug: 'cyan',
+      warn: 'yellow',
+      error: 'red',
+    },
+  }),
 });

--- a/lib/reporters/reporterOutputLogger.js
+++ b/lib/reporters/reporterOutputLogger.js
@@ -1,8 +1,8 @@
-const winston = require('winston');
+const { createLogger, transports, format } = require('winston');
 
-module.exports = new (winston.Logger)({
+module.exports = createLogger({
   transports: [
-    new (winston.transports.Console)({ colorize: true, level: 'info' }),
+    new transports.Console({ colorize: true, level: 'info' }),
   ],
   levels: {
     info: 10,
@@ -17,17 +17,19 @@ module.exports = new (winston.Logger)({
     skip: 1,
     error: 0,
   },
-  colors: {
-    info: 'blue',
-    test: 'yellow',
-    pass: 'green',
-    fail: 'red',
-    complete: 'green',
-    actual: 'red',
-    expected: 'red',
-    hook: 'green',
-    request: 'green',
-    skip: 'yellow',
-    error: 'red',
-  },
+  format: format.colorize({
+    colors: {
+      info: 'blue',
+      test: 'yellow',
+      pass: 'green',
+      fail: 'red',
+      complete: 'green',
+      actual: 'red',
+      expected: 'red',
+      hook: 'green',
+      request: 'green',
+      skip: 'yellow',
+      error: 'red',
+    },
+  }),
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "untildify": "3.0.3",
     "uuid": "3.3.2",
     "which": "1.3.1",
-    "winston": "2.4.0"
+    "winston": "3.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "7.5.2",

--- a/test/unit/reporters/CLIReporter-test.js
+++ b/test/unit/reporters/CLIReporter-test.js
@@ -14,16 +14,6 @@ const CLIReporter = proxyquire('../../../lib/reporters/CLIReporter', {
 describe('CLIReporter', () => {
   let test = {};
 
-  before(() => {
-    loggerStub.transports.console.silent = true;
-    reporterOutputLoggerStub.transports.console.silent = true;
-  });
-
-  after(() => {
-    loggerStub.transports.console.silent = false;
-    reporterOutputLoggerStub.transports.console.silent = false;
-  });
-
   describe('when starting', () => {
     beforeEach(() => sinon.spy(loggerStub, 'debug'));
 


### PR DESCRIPTION
#### :rocket: Why this change?

Upgrades `winston` package to version 3. Follows the [migration guides](https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md) to adjust existing usage for breaking API changes of the `winston` package.

* Uses `winston.createLogger` instead of `winston.Logger`
* Removes deprecated `colors` field from the logger config
* Uses` format` field with `format.colorize()` for logs' colors (retains the previously set colors mapping)

#### :memo: Related issues and Pull Requests

- Closes #1225 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
