### PR TITLE
test: uses "hasAllKeys" for order-insensitive keys assertion

### DIFF
--- a/test/integration/sanitation-test.js
+++ b/test/integration/sanitation-test.js
@@ -455,7 +455,7 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(events[2].test.status, 'fail');
       assert.include(events[2].test.results.general.results[0].message.toLowerCase(), 'fail');
     });
-    it('emitted test data results contain just \'general\' section', () => assert.deepEqual(Object.keys(events[2].test.results), ['general']));
+    it('emitted test data results contain just \'general\' section', () => assert.hasAllKeys(events[2].test.results, ['general']));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -494,7 +494,7 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(events[2].test.status, 'fail');
       assert.include(events[2].test.results.general.results[0].message.toLowerCase(), 'fail');
     });
-    it('emitted test data results contain all regular sections', () => assert.deepEqual(Object.keys(events[2].test.results), ['general', 'headers', 'body', 'statusCode']));
+    it('emitted test data results contain all regular sections', () => assert.hasAllKeys(events[2].test.results, ['general', 'headers', 'body', 'statusCode']));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -530,7 +530,7 @@ describe('Sanitation of Reported Data', () => {
     ]));
     it('emitted test is skipped', () => {
       assert.equal(events[2].test.status, 'skip');
-      assert.deepEqual(Object.keys(events[2].test.results), ['general']);
+      assert.hasAllKeys(events[2].test.results, ['general']);
       assert.include(events[2].test.results.general.results[0].message.toLowerCase(), 'skip');
     });
     it('sensitive data cannot be found anywhere in the emitted test data', () => {


### PR DESCRIPTION
#### :rocket: Why this change?

Uses `hasAllKeys` for assertion of validation results object keys in sanitization tests. Makes assertion order-insensitive, improving the tests' sustainability. Also fixes a logical flaw where object's keys are asserted in specific order.

#### :memo: Related issues and Pull Requests

- Fixes #1368 

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
