### PR TITLE
Add extension for detecting broken links to Dredd's repository

### DIFF
--- a/docs/_extensions/ghlink_check.py
+++ b/docs/_extensions/ghlink_check.py
@@ -1,0 +1,61 @@
+import unittest
+from pathlib import Path
+from urllib.parse import urlparse
+
+import docutils
+from sphinx.util import logging
+
+
+def check_uri(uri):
+    if 'github.com/apiaryio/dredd/blob/master' in uri:
+        path = Path(urlparse(uri).path
+                    .replace('apiaryio/dredd/blob/master', '.').lstrip('/'))
+        return path.exists()
+    return True
+
+
+def ghlink_check(app, doctree, docname):
+    uris = filter(None, (
+        reference.get('refuri') for reference
+        in doctree.traverse(docutils.nodes.reference)
+    ))
+
+    logger = logging.getLogger(__name__)
+    for uri in uris:
+        if not check_uri(uri):
+            logger.error("Broken link in '%s': %s", docname, uri)
+
+
+def setup(app):
+    app.connect('doctree-resolved', ghlink_check)
+    return {'version': '1.0', 'parallel_read_safe': True}
+
+
+class Tests(unittest.TestCase):
+    def test_local(self):
+        self.assertTrue(check_uri('page.html#usage'))
+
+    def test_external(self):
+        self.assertTrue(check_uri('https://apiblueprint.org'))
+
+    def test_github(self):
+        self.assertTrue(check_uri('https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md'))
+
+    def test_relevant_github_repo_but_irrelevant_path(self):
+        self.assertTrue(check_uri('https://github.com/apiaryio/dredd/issues/820'))
+
+    def test_local_github_project_root_without_slash(self):
+        self.assertTrue(check_uri('https://github.com/apiaryio/dredd/blob/master'))
+
+    def test_local_github_project_root_with_slash(self):
+        self.assertTrue(check_uri('https://github.com/apiaryio/dredd/blob/master/'))
+
+    def test_local_github_existing(self):
+        self.assertTrue(check_uri('https://github.com/apiaryio/dredd/blob/master/README.md'))
+
+    def test_local_github_missing(self):
+        self.assertFalse(check_uri('https://github.com/apiaryio/dredd/blob/master/foo/bar/doesnt-exist'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'cli_options',
     'ghissue',
     'specs',
+    'ghlink_check',
 ]
 
 # The suffix(es) of source filenames.


### PR DESCRIPTION
### :rocket: Why this change?

It can happen that a file, which is linked by an absolute GitHub link from the docs, is removed from a development branch. Such link passes as not broken with the existing link check, but when a PR with such branch gets merged into master, the file disappears and the link gets broken (and master build gets broken). This commit introduces a simple extension to prevent that.

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd/issues/1472

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
