### PR TITLE
HTMLReporter: Add summary

### DIFF
--- a/lib/reporters/HTMLReporter.js
+++ b/lib/reporters/HTMLReporter.js
@@ -44,6 +44,16 @@ HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   });
 
   emitter.on('end', (callback) => {
+    this.buf += '\n---';
+    this.buf += `\n${title('Summary')}`;
+    this.buf += `\n**Tests completed:** ${this.stats.passes} passing,
+      ${this.stats.failures} failing,
+      ${this.stats.errors} errors,
+      ${this.stats.skipped} skipped,
+      ${this.stats.tests} total.
+    `;
+    this.buf += `\n\n**Tests took:** ${this.stats.duration}ms.`;
+
     const html = md.render(this.buf);
     makeDir(pathmodule.dirname(this.path))
       .then(() => {


### PR DESCRIPTION
#### :rocket: Why this change?

Adds a summary section to the HTMLReporter output.

#### :memo: Related issues and Pull Requests

* Fixes #1001 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests (currently no integration tests to assert UI elements on HTMLReporter output)
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
