### PR TITLE
fix: using "apiaryApiKey" and "apiaryApiName" from dredd.yml config

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -331,7 +331,11 @@ ${packageData.name} v${packageData.version} \
     if (!cliConfig.path) { cliConfig.path = []; }
     cliConfig.path.push(this.argv._[0]);
 
-    cliConfig.custom = this.custom;
+    // Merge "this.custom" which is an input of CLI constructor
+    // (used for internal testing), and "cliConfig" which is a result
+    // of merge upon "argv". Otherwise "custom" key from "dredd.yml"
+    // is always overridden by "this.custom".
+    cliConfig.custom = R.mergeDeepRight(this.custom, cliConfig.custom || {});
 
     return cliConfig;
   }


### PR DESCRIPTION
#### :rocket: Why this change?
To fix dredd.yml config usage

#### :memo: Related issues and Pull Requests
https://github.com/apiaryio/dredd/issues/1377

#### :white_check_mark: What didn't I forget?

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
