### PR TITLE
Use Node 12 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
 install:
-  - ps: Install-Product node 10
+  - ps: Install-Product node 12
   - "npm -g install npm@6"
   - "set PATH=%APPDATA%\\npm;%PATH%"
   - "npm install"


### PR DESCRIPTION
#### :rocket: Why this change?

We always use the latest Node version we support when testing on AppVeyor. We added Node 12 to the other CI, but didn't switch AppVeyor to use it.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
