### PR TITLE
docs: removes links to "ApiaryReportingAnonymous.apib"

### DIFF
--- a/docs/data-structures.rst
+++ b/docs/data-structures.rst
@@ -175,7 +175,7 @@ Apiary Reporter Test Data (object)
 Internal Apiary Data Structures
 -------------------------------
 
-These are private data structures used in Apiary internally and they are documented incompletely. They’re present in this document just to provide better insight on what and how Apiary internally saves. It is closely related to what you can see in documentation for `Apiary Tests API for anonymous test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApiAnonymous.apib>`__ and `Apiary Tests API for authenticated test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApi.apib>`__.
+These are private data structures used in Apiary internally and they are documented incompletely. They’re present in this document just to provide better insight on what and how Apiary internally saves. It is closely related to what you can see in documentation for `Apiary Tests API for authenticated test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApi.apib>`__.
 
 .. _apiary-test-run:
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -196,10 +196,7 @@ Hacking Apiary reporter
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to build something on top of the Apiary Reporter, note that
-it uses a public API described in following documents:
-
--  `Apiary Tests API for anonymous test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApiAnonymous.apib>`__
--  `Apiary Tests API for authenticated test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApi.apib>`__
+it uses a public API described in `Apiary Tests API for authenticated test reports <https://github.com/apiaryio/dredd/blob/master/ApiaryReportingApi.apib>`__
 
 Following data are sent over the wire to Apiary:
 


### PR DESCRIPTION
#### :rocket: Why this change?

- Some of the documentation links still point to the removed `ApiaryReportingAnonymous.apib` file. They must be updated.

#### :memo: Related issues and Pull Requests

- Fixes #1472 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests (not applicable)
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
