### PR TITLE
feat: removes "gavel.isValid" calls

### DIFF
--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -528,11 +528,11 @@ Not performing HTTP request for '${transaction.name}'.\
 
   validateTransaction(test, transaction, callback) {
     logger.debug('Validating HTTP transaction by Gavel.js');
-    logger.debug('Determining whether HTTP transaction is valid (getting boolean verdict)');
-    gavel.isValid(transaction.real, transaction.expected, 'response', (isValidError, isValid) => {
-      if (isValidError) {
-        logger.debug('Gavel.js validation errored:', isValidError);
-        this.emitError(isValidError, test);
+
+    gavel.validate(transaction.real, transaction.expected, 'response', (validateError, gavelResult) => {
+      if (validateError) {
+        logger.debug('Gavel.js validation errored:', validateError);
+        this.emitError(validateError, test);
       }
 
       test.title = transaction.id;
@@ -540,90 +540,84 @@ Not performing HTTP request for '${transaction.name}'.\
       test.expected = transaction.expected;
       test.request = transaction.request;
 
+      const isValid = gavelResult ? gavelResult.isValid : false;
+
       if (isValid) {
         test.status = 'pass';
       } else {
         test.status = 'fail';
       }
 
-      logger.debug('Validating HTTP transaction (getting verbose validation result)');
-      gavel.validate(transaction.real, transaction.expected, 'response', (validateError, gavelResult) => {
-        if (!isValidError && validateError) {
-          logger.debug('Gavel.js validation errored:', validateError);
-          this.emitError(validateError, test);
-        }
-
-        // Warn about empty responses
-        // Expected is as string, actual is as integer :facepalm:
-        const isExpectedResponseStatusCodeEmpty = ['204', '205'].includes(
-          test.expected.statusCode ? test.expected.statusCode.toString() : undefined
-        );
-        const isActualResponseStatusCodeEmpty = ['204', '205'].includes(
-          test.actual.statusCode ? test.actual.statusCode.toString() : undefined
-        );
-        const hasBody = (test.expected.body || test.actual.body);
-        if ((isExpectedResponseStatusCodeEmpty || isActualResponseStatusCodeEmpty) && hasBody) {
-          logger.warn(`\
+      // Warn about empty responses
+      // Expected is as string, actual is as integer :facepalm:
+      const isExpectedResponseStatusCodeEmpty = ['204', '205'].includes(
+        test.expected.statusCode ? test.expected.statusCode.toString() : undefined
+      );
+      const isActualResponseStatusCodeEmpty = ['204', '205'].includes(
+        test.actual.statusCode ? test.actual.statusCode.toString() : undefined
+      );
+      const hasBody = (test.expected.body || test.actual.body);
+      if ((isExpectedResponseStatusCodeEmpty || isActualResponseStatusCodeEmpty) && hasBody) {
+        logger.warn(`\
 ${test.title} HTTP 204 and 205 responses must not \
 include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
 `);
-        }
+      }
 
-        // Create test message from messages of all validation errors
-        let message = '';
-        const object = gavelResult || {};
-        let validatorOutput;
+      // Create test message from messages of all validation errors
+      let message = '';
+      const object = gavelResult || {};
+      let validatorOutput;
 
-        // Order-sensitive list of validation sections to output in the log
-        const resultSections = ['headers', 'body', 'statusCode']
-          .filter(sectionName => Object.prototype.hasOwnProperty.call(object, sectionName));
+      // Order-sensitive list of validation sections to output in the log
+      const resultSections = ['headers', 'body', 'statusCode']
+        .filter(sectionName => Object.prototype.hasOwnProperty.call(object, sectionName));
 
-        resultSections.forEach((sectionName) => {
-          validatorOutput = object[sectionName];
-          (validatorOutput.results || []).forEach((gavelError) => {
-            message += `${sectionName}: ${gavelError.message}\n`;
-          });
+      resultSections.forEach((sectionName) => {
+        validatorOutput = object[sectionName];
+        (validatorOutput.results || []).forEach((gavelError) => {
+          message += `${sectionName}: ${gavelError.message}\n`;
         });
-
-        test.message = message;
-
-        // Record raw validation output to transaction results object
-        //
-        // It looks like the transaction object can already contain 'results'.
-        // (Needs to be prooved, the assumption is based just on previous
-        // version of the code.) In that case, we want to save the new validation
-        // output, but we want to keep at least the original array of Gavel errors.
-        const results = transaction.results || {};
-        for (const sectionName of Object.keys(gavelResult || {})) {
-          // Section names are 'statusCode', 'headers', 'body' (and 'version', which is irrelevant)
-          const rawValidatorOutput = gavelResult[sectionName];
-          if (sectionName !== 'version') {
-            if (!results[sectionName]) { results[sectionName] = {}; }
-
-            // We don't want to modify the object and we want to get rid of some
-            // custom Gavel.js types ('clone' will keep just plain JS objects).
-            validatorOutput = clone(rawValidatorOutput);
-
-            // If transaction already has the 'results' object, ...
-            if (results[sectionName].results) {
-              // ...then take all Gavel errors it contains and add them to the array
-              // of Gavel errors in the new validator output object...
-              validatorOutput.results = validatorOutput.results.concat(results[sectionName].results);
-            }
-            // ...and replace the original validator object with the new one.
-            results[sectionName] = validatorOutput;
-          }
-        }
-        transaction.results = results;
-
-        // Set the validation results and the boolean verdict to the test object
-        test.results = transaction.results;
-        test.valid = isValid;
-
-        // Propagate test object so 'after' hooks can modify it
-        transaction.test = test;
-        callback();
       });
+
+      test.message = message;
+
+      // Record raw validation output to transaction results object
+      //
+      // It looks like the transaction object can already contain 'results'.
+      // (Needs to be prooved, the assumption is based just on previous
+      // version of the code.) In that case, we want to save the new validation
+      // output, but we want to keep at least the original array of Gavel errors.
+      const results = transaction.results || {};
+      for (const sectionName of Object.keys(gavelResult || {})) {
+        // Section names are 'statusCode', 'headers', 'body' (and 'version', which is irrelevant)
+        const rawValidatorOutput = gavelResult[sectionName];
+        if (sectionName !== 'version') {
+          if (!results[sectionName]) { results[sectionName] = {}; }
+
+          // We don't want to modify the object and we want to get rid of some
+          // custom Gavel.js types ('clone' will keep just plain JS objects).
+          validatorOutput = clone(rawValidatorOutput);
+
+          // If transaction already has the 'results' object, ...
+          if (results[sectionName].results) {
+            // ...then take all Gavel errors it contains and add them to the array
+            // of Gavel errors in the new validator output object...
+            validatorOutput.results = validatorOutput.results.concat(results[sectionName].results);
+          }
+          // ...and replace the original validator object with the new one.
+          results[sectionName] = validatorOutput;
+        }
+      }
+      transaction.results = results;
+
+      // Set the validation results and the boolean verdict to the test object
+      test.results = transaction.results;
+      test.valid = isValid;
+
+      // Propagate test object so 'after' hooks can modify it
+      transaction.test = test;
+      callback();
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clone": "2.1.2",
     "cross-spawn": "6.0.5",
     "dredd-transactions": "8.1.3",
-    "gavel": "3.1.2",
+    "gavel": "3.2.0",
     "glob": "7.1.4",
     "html": "1.0.0",
     "htmlencode": "0.0.4",

--- a/test/integration/sanitation-test.js
+++ b/test/integration/sanitation-test.js
@@ -494,7 +494,7 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(events[2].test.status, 'fail');
       assert.include(events[2].test.results.general.results[0].message.toLowerCase(), 'fail');
     });
-    it('emitted test data results contain all regular sections', () => assert.hasAllKeys(events[2].test.results, ['general', 'headers', 'body', 'statusCode']));
+    it('emitted test data results contain all regular sections', () => assert.hasAllKeys(events[2].test.results, ['isValid', 'general', 'headers', 'body', 'statusCode']));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);


### PR DESCRIPTION
#### :rocket: Why this change?

- Removes [deprecated `gavel.isValid(https://github.com/apiaryio/gavel.js/issues/166)` method]() usage from Dredd.
- Consequentially, improves performance by validating transaction once, as opposed to twice previously (`gavel.isValid()` used to validate a transaction, but share no results with you).

#### :memo: Related issues and Pull Requests

- Changes are a part of Gavel upgrades and have no corresponding Dredd issue I'm aware of

#### :white_check_mark: What didn't I forget?

- [x] To write docs (no need, no public API changes)
- [x] To write tests (tests adjusted)
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
