### PR TITLE
Ignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules
 cov.*
 *.log
 .env*
+__pycache__
 
 # Regardless the rules above, never ignore following
 !.vscode/launch.json


### PR DESCRIPTION
#### :rocket: Why this change?

Not to accidentally commit `__pycache__` directories.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
