### PR TITLE
fix: uses explicit validation result sections list for logging output

### DIFF
--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -573,15 +573,18 @@ include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
         let message = '';
         const object = gavelResult || {};
         let validatorOutput;
-        for (const sectionName of Object.keys(object || {})) {
-          // Section names are 'statusCode', 'headers', 'body' (and 'version', which is irrelevant)
+
+        // Order-sensitive list of validation sections to output in the log
+        const resultSections = ['headers', 'body', 'statusCode']
+          .filter(sectionName => Object.prototype.hasOwnProperty.call(object, sectionName));
+
+        resultSections.forEach((sectionName) => {
           validatorOutput = object[sectionName];
-          if (sectionName !== 'version') {
-            for (const gavelError of validatorOutput.results || []) {
-              message += `${sectionName}: ${gavelError.message}\n`;
-            }
-          }
-        }
+          (validatorOutput.results || []).forEach((gavelError) => {
+            message += `${sectionName}: ${gavelError.message}\n`;
+          });
+        });
+
         test.message = message;
 
         // Record raw validation output to transaction results object


### PR DESCRIPTION
#### :rocket: Why this change?

Introduces an explicit list of validation result sections to be present in the Dredd's transaction runner output. This allows Dredd to be independent from Gavel's validation order, and also makes it resilient to new Gavel releases.

#### :memo: Related issues and Pull Requests

- Fixes #1371

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
