### PR TITLE
Document GitHub links checker extension

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -294,6 +294,9 @@ CLI options
 GitHub issues
     Simplifies linking GitHub issues. Usage: ``:ghissue:`drafter#123```
 
+GitHub links checker
+    Fails the docs build if there's an absolute link (``github.com/apiaryio/dredd/blob/master``) to a non-existing local file
+
 API Blueprint spec
     Simplifies linking the `API Blueprint`_ spec. Usage: ``:apib:`schema-section```
 


### PR DESCRIPTION
#### :rocket: Why this change?

I recently added an extension to Sphinx, but I forgot to document it.

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
