### PR TITLE
Fix the prefix, py deps are used only for docs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,6 +15,6 @@ update_configs:
     default_labels:
       - "dependencies"
     commit_message:
-      prefix: "fix"
+      prefix: "chore"
       prefix_development: "chore"
       include_scope: true


### PR DESCRIPTION
#### :rocket: Why this change?

Because https://github.com/apiaryio/dredd/releases/tag/v12.0.1

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
