### PR TITLE
Do not initiate hooks if there are no hookfiles

### DIFF
--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -42,6 +42,11 @@ module.exports = function addHooks(runner, transactions, callback) {
     runner.hooks.transactions[transaction.name] = transaction;
   });
 
+  // No hooks
+  if (!runner.configuration.hookfiles || !runner.configuration.hookfiles.length) {
+    return callback();
+  }
+
   // Loading hookfiles from fs
   let hookfiles;
   try {

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -74,12 +74,26 @@ describe('addHooks()', () => {
 
   it('sets transactionRunner.hooks.configuation', (done) => {
     const transactionRunner = createTransactionRunner();
+    transactionRunner.configuration.hookfiles = [
+      './hooks.js',
+    ];
 
     addHooks(transactionRunner, [], (err) => {
       assert.deepEqual(
         transactionRunner.hooks.configuration,
         transactionRunner.configuration
       );
+      done(err);
+    });
+  });
+
+  it('skips hooks loading when there are no hookfiles', (done) => {
+    const transactionRunner = createTransactionRunner();
+    transactionRunner.configuration.hookfiles = [];
+    transactionRunner.configuration.language = 'python';
+
+    addHooks(transactionRunner, [], (err) => {
+      assert.isUndefined(transactionRunner.hooks.configuration);
       done(err);
     });
   });


### PR DESCRIPTION
#### :rocket: Why this change?

I believe it is a regression. @kylef had to work around it when upgrading Dredd in https://github.com/apiaryio/polls-api/pull/66/commits/4f66c3409757f241334473ed2d13fba0f5c7142a

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/polls-api/pull/66

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
