### PR TITLE
docs: remove david dm

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Dredd — HTTP API Testing Framework
 ==================================
 
-|npm version| |Build Status| |Windows Build Status| |Dependency Status| |devDependency Status| |Documentation Status| |Coverage Status| |Known Vulnerabilities|
+|npm version| |Build Status| |Windows Build Status| |Documentation Status| |Coverage Status| |Known Vulnerabilities|
 
 .. figure:: _static/images/dredd.png
    :alt: Dredd - HTTP API Testing Framework
@@ -80,10 +80,6 @@ Example Applications
    :target: https://travis-ci.org/apiaryio/dredd
 .. |Windows Build Status| image:: https://ci.appveyor.com/api/projects/status/n3ixfxh72qushyr4/branch/master?svg=true
    :target: https://ci.appveyor.com/project/Apiary/dredd/branch/master
-.. |Dependency Status| image:: https://david-dm.org/apiaryio/dredd.svg
-   :target: https://david-dm.org/apiaryio/dredd
-.. |devDependency Status| image:: https://david-dm.org/apiaryio/dredd/dev-status.svg
-   :target: https://david-dm.org/apiaryio/dredd?type=dev
 .. |Documentation Status| image:: https://readthedocs.org/projects/dredd/badge/?version=latest
    :target: https://readthedocs.org/projects/dredd/builds/
 .. |Coverage Status| image:: https://coveralls.io/repos/apiaryio/dredd/badge.svg?branch=master

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -143,7 +143,7 @@ When dropping support for a certain Node.js version, it should be removed from t
 Dependencies
 ~~~~~~~~~~~~
 
-New versions of dependencies are monitored by `David <https://david-dm.org/apiaryio/dredd>`__ and `Greenkeeper <https://greenkeeper.io/>`__. Vulnerabilities are monitored by `Snyk <https://snyk.io/test/npm/dredd>`__.
+New versions of dependencies are monitored by `Dependabot <https://dependabot.com/>`__. Vulnerabilities are monitored by `Snyk <https://snyk.io/test/npm/dredd>`__.
 
 Dependencies should not be specified in a loose way - only exact versions are allowed. This is ensured by ``.npmrc`` and the lock file. Any changes to dependencies (version upgrades included) are a subject to internal policies and must be first checked and approved by the maintainers before merged to ``master``. This is because we are trying to be good Open Source citizens and to do our best to comply with licenses of all our dependencies.
 


### PR DESCRIPTION
#### :rocket: Why this change?

We use other tools now to monitor dependencies and the links to David stopped to work.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
