### PR TITLE
Installs "python@3.6" explicitly during the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ jobs:
       env: "JOB=quality_checks"
       before_install:
         - "npm install npm@6 --global"
-        - "pyenv global 3.6"
+        - "pyenv install 3.6.3"
+        - "pyenv global 3.6.3"
         - "pip install pip --upgrade"
       install:
         - "npm install --no-save"
@@ -26,7 +27,8 @@ jobs:
     - env: "JOB=docs_build_dry_run"
       before_install:
         - "npm install npm@6 --global"
-        - "pyenv global 3.6"
+        - "pyenv install 3.6.3"
+        - "pyenv global 3.6.3"
         - "pip install pip --upgrade"
       install:
         - "npm install --no-save"


### PR DESCRIPTION
#### :rocket: Why this change?

Current Travis CI build fails due to inability to run `pyenv global 3.6`. The mentioned version doesn't appear to be properly installed (most likely for a third-party reason). This pull request installs an explicit `pyenv` version and uses it throughout the build.

#### :memo: Related issues and Pull Requests

- Fixes #1448 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
