### PR TITLE
fix: ensures skipped test inherits transaction data

### DIFF
--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -332,20 +332,16 @@ class TransactionRunner {
     };
   }
 
-  ensureTestStructure(test, transaction) {
-    return {
-      ...test,
-
-      // If a test is skipped the data below will never be set on it.
-      // This makes a skipped test not inspectable in the Apiary repoter.
-      request: transaction.request,
-      actual: transaction.actual,
-      expected: transaction.expected,
-
-      // Ensure transaction errors are propagates to the test.
-      // That way transaction errors are a part of an Apiary Reporter.
-      errors: transaction.errors,
-    };
+  // Purposely side-effectish method to ensure "transaction.test"
+  // inherits data from the "transaction".
+  // Necessary when a test is skipped/failed to contain
+  // transaction information that is otherwise missing.
+  ensureTestStructure(transaction) {
+    transaction.test.request = transaction.request;
+    transaction.test.expected = transaction.expected;
+    transaction.test.actual = transaction.actual;
+    transaction.test.errors = transaction.errors;
+    transaction.test.results = transaction.results;
   }
 
   // Marks the transaction as failed and makes sure everything in the transaction
@@ -361,9 +357,7 @@ class TransactionRunner {
     transaction.test.status = 'fail';
     if (reason) { transaction.test.message = reason; }
 
-    transaction.test = this.ensureTestStructure(transaction.test, transaction);
-
-    return transaction.results;
+    this.ensureTestStructure(transaction);
   }
 
   // Marks the transaction as skipped and makes sure everything in the transaction
@@ -380,9 +374,7 @@ class TransactionRunner {
     transaction.test.status = 'skip';
     if (reason) { transaction.test.message = reason; }
 
-    transaction.test = this.ensureTestStructure(transaction.test, transaction);
-
-    return transaction.results;
+    this.ensureTestStructure(transaction);
   }
 
   // Ensures that given transaction object has the "errors" key

--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -332,6 +332,22 @@ class TransactionRunner {
     };
   }
 
+  ensureTestStructure(test, transaction) {
+    return {
+      ...test,
+
+      // If a test is skipped the data below will never be set on it.
+      // This makes a skipped test not inspectable in the Apiary repoter.
+      request: transaction.request,
+      actual: transaction.actual,
+      expected: transaction.expected,
+
+      // Ensure transaction errors are propagates to the test.
+      // That way transaction errors are a part of an Apiary Reporter.
+      errors: transaction.errors,
+    };
+  }
+
   // Marks the transaction as failed and makes sure everything in the transaction
   // object is set accordingly. Typically this would be invoked when transaction
   // runner decides to force a transaction to behave as failed.
@@ -344,18 +360,10 @@ class TransactionRunner {
     if (!transaction.test) { transaction.test = this.createTest(transaction); }
     transaction.test.status = 'fail';
     if (reason) { transaction.test.message = reason; }
-    let results;
-    if (transaction.test.results) {
-      results = transaction.test.results;
-    } else {
-      results = transaction.test.results = transaction.results;
-    }
 
-    // Ensure transaction errors are propagates to the test.
-    // That way transaction errors are a part of an Apiary Reporter.
-    transaction.test.errors = transaction.errors;
+    transaction.test = this.ensureTestStructure(transaction.test, transaction);
 
-    return results;
+    return transaction.results;
   }
 
   // Marks the transaction as skipped and makes sure everything in the transaction
@@ -366,21 +374,15 @@ class TransactionRunner {
     this.ensureTransactionErrors(transaction);
     if (reason) { transaction.errors.push({ severity: 'warning', message: reason }); }
 
-    if (!transaction.test) { transaction.test = this.createTest(transaction); }
+    if (!transaction.test) {
+      transaction.test = this.createTest(transaction);
+    }
     transaction.test.status = 'skip';
     if (reason) { transaction.test.message = reason; }
-    let results;
-    if (transaction.test.results) {
-      results = transaction.test.results;
-    } else {
-      results = transaction.test.results = transaction.results;
-    }
 
-    // Ensure transaction errors propagate to the test.
-    // That way transaction errors can make it to reporters.
-    transaction.test.errors = transaction.errors;
+    transaction.test = this.ensureTestStructure(transaction.test, transaction);
 
-    return results;
+    return transaction.results;
   }
 
   // Ensures that given transaction object has the "errors" key

--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -339,7 +339,7 @@ class TransactionRunner {
   ensureTestStructure(transaction) {
     transaction.test.request = transaction.request;
     transaction.test.expected = transaction.expected;
-    transaction.test.actual = transaction.actual;
+    transaction.test.actual = transaction.real;
     transaction.test.errors = transaction.errors;
     transaction.test.results = transaction.results;
   }

--- a/test/unit/transactionRunner-test.js
+++ b/test/unit/transactionRunner-test.js
@@ -514,13 +514,13 @@ describe('TransactionRunner', () => {
         done(err);
       }));
 
-      it('should add skip message as a warning under `general` to the results on transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
+      it('should add skip message as a warning under `errors` to the results on transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
         const messages = clonedTransaction.errors.map(value => value.message);
         assert.include(messages.join().toLowerCase(), 'skipped');
         done(err);
       }));
 
-      it('should add fail message as a warning under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
+      it('should add fail message as a warning under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
         const messages = [];
         const { callCount } = configuration.emitter.emit;
         for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -542,6 +542,13 @@ describe('TransactionRunner', () => {
         assert.equal(tests.length, 1);
         assert.equal(tests[0].status, 'skip');
         done(err);
+      }));
+
+      it('should set transaction info on the skipped test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+        assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
+        assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
+        assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
+        done();
       }));
     });
 
@@ -1604,6 +1611,13 @@ describe('TransactionRunner', () => {
         assert.isOk(configuration.emitter.emit.calledWith('test error'));
         done();
       }));
+
+      it('should set transaction info on the errored test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+        assert.propertyVal(transaction.test, 'request', transaction.request);
+        assert.propertyVal(transaction.test, 'expected', transaction.expected);
+        assert.propertyVal(transaction.test, 'actual', transaction.real);
+        done();
+      }));
     });
 
     describe('with ‘after’ hook that throws an error', () => {
@@ -1621,6 +1635,13 @@ describe('TransactionRunner', () => {
 
       it('should report an error with the test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
         assert.isOk(configuration.emitter.emit.calledWith('test error'));
+        done();
+      }));
+
+      it('should set transaction info on the errored test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+        assert.propertyVal(transaction.test, 'request', transaction.request);
+        assert.propertyVal(transaction.test, 'expected', transaction.expected);
+        assert.propertyVal(transaction.test, 'actual', transaction.real);
         done();
       }));
     });
@@ -1648,13 +1669,13 @@ describe('TransactionRunner', () => {
         done();
       }));
 
-      it('should add fail message as a error under `general` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+      it('should add fail message as a error under `errors` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
         const messages = transaction.errors.map(value => value.message);
         assert.include(messages.join(), 'expected false to be truthy');
         done();
       }));
 
-      it('should add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+      it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
         const messages = [];
         const { callCount } = configuration.emitter.emit;
         for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -1663,6 +1684,13 @@ describe('TransactionRunner', () => {
           ));
         }
         assert.include(messages.join(), 'expected false to be truthy');
+        done();
+      }));
+
+      it('should set transaction info on the failed test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+        assert.propertyVal(transaction.test, 'request', transaction.request);
+        assert.propertyVal(transaction.test, 'expected', transaction.expected);
+        assert.propertyVal(transaction.test, 'actual', transaction.real);
         done();
       }));
     });
@@ -1695,13 +1723,13 @@ describe('TransactionRunner', () => {
         done();
       }));
 
-      it('should add fail message as a error under `general` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+      it('should add fail message as a error under `errors` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
         const messages = transaction.errors.map(value => value.message);
         assert.include(messages.join(), 'expected false to be truthy');
         done();
       }));
 
-      it('should add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+      it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
         const messages = [];
         const { callCount } = configuration.emitter.emit;
         for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -1710,6 +1738,13 @@ describe('TransactionRunner', () => {
           ));
         }
         assert.include(messages.join(), 'expected false to be truthy');
+        done();
+      }));
+
+      it('should set transaction info on the failed test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
+        assert.propertyVal(transaction.test, 'request', transaction.request);
+        assert.propertyVal(transaction.test, 'expected', transaction.expected);
+        assert.propertyVal(transaction.test, 'actual', transaction.real);
         done();
       }));
     });
@@ -1759,13 +1794,13 @@ describe('TransactionRunner', () => {
           done();
         }));
 
-        it('should add fail message as a error under `general` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+        it('should add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
           const messages = clonedTransaction.errors.map(value => value.message);
           assert.include(messages.join(), 'Message before');
           done();
         }));
 
-        it('should add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+        it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
           const messages = [];
           const { callCount } = configuration.emitter.emit;
           for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -1774,6 +1809,13 @@ describe('TransactionRunner', () => {
             ));
           }
           assert.include(messages.join(), 'Message before');
+          done();
+        }));
+
+        it('should set transaction info on the failed test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+          assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
+          assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
+          assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
           done();
         }));
 
@@ -1808,13 +1850,13 @@ describe('TransactionRunner', () => {
             done();
           }));
 
-          it('should not add fail message as a error under `general` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+          it('should not add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
             const messages = clonedTransaction.errors.map(value => value.message);
             assert.notInclude(messages.join(), 'Message after fail');
             done();
           }));
 
-          it('should not add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+          it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
             const messages = [];
             const { callCount } = configuration.emitter.emit;
             for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -1823,6 +1865,13 @@ describe('TransactionRunner', () => {
               ));
             }
             assert.notInclude(messages.join(), 'Message after fail');
+            done();
+          }));
+
+          it('should set transaction info on the failed test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+            assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
+            assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
+            assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
             done();
           }));
         });
@@ -1884,13 +1933,13 @@ describe('TransactionRunner', () => {
           done();
         }));
 
-        it('should not add fail message as a error under `general` to the results on the transaction', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
+        it('should not add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
           const messages = modifiedTransaction.errors.map(value => value.message);
           assert.notInclude(messages.join(), 'Message after fail');
           done();
         }));
 
-        it('should not add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
+        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
           const messages = [];
           const { callCount } = configuration.emitter.emit;
           for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
@@ -1899,6 +1948,13 @@ describe('TransactionRunner', () => {
             ));
           }
           assert.notInclude(messages.join(), 'Message after fail');
+          done();
+        }));
+
+        it('should set transaction info on the failed test', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
+          assert.propertyVal(modifiedTransaction.test, 'request', modifiedTransaction.request);
+          assert.propertyVal(modifiedTransaction.test, 'expected', modifiedTransaction.expected);
+          assert.propertyVal(modifiedTransaction.test, 'actual', modifiedTransaction.real);
           done();
         }));
       });
@@ -1960,13 +2016,13 @@ describe('TransactionRunner', () => {
           done();
         }));
 
-        it('should add fail message as a error under `general` to the results', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+        it('should add fail message as a error under `errors` to the results', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
           const messages = clonedTransaction.errors.map(value => value.message);
           assert.include(messages.join(), 'Message after pass');
           done();
         }));
 
-        it('should not add fail message as a error under `general` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
           const messages = [];
           const { callCount } = configuration.emitter.emit;
           for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {


### PR DESCRIPTION
#### :rocket: Why this change?

Fixes an empty `resultData.results` sent to the Apiary Reporter when a test has been skipped.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/apiary/pull/6267

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
