### PR TITLE
Use explicit variable names

### DIFF
--- a/lib/performRequest.js
+++ b/lib/performRequest.js
@@ -5,7 +5,7 @@ const defaultLogger = require('./logger');
 
 
 /**
- * Performs the HTTP request as described in the 'transaction.request' object.
+ * Performs the HTTP request as described in the 'transaction.request' object
  *
  * In future we should introduce a 'real' request object as well so user has
  * access to the modifications made on the way.
@@ -19,9 +19,7 @@ const defaultLogger = require('./logger');
  * @param {Function} callback
  */
 function performRequest(uri, transactionReq, options, callback) {
-  if (typeof options === 'function') {
-    [options, callback] = [{}, options];
-  }
+  if (typeof options === 'function') { [options, callback] = [{}, options]; }
   const logger = options.logger || defaultLogger;
   const request = options.request || defaultRequest;
 
@@ -40,12 +38,12 @@ function performRequest(uri, transactionReq, options, callback) {
     logger.debug(`Performing ${protocol} request to the server under test: `
       + `${httpOptions.method} ${httpOptions.uri}`);
 
-    request(httpOptions, (error, res, resBody) => {
+    request(httpOptions, (error, response, responseBody) => {
       logger.debug(`Handling ${protocol} response from the server under test`);
       if (error) {
         callback(error);
       } else {
-        callback(null, createTransactionResponse(res, resBody));
+        callback(null, createTransactionResponse(response, responseBody));
       }
     });
   } catch (error) {
@@ -122,13 +120,13 @@ function normalizeContentLengthHeader(headers, body, options = {}) {
  * Real transaction response object factory. Serializes binary responses
  * to string using Base64 encoding.
  *
- * @param {Object} res Node.js HTTP response
+ * @param {Object} response Node.js HTTP response
  * @param {Buffer} body HTTP response body as Buffer
  */
-function createTransactionResponse(res, body) {
+function createTransactionResponse(response, body) {
   const transactionRes = {
-    statusCode: res.statusCode,
-    headers: Object.assign({}, res.headers),
+    statusCode: response.statusCode,
+    headers: Object.assign({}, response.headers),
   };
   if (Buffer.byteLength(body || '')) {
     transactionRes.bodyEncoding = detectBodyEncoding(body);


### PR DESCRIPTION
#### :rocket: Why this change?

Because I think `response` is better than `res`.

#### :memo: Related issues and Pull Requests

Factored out from https://github.com/apiaryio/dredd/pull/1289/

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
