### PR TITLE
Fixes syntactically invalid JavaScript

### DIFF
--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -27,17 +27,19 @@ function prefixErrors(decoratedCallback, prefix) {
 
 
 function readLocations(locations, options, callback) {
-  if (typeof options === 'function') { [options, callback] = [{}, options]; }
+  const usesOptions = typeof options !== 'function';
+  const resolvedOptions = usesOptions ? options : {};
+  const resolvedCallback = usesOptions ? callback : options;
 
   async.map(locations, (location, next) => {
     const decoratedNext = prefixErrors(next, `Unable to load API description document from '${location}'`);
-    readLocation(location, options, decoratedNext);
+    readLocation(location, resolvedOptions, decoratedNext);
   }, (error, contents) => {
-    if (error) { callback(error); return; }
+    if (error) { resolvedCallback(error); return; }
 
     const apiDescriptions = locations
       .map((location, i) => ({ location, content: contents[i] }));
-    callback(null, apiDescriptions);
+    resolvedCallback(null, apiDescriptions);
   });
 }
 

--- a/lib/Hooks.js
+++ b/lib/Hooks.js
@@ -15,7 +15,8 @@ class Hooks {
     this.beforeEachValidation = this.beforeEachValidation.bind(this);
     this.afterEach = this.afterEach.bind(this);
     this.log = this.log.bind(this);
-    ({ logs: this.logs, logger: this.logger } = options);
+    this.logs = options.logs;
+    this.logger = options.logger;
     this.beforeHooks = {};
     this.beforeValidationHooks = {};
     this.afterHooks = {};


### PR DESCRIPTION
#### :rocket: Why this change?

- Certain parts look like survivors after decaffeinate, and represent invalid JavaScript code

#### :memo: Related issues and Pull Requests

- Necessary prerequisite for #1524 
- Problematic spots found in #1497 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
