### PR TITLE
fix: coerces "server" option to "endpoint"

### DIFF
--- a/lib/configuration/applyConfiguration.js
+++ b/lib/configuration/applyConfiguration.js
@@ -50,22 +50,26 @@ const DEFAULT_CONFIG = {
 // a breaking change to the library's public API.
 // TODO https://github.com/apiaryio/dredd/issues/1344
 function flattenConfig(config) {
-  const proxiedConfig = R.compose(
-    // Rename root "server" key to "endpoint".
-    // Necessary to prevent options values collision, as:
-    // - root.server - stands for server url.
-    // - options.server - stands for a server command (i.e. "npm start").
-    // - options.endpoint - semantically the same as "root.server"
-    // When merged, these values must not be overriden.
-    R.dissoc('server'),
-    R.over(
-      R.lens(R.prop('server'), R.assoc('endpoint')),
-      R.identity
+  // Rename "root.server" key to "root.endpoint".
+  // Necessary to prevent options values collision between:
+  // - root.server - stands for server url.
+  // - options.server - stands for a server command (i.e. "npm start").
+  // - options.endpoint - semantically the same as "root.server"
+  //
+  // NOTE It's important to rename the option here, as when flattened
+  // there is no difference between "root.server" and "options.server"
+  // which serve entirely different purposes. Thus it cannot be coerced
+  // on the normalization layer.
+  const aliasedConfig = R.when(
+    R.has('server'),
+    R.compose(
+      R.dissoc('server'),
+      R.assoc('endpoint', R.prop('server', config))
     )
   )(config);
 
-  const nestedOptions = R.prop('options', proxiedConfig);
-  const rootOptions = R.omit(['server', 'options'], proxiedConfig);
+  const rootOptions = R.omit(['options'], aliasedConfig);
+  const nestedOptions = R.prop('options', aliasedConfig);
 
   if (nestedOptions) {
     logger.warn('Deprecated usage of `options` in Dredd configuration.');

--- a/lib/configuration/normalizeConfig.js
+++ b/lib/configuration/normalizeConfig.js
@@ -166,16 +166,11 @@ const normalizeConfig = R.compose(
 );
 
 normalizeConfig.removeUnsupportedOptions = removeUnsupportedOptions;
-
-normalizeConfig.removeUnsupportedOptions = removeUnsupportedOptions;
-
 normalizeConfig.coerceToArray = coerceToArray;
 normalizeConfig.coerceToBoolean = coerceToBoolean;
-
 normalizeConfig.coerceUserOption = coerceUserOption;
 normalizeConfig.coerceApiDescriptions = coerceApiDescriptions;
 normalizeConfig.coerceColorOption = coerceColorOption;
-
 normalizeConfig.coerceDeprecatedLevelOption = coerceDeprecatedLevelOption;
 normalizeConfig.coerceDeprecatedDataOption = coerceDeprecatedDataOption;
 

--- a/test/integration/configuration/resolveConfig-test.js
+++ b/test/integration/configuration/resolveConfig-test.js
@@ -58,6 +58,20 @@ describe('resolveConfig()', () => {
 
   // Options
   describe('option: server', () => {
+    describe('when no "server" set', () => {
+      const { config: nextConfig } = resolveConfig({
+        path: [],
+      });
+
+      it('has default "endpoint" option value', () => {
+        assert.propertyVal(nextConfig, 'endpoint', DEFAULT_CONFIG.endpoint);
+      });
+
+      it('has no "server" option', () => {
+        assert.notProperty(nextConfig, 'server');
+      });
+    });
+
     describe('when "server" set', () => {
       const { config: nextConfig } = resolveConfig({
         server: 'http://127.0.0.1',


### PR DESCRIPTION
#### :rocket: Why this change?

- Moves coercion of `server` option from `flattenConfig` to `normalizeConfig`
- Explicitly checks `R.has('server')` to prevent erazing the value of `endpoint`, which acts as a target of the value coercion

#### :memo: Related issues and Pull Requests

- Fixes #1370 

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests (8275b6e)
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
