### PR TITLE
Adds Prettier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,13 @@ jobs:
       - pip-install-docs
       - run: npm run ci:lint
 
+  format-check:
+    docker: [<<: *node12]
+    steps:
+      - checkout
+      - npm-install
+      - run: npm run prettify:check
+
   docs-dry-run:
     # 'dry run', because production build happens directly on the ReadTheDocs
     # infrastructure
@@ -110,6 +117,7 @@ workflows:
   version: 2
   test-and-release:
     jobs:
+      - format-check
       - quality-checks
       - test-node12
       - test-node10

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,22 +1,12 @@
 module.exports = {
-  extends: 'airbnb-base',
+  extends: ['airbnb-base', 'prettier'],
   env: {
-    'node': true
+    node: true
   },
   rules: {
     // Using 'console' is perfectly okay for a Node.js CLI tool and avoiding
     // it only brings unnecessary complexity
     'no-console': 'off',
-
-    // Node 6 does not support dangling commas in function arguments
-    'comma-dangle': [
-      'error',
-      {
-        'arrays': 'always-multiline',
-        'objects': 'always-multiline',
-        'functions': 'never'
-      }
-    ],
 
     // This is to allow a convention for exporting functions solely for
     // the purpose of the unit tests, see

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "trailingComma": "all"
+}

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -17,7 +17,6 @@ const { spawn } = require('./childProcess');
 const dreddOptions = require('./options');
 const packageData = require('../package.json');
 
-
 class CLI {
   constructor(options = {}, cb) {
     this.cb = cb;
@@ -40,7 +39,9 @@ class CLI {
     this.optimist = optimist(this.custom.argv, this.custom.cwd);
     this.cliArgv = this.optimist.argv;
 
-    this.optimist.usage(`\
+    this.optimist
+      .usage(
+        `\
 Usage:
   $ dredd init
 
@@ -49,7 +50,8 @@ Or:
 
 Example:
   $ dredd ./api-description.apib http://127.0.0.1:3000 --dry-run\
-`)
+`,
+      )
       .options(dreddOptions)
       .wrap(80);
 
@@ -67,7 +69,10 @@ Example:
       logger.debug('The backend server process has already terminated');
       return callback();
     }
-    logger.debug('Terminating backend server process, PID', this.serverProcess.pid);
+    logger.debug(
+      'Terminating backend server process, PID',
+      this.serverProcess.pid,
+    );
     this.serverProcess.terminate({ force: true });
     this.serverProcess.on('exit', () => callback());
   }
@@ -82,7 +87,9 @@ Example:
 
       if (this.exit) {
         this._processExit = (exitStatus) => {
-          logger.debug(`Using configured custom exit() method to terminate the Dredd process with status '${exitStatus}'.`);
+          logger.debug(
+            `Using configured custom exit() method to terminate the Dredd process with status '${exitStatus}'.`,
+          );
           this.finished = true;
           this.stopServer(() => {
             this.exit(exitStatus);
@@ -90,13 +97,17 @@ Example:
         };
       } else {
         this._processExit = (exitStatus) => {
-          logger.debug(`Using native process.exit() method to terminate the Dredd process with status '${exitStatus}'.`);
+          logger.debug(
+            `Using native process.exit() method to terminate the Dredd process with status '${exitStatus}'.`,
+          );
           this.stopServer(() => process.exit(exitStatus));
         };
       }
     } else {
       this._processExit = (exitStatus) => {
-        logger.debug(`Using configured custom callback to terminate the Dredd process with status '${exitStatus}'.`);
+        logger.debug(
+          `Using configured custom callback to terminate the Dredd process with status '${exitStatus}'.`,
+        );
         this.finished = true;
         if (this.sigIntEventAdded) {
           if (this.serverProcess && !this.serverProcess.terminated) {
@@ -146,19 +157,25 @@ Example:
     if (this.argv._[0] === 'init' || this.argv.init === true) {
       logger.debug('Starting interactive configuration.');
       this.finished = true;
-      interactiveConfig(this.argv, (config) => {
-        configUtils.save(config);
-      }, (err) => {
-        if (err) { logger.error('Could not configure Dredd', err); }
-        this._processExit(0);
-      });
+      interactiveConfig(
+        this.argv,
+        (config) => {
+          configUtils.save(config);
+        },
+        (err) => {
+          if (err) {
+            logger.error('Could not configure Dredd', err);
+          }
+          this._processExit(0);
+        },
+      );
 
-    // Show help
+      // Show help
     } else if (this.argv.help === true) {
       this.optimist.showHelp(console.error);
       this._processExit(0);
 
-    // Show version
+      // Show version
     } else if (this.argv.version === true) {
       console.log(`\
 ${packageData.name} v${packageData.version} \
@@ -173,7 +190,9 @@ ${packageData.name} v${packageData.version} \
     logger.debug('Loading configuration file:', configPath);
 
     if (configPath && fs.existsSync(configPath)) {
-      logger.debug(`Configuration '${configPath}' found, ignoring other arguments.`);
+      logger.debug(
+        `Configuration '${configPath}' found, ignoring other arguments.`,
+      );
       this.argv = configUtils.load(configPath);
     }
 
@@ -194,29 +213,49 @@ ${packageData.name} v${packageData.version} \
 
   runServerAndThenDredd() {
     if (!this.argv.server) {
-      logger.debug('No backend server process specified, starting testing at once');
+      logger.debug(
+        'No backend server process specified, starting testing at once',
+      );
       this.runDredd(this.dreddInstance);
     } else {
-      logger.debug('Backend server process specified, starting backend server and then testing');
+      logger.debug(
+        'Backend server process specified, starting backend server and then testing',
+      );
 
       const parsedArgs = spawnArgs(this.argv.server);
       const command = parsedArgs.shift();
 
-      logger.debug(`Using '${command}' as a server command, ${JSON.stringify(parsedArgs)} as arguments`);
+      logger.debug(
+        `Using '${command}' as a server command, ${JSON.stringify(
+          parsedArgs,
+        )} as arguments`,
+      );
       this.serverProcess = spawn(command, parsedArgs);
-      logger.debug(`Starting backend server process with command: ${this.argv.server}`);
+      logger.debug(
+        `Starting backend server process with command: ${this.argv.server}`,
+      );
 
       this.serverProcess.stdout.setEncoding('utf8');
-      this.serverProcess.stdout.on('data', data => process.stdout.write(data.toString()));
+      this.serverProcess.stdout.on('data', (data) =>
+        process.stdout.write(data.toString()),
+      );
 
       this.serverProcess.stderr.setEncoding('utf8');
-      this.serverProcess.stderr.on('data', data => process.stdout.write(data.toString()));
+      this.serverProcess.stderr.on('data', (data) =>
+        process.stdout.write(data.toString()),
+      );
 
-      this.serverProcess.on('signalTerm', () => logger.debug('Gracefully terminating the backend server process'));
-      this.serverProcess.on('signalKill', () => logger.debug('Killing the backend server process'));
+      this.serverProcess.on('signalTerm', () =>
+        logger.debug('Gracefully terminating the backend server process'),
+      );
+      this.serverProcess.on('signalKill', () =>
+        logger.debug('Killing the backend server process'),
+      );
 
       this.serverProcess.on('crash', (exitStatus, killed) => {
-        if (killed) { logger.debug('Backend server process was killed'); }
+        if (killed) {
+          logger.debug('Backend server process was killed');
+        }
       });
 
       this.serverProcess.on('exit', () => {
@@ -224,7 +263,10 @@ ${packageData.name} v${packageData.version} \
       });
 
       this.serverProcess.on('error', (err) => {
-        logger.error('Command to start backend server process failed, exiting Dredd', err);
+        logger.error(
+          'Command to start backend server process failed, exiting Dredd',
+          err,
+        );
         this._processExit(1);
       });
 
@@ -239,19 +281,20 @@ ${packageData.name} v${packageData.version} \
       // Ensure server is not running when dredd exits prematurely somewhere
       process.on('exit', () => {
         if (this.serverProcess && !this.serverProcess.terminated) {
-          logger.debug('Killing backend server process on Dredd\'s exit');
+          logger.debug("Killing backend server process on Dredd's exit");
           this.serverProcess.signalKill();
         }
       });
 
       const waitSecs = parseInt(this.argv['server-wait'], 10);
       const waitMilis = waitSecs * 1000;
-      logger.debug(`Waiting ${waitSecs} seconds for backend server process to start`);
+      logger.debug(
+        `Waiting ${waitSecs} seconds for backend server process to start`,
+      );
 
       this.wait = setTimeout(() => {
         this.runDredd(this.dreddInstance);
-      },
-      waitMilis);
+      }, waitMilis);
     }
   }
 
@@ -263,8 +306,13 @@ ${packageData.name} v${packageData.version} \
     logger.debug('Node.js environment:', process.versions);
     logger.debug('System version:', os.type(), os.release(), os.arch());
     try {
-      const npmVersion = spawnSync('npm', ['--version']).stdout.toString().trim();
-      logger.debug('npm version:', npmVersion || 'unable to determine npm version');
+      const npmVersion = spawnSync('npm', ['--version'])
+        .stdout.toString()
+        .trim();
+      logger.debug(
+        'npm version:',
+        npmVersion || 'unable to determine npm version',
+      );
     } catch (err) {
       logger.debug('npm version: unable to determine npm version:', err);
     }
@@ -282,7 +330,9 @@ ${packageData.name} v${packageData.version} \
         this.moveBlueprintArgToPath,
       ]) {
         task.call(this);
-        if (this.finished) { return; }
+        if (this.finished) {
+          return;
+        }
       }
 
       const configurationForDredd = this.initConfig();
@@ -328,7 +378,9 @@ ${packageData.name} v${packageData.version} \
     });
 
     // Push first argument (without some known configuration --key) into paths
-    if (!cliConfig.path) { cliConfig.path = []; }
+    if (!cliConfig.path) {
+      cliConfig.path = [];
+    }
     cliConfig.path.push(this.argv._[0]);
 
     // Merge "this.custom" which is an input of CLI constructor
@@ -367,11 +419,13 @@ ${packageData.name} v${packageData.version} \
 
   exitWithStatus(error, stats) {
     if (error) {
-      if (error.message) { logger.error(error.message); }
+      if (error.message) {
+        logger.error(error.message);
+      }
       this._processExit(1);
     }
 
-    if ((stats.failures + stats.errors) > 0) {
+    if (stats.failures + stats.errors > 0) {
       this._processExit(1);
     } else {
       this._processExit(0);

--- a/lib/Dredd.js
+++ b/lib/Dredd.js
@@ -11,52 +11,72 @@ const TransactionRunner = require('./TransactionRunner');
 const { applyConfiguration } = require('./configuration');
 const annotationToLoggerInfo = require('./annotationToLoggerInfo');
 
-
 function prefixError(error, prefix) {
   error.message = `${prefix}: ${error.message}`;
   return error;
 }
 
-
 function prefixErrors(decoratedCallback, prefix) {
   return (error, ...args) => {
-    if (error) { prefixError(error, prefix); }
+    if (error) {
+      prefixError(error, prefix);
+    }
     decoratedCallback(error, ...args);
   };
 }
-
 
 function readLocations(locations, options, callback) {
   const usesOptions = typeof options !== 'function';
   const resolvedOptions = usesOptions ? options : {};
   const resolvedCallback = usesOptions ? callback : options;
 
-  async.map(locations, (location, next) => {
-    const decoratedNext = prefixErrors(next, `Unable to load API description document from '${location}'`);
-    readLocation(location, resolvedOptions, decoratedNext);
-  }, (error, contents) => {
-    if (error) { resolvedCallback(error); return; }
+  async.map(
+    locations,
+    (location, next) => {
+      const decoratedNext = prefixErrors(
+        next,
+        `Unable to load API description document from '${location}'`,
+      );
+      readLocation(location, resolvedOptions, decoratedNext);
+    },
+    (error, contents) => {
+      if (error) {
+        resolvedCallback(error);
+        return;
+      }
 
-    const apiDescriptions = locations
-      .map((location, i) => ({ location, content: contents[i] }));
-    resolvedCallback(null, apiDescriptions);
-  });
+      const apiDescriptions = locations.map((location, i) => ({
+        location,
+        content: contents[i],
+      }));
+      resolvedCallback(null, apiDescriptions);
+    },
+  );
 }
-
 
 function parseContent(apiDescriptions, callback) {
-  async.map(apiDescriptions, ({ location, content }, next) => {
-    const decoratedNext = prefixErrors(next, `Unable to parse API description document '${location}'`);
-    parse(content, decoratedNext);
-  }, (error, parseResults) => {
-    if (error) { callback(error); return; }
+  async.map(
+    apiDescriptions,
+    ({ location, content }, next) => {
+      const decoratedNext = prefixErrors(
+        next,
+        `Unable to parse API description document '${location}'`,
+      );
+      parse(content, decoratedNext);
+    },
+    (error, parseResults) => {
+      if (error) {
+        callback(error);
+        return;
+      }
 
-    const parsedAPIdescriptions = apiDescriptions
-      .map((apiDescription, i) => Object.assign({}, parseResults[i], apiDescription));
-    callback(null, parsedAPIdescriptions);
-  });
+      const parsedAPIdescriptions = apiDescriptions.map((apiDescription, i) =>
+        Object.assign({}, parseResults[i], apiDescription),
+      );
+      callback(null, parsedAPIdescriptions);
+    },
+  );
 }
-
 
 function compileTransactions(apiDescriptions) {
   return apiDescriptions
@@ -64,40 +84,54 @@ function compileTransactions(apiDescriptions) {
       try {
         return compile(mediaType, apiElements, location);
       } catch (error) {
-        throw prefixError(error, 'Unable to compile HTTP transactions from '
-          + `API description document '${location}': ${error.message}`);
+        throw prefixError(
+          error,
+          'Unable to compile HTTP transactions from ' +
+            `API description document '${location}': ${error.message}`,
+        );
       }
     })
-    .map((compileResult, i) => Object.assign({}, compileResult, apiDescriptions[i]));
+    .map((compileResult, i) =>
+      Object.assign({}, compileResult, apiDescriptions[i]),
+    );
 }
-
 
 function toTransactions(apiDescriptions) {
-  return apiDescriptions
-    // produce an array of transactions for each API description,
-    // where each transaction object gets an extra 'apiDescription'
-    // property with details about the API description it comes from
-    .map(apiDescription => (
-      apiDescription.transactions
-        .map(transaction => Object.assign({
-          apiDescription: {
-            location: apiDescription.location,
-            mediaType: apiDescription.mediaType,
-          },
-        }, transaction))
-    ))
-    // flatten array of arrays
-    .reduce((flatArray, array) => flatArray.concat(array), []);
+  return (
+    apiDescriptions
+      // produce an array of transactions for each API description,
+      // where each transaction object gets an extra 'apiDescription'
+      // property with details about the API description it comes from
+      .map((apiDescription) =>
+        apiDescription.transactions.map((transaction) =>
+          Object.assign(
+            {
+              apiDescription: {
+                location: apiDescription.location,
+                mediaType: apiDescription.mediaType,
+              },
+            },
+            transaction,
+          ),
+        ),
+      )
+      // flatten array of arrays
+      .reduce((flatArray, array) => flatArray.concat(array), [])
+  );
 }
-
 
 function toLoggerInfos(apiDescriptions) {
   return apiDescriptions
-    .map(apiDescription => apiDescription.annotations
-      .map(annotation => annotationToLoggerInfo(apiDescription.location, annotation)))
-    .reduce((flatAnnotations, annotations) => flatAnnotations.concat(annotations), []);
+    .map((apiDescription) =>
+      apiDescription.annotations.map((annotation) =>
+        annotationToLoggerInfo(apiDescription.location, annotation),
+      ),
+    )
+    .reduce(
+      (flatAnnotations, annotations) => flatAnnotations.concat(annotations),
+      [],
+    );
 }
-
 
 class Dredd {
   constructor(config) {
@@ -120,42 +154,60 @@ class Dredd {
     this.logger.debug('Resolving locations of API description documents');
     let locations;
     try {
-      locations = resolveLocations(this.configuration.custom.cwd, this.configuration.path);
+      locations = resolveLocations(
+        this.configuration.custom.cwd,
+        this.configuration.path,
+      );
     } catch (error) {
       process.nextTick(() => callback(error));
       return;
     }
 
-    async.waterfall([
-      (next) => {
-        this.logger.debug('Reading API description documents');
-        readLocations(locations, { http: this.configuration.http }, next);
-      },
-      (apiDescriptions, next) => {
-        const allAPIdescriptions = this.configuration.apiDescriptions.concat(apiDescriptions);
-        this.logger.debug('Parsing API description documents');
-        parseContent(allAPIdescriptions, next);
-      },
-    ], (error, apiDescriptions) => {
-      if (error) { callback(error); return; }
+    async.waterfall(
+      [
+        (next) => {
+          this.logger.debug('Reading API description documents');
+          readLocations(locations, { http: this.configuration.http }, next);
+        },
+        (apiDescriptions, next) => {
+          const allAPIdescriptions = this.configuration.apiDescriptions.concat(
+            apiDescriptions,
+          );
+          this.logger.debug('Parsing API description documents');
+          parseContent(allAPIdescriptions, next);
+        },
+      ],
+      (error, apiDescriptions) => {
+        if (error) {
+          callback(error);
+          return;
+        }
 
-      this.logger.debug('Compiling HTTP transactions from API description documents');
-      let apiDescriptionsWithTransactions;
-      try {
-        apiDescriptionsWithTransactions = compileTransactions(apiDescriptions);
-      } catch (compileErr) {
-        callback(compileErr);
-        return;
-      }
+        this.logger.debug(
+          'Compiling HTTP transactions from API description documents',
+        );
+        let apiDescriptionsWithTransactions;
+        try {
+          apiDescriptionsWithTransactions = compileTransactions(
+            apiDescriptions,
+          );
+        } catch (compileErr) {
+          callback(compileErr);
+          return;
+        }
 
-      callback(null, apiDescriptionsWithTransactions);
-    });
+        callback(null, apiDescriptionsWithTransactions);
+      },
+    );
   }
 
   run(callback) {
     this.logger.debug('Resolving --require');
     if (this.configuration.require) {
-      const requirePath = resolveModule(this.configuration.custom.cwd, this.configuration.require);
+      const requirePath = resolveModule(
+        this.configuration.custom.cwd,
+        this.configuration.require,
+      );
       try {
         require(requirePath); // eslint-disable-line global-require, import/no-dynamic-require
       } catch (error) {
@@ -174,7 +226,10 @@ class Dredd {
 
     this.logger.debug('Preparing API description documents');
     this.prepareAPIdescriptions((error, apiDescriptions) => {
-      if (error) { callback(error, this.stats); return; }
+      if (error) {
+        callback(error, this.stats);
+        return;
+      }
 
       const loggerInfos = toLoggerInfos(apiDescriptions);
       // FIXME: Winston 3.x supports calling .log() directly with the loggerInfo
@@ -182,8 +237,10 @@ class Dredd {
       // Once we upgrade Winston, the line below can be simplified to .log(loggerInfo)
       //
       // Watch https://github.com/apiaryio/dredd/issues/1225 for updates
-      loggerInfos.forEach(({ level, message }) => this.logger.log(level, message));
-      if (loggerInfos.find(loggerInfo => loggerInfo.level === 'error')) {
+      loggerInfos.forEach(({ level, message }) =>
+        this.logger.log(level, message),
+      );
+      if (loggerInfos.find((loggerInfo) => loggerInfo.level === 'error')) {
         callback(new Error('API description processing error'), this.stats);
         return;
       }
@@ -198,6 +255,5 @@ class Dredd {
     });
   }
 }
-
 
 module.exports = Dredd;

--- a/lib/HooksWorkerClient.js
+++ b/lib/HooksWorkerClient.js
@@ -32,22 +32,30 @@ class HooksWorkerClient {
   start(callback) {
     logger.debug('Looking up hooks handler implementation:', this.language);
     this.setCommandAndCheckForExecutables((executablesError) => {
-      if (executablesError) { return callback(executablesError); }
+      if (executablesError) {
+        return callback(executablesError);
+      }
 
       logger.debug('Starting hooks handler.');
       this.spawnHandler((spawnHandlerError) => {
-        if (spawnHandlerError) { return callback(spawnHandlerError); }
+        if (spawnHandlerError) {
+          return callback(spawnHandlerError);
+        }
 
         logger.debug('Connecting to hooks handler.');
         this.connectToHandler((connectHandlerError) => {
           if (connectHandlerError) {
-            this.terminateHandler(terminateError => callback(connectHandlerError || terminateError));
+            this.terminateHandler((terminateError) =>
+              callback(connectHandlerError || terminateError),
+            );
             return;
           }
 
           logger.debug('Registering hooks.');
           this.registerHooks((registerHooksError) => {
-            if (registerHooksError) { return callback(registerHooksError); }
+            if (registerHooksError) {
+              return callback(registerHooksError);
+            }
             callback();
           });
         });
@@ -67,7 +75,11 @@ class HooksWorkerClient {
       return callback();
     }
 
-    this.handler.terminate({ force: true, timeout: this.termTimeout, retryDelay: this.termRetry });
+    this.handler.terminate({
+      force: true,
+      timeout: this.termTimeout,
+      retryDelay: this.termRetry,
+    });
     this.handler.on('close', () => callback());
   }
 
@@ -152,7 +164,9 @@ Use Dredd's native Node.js hooks instead.
     } else if (this.language === 'go') {
       getGoBinary((err, goBin) => {
         if (err) {
-          callback(new Error(`Go doesn't seem to be installed: ${err.message}`));
+          callback(
+            new Error(`Go doesn't seem to be installed: ${err.message}`),
+          );
         } else {
           this.handlerCommand = path.join(goBin, 'goodman');
           this.handlerCommandArgs = [];
@@ -173,7 +187,13 @@ $ go get github.com/snikch/goodman/cmd/goodman
       this.handlerCommand = parsedArgs.shift();
       this.handlerCommandArgs = parsedArgs;
 
-      logger.debug(`Using '${this.handlerCommand}' as a hooks handler command, '${this.handlerCommandArgs.join(' ')}' as arguments`);
+      logger.debug(
+        `Using '${
+          this.handlerCommand
+        }' as a hooks handler command, '${this.handlerCommandArgs.join(
+          ' ',
+        )}' as arguments`,
+      );
       if (!which.which(this.handlerCommand)) {
         msg = `Hooks handler command not found: ${this.handlerCommand}`;
         callback(new Error(msg));
@@ -190,18 +210,30 @@ $ go get github.com/snikch/goodman/cmd/goodman
     logger.debug(`Spawning '${this.language}' hooks handler process.`);
     this.handler = spawn(this.handlerCommand, handlerCommandArgs);
 
-    this.handler.stdout.on('data', data => logger.debug('Hooks handler stdout:', data.toString()));
-    this.handler.stderr.on('data', data => logger.debug('Hooks handler stderr:', data.toString()));
+    this.handler.stdout.on('data', (data) =>
+      logger.debug('Hooks handler stdout:', data.toString()),
+    );
+    this.handler.stderr.on('data', (data) =>
+      logger.debug('Hooks handler stderr:', data.toString()),
+    );
 
-    this.handler.on('signalTerm', () => logger.debug('Gracefully terminating the hooks handler process'));
-    this.handler.on('signalKill', () => logger.debug('Killing the hooks handler process'));
+    this.handler.on('signalTerm', () =>
+      logger.debug('Gracefully terminating the hooks handler process'),
+    );
+    this.handler.on('signalKill', () =>
+      logger.debug('Killing the hooks handler process'),
+    );
 
     this.handler.on('crash', (exitStatus, killed) => {
       let msg;
       if (killed) {
-        msg = `Hooks handler process '${this.handlerCommand} ${handlerCommandArgs.join(' ')}' was killed.`;
+        msg = `Hooks handler process '${
+          this.handlerCommand
+        } ${handlerCommandArgs.join(' ')}' was killed.`;
       } else {
-        msg = `Hooks handler process '${this.handlerCommand} ${handlerCommandArgs.join(' ')}' exited with status: ${exitStatus}`;
+        msg = `Hooks handler process '${
+          this.handlerCommand
+        } ${handlerCommandArgs.join(' ')}' exited with status: ${exitStatus}`;
       }
       logger.error(msg);
       this.runner.hookHandlerError = new Error(msg);
@@ -216,11 +248,13 @@ $ go get github.com/snikch/goodman/cmd/goodman
     let timeout;
     const start = Date.now();
     const waitForConnect = () => {
-      if ((Date.now() - start) < this.connectTimeout) {
+      if (Date.now() - start < this.connectTimeout) {
         clearTimeout(timeout);
 
         if (this.connectError !== false) {
-          logger.warn('Error connecting to the hooks handler process. Is the handler running? Retrying.');
+          logger.warn(
+            'Error connecting to the hooks handler process. Is the handler running? Retrying.',
+          );
           this.connectError = false;
         }
 
@@ -231,9 +265,13 @@ $ go get github.com/snikch/goodman/cmd/goodman
       } else {
         clearTimeout(timeout);
         if (!this.clientConnected) {
-          if (this.handlerClient) { this.handlerClient.destroy(); }
-          const msg = `Connection timeout ${this.connectTimeout / 1000}s to hooks handler `
-          + `on ${this.handlerHost}:${this.handlerPort} exceeded. Try increasing the limit.`;
+          if (this.handlerClient) {
+            this.handlerClient.destroy();
+          }
+          const msg =
+            `Connection timeout ${this.connectTimeout /
+              1000}s to hooks handler ` +
+            `on ${this.handlerHost}:${this.handlerPort} exceeded. Try increasing the limit.`;
           callback(new Error(msg));
         }
       }
@@ -246,19 +284,30 @@ $ go get github.com/snikch/goodman/cmd/goodman
         callback(this.runner.hookHandlerError);
       }
 
-      this.handlerClient = net.connect({ port: this.handlerPort, host: this.handlerHost });
+      this.handlerClient = net.connect({
+        port: this.handlerPort,
+        host: this.handlerHost,
+      });
 
       this.handlerClient.on('connect', () => {
-        logger.debug(`Successfully connected to hooks handler. Waiting ${this.afterConnectWait / 1000}s to start testing.`);
+        logger.debug(
+          `Successfully connected to hooks handler. Waiting ${this
+            .afterConnectWait / 1000}s to start testing.`,
+        );
         this.clientConnected = true;
         clearTimeout(timeout);
         setTimeout(callback, this.afterConnectWait);
       });
 
-      this.handlerClient.on('close', () => logger.debug('TCP communication with hooks handler closed.'));
+      this.handlerClient.on('close', () =>
+        logger.debug('TCP communication with hooks handler closed.'),
+      );
 
       this.handlerClient.on('error', (connectError) => {
-        logger.debug('TCP communication with hooks handler errored.', connectError);
+        logger.debug(
+          'TCP communication with hooks handler errored.',
+          connectError,
+        );
         this.connectError = connectError;
       });
 
@@ -269,7 +318,9 @@ $ go get github.com/snikch/goodman/cmd/goodman
 
         handlerBuffer += data.toString();
         if (data.toString().indexOf(this.handlerMessageDelimiter) > -1) {
-          const splittedData = handlerBuffer.split(this.handlerMessageDelimiter);
+          const splittedData = handlerBuffer.split(
+            this.handlerMessageDelimiter,
+          );
 
           // Add last chunk to the buffer
           handlerBuffer = splittedData.pop();
@@ -282,10 +333,18 @@ $ go get github.com/snikch/goodman/cmd/goodman
           const result = [];
           for (const message of messages) {
             if (message.uuid) {
-              logger.debug('Dredd received a valid message from hooks handler:', message.uuid);
+              logger.debug(
+                'Dredd received a valid message from hooks handler:',
+                message.uuid,
+              );
               result.push(this.emitter.emit(message.uuid, message));
             } else {
-              result.push(logger.debug('UUID not present in hooks handler message, ignoring:', JSON.stringify(message, null, 2)));
+              result.push(
+                logger.debug(
+                  'UUID not present in hooks handler message, ignoring:',
+                  JSON.stringify(message, null, 2),
+                ),
+              );
             }
           }
           return result;
@@ -335,7 +394,7 @@ $ go get github.com/snikch/goodman/cmd/goodman
               value = receivedMessage.data[index];
               data[index] = value;
             }
-          // *Each hook receives single transaction
+            // *Each hook receives single transaction
           } else {
             for (const key of Object.keys(receivedMessage.data || {})) {
               value = receivedMessage.data[key];
@@ -370,7 +429,8 @@ $ go get github.com/snikch/goodman/cmd/goodman
       // https://github.com/apiaryio/dredd-hooks-template/blob/master/features/execution_order.feature
       if (process.env.TEST_DREDD_HOOKS_HANDLER_ORDER === 'true') {
         console.error('FOR TESTING ONLY');
-        const modifications = (transactions[0] && transactions[0].hooks_modifications) || [];
+        const modifications =
+          (transactions[0] && transactions[0].hooks_modifications) || [];
         if (!modifications.length) {
           throw new Error('Hooks must modify transaction.hooks_modifications');
         }

--- a/lib/TransactionRunner.js
+++ b/lib/TransactionRunner.js
@@ -11,7 +11,6 @@ const packageData = require('../package.json');
 const sortTransactions = require('./sortTransactions');
 const performRequest = require('./performRequest');
 
-
 function headersArrayToObject(arr) {
   return Array.from(arr).reduce((result, currentItem) => {
     result[currentItem.name] = currentItem.value;
@@ -20,9 +19,10 @@ function headersArrayToObject(arr) {
 }
 
 function eventCallback(reporterError) {
-  if (reporterError) { logger.error(reporterError.message); }
+  if (reporterError) {
+    logger.error(reporterError.message);
+  }
 }
-
 
 class TransactionRunner {
   constructor(configuration) {
@@ -43,25 +43,39 @@ class TransactionRunner {
   run(transactions, callback) {
     logger.debug('Starting reporters and waiting until all of them are ready');
     this.emitStart((emitStartErr) => {
-      if (emitStartErr) { return callback(emitStartErr); }
+      if (emitStartErr) {
+        return callback(emitStartErr);
+      }
 
       logger.debug('Sorting HTTP transactions');
-      transactions = this.configuration.sorted ? sortTransactions(transactions) : transactions;
+      transactions = this.configuration.sorted
+        ? sortTransactions(transactions)
+        : transactions;
 
       logger.debug('Configuring HTTP transactions');
       transactions = transactions.map(this.configureTransaction.bind(this));
 
       logger.debug('Reading hook files and registering hooks');
       addHooks(this, transactions, (addHooksError) => {
-        if (addHooksError) { return callback(addHooksError); }
+        if (addHooksError) {
+          return callback(addHooksError);
+        }
 
         logger.debug('Executing HTTP transactions');
-        this.executeAllTransactions(transactions, this.hooks, (execAllTransErr) => {
-          if (execAllTransErr) { return callback(execAllTransErr); }
+        this.executeAllTransactions(
+          transactions,
+          this.hooks,
+          (execAllTransErr) => {
+            if (execAllTransErr) {
+              return callback(execAllTransErr);
+            }
 
-          logger.debug('Wrapping up testing and waiting until all reporters are done');
-          this.emitEnd(callback);
-        });
+            logger.debug(
+              'Wrapping up testing and waiting until all reporters are done',
+            );
+            this.emitEnd(callback);
+          },
+        );
       });
     });
   }
@@ -72,13 +86,21 @@ class TransactionRunner {
 
     // When event 'start' is emitted, function in callback is executed for each
     // reporter registered by listeners
-    this.configuration.emitter.emit('start', this.configuration.apiDescriptions, (reporterError) => {
-      if (reporterError) { logger.error(reporterError.message); }
+    this.configuration.emitter.emit(
+      'start',
+      this.configuration.apiDescriptions,
+      (reporterError) => {
+        if (reporterError) {
+          logger.error(reporterError.message);
+        }
 
-      // Last called reporter callback function starts the runner
-      reporterCount--;
-      if (reporterCount === 0) { callback(); }
-    });
+        // Last called reporter callback function starts the runner
+        reporterCount--;
+        if (reporterCount === 0) {
+          callback();
+        }
+      },
+    );
   }
 
   executeAllTransactions(transactions, hooks, callback) {
@@ -96,63 +118,103 @@ class TransactionRunner {
     }
     // End of warning
 
-    if (this.hookHandlerError) { return callback(this.hookHandlerError); }
+    if (this.hookHandlerError) {
+      return callback(this.hookHandlerError);
+    }
 
-    logger.debug('Running \'beforeAll\' hooks');
+    logger.debug("Running 'beforeAll' hooks");
 
     this.runHooksForData(hooks.beforeAllHooks, transactions, () => {
-      if (this.hookHandlerError) { return callback(this.hookHandlerError); }
+      if (this.hookHandlerError) {
+        return callback(this.hookHandlerError);
+      }
 
       // Iterate over transactions' transaction
       // Because async changes the way referencing of properties work,
       // we need to work with indexes (keys) here, no other way of access.
-      return async.timesSeries(transactions.length, (transactionIndex, iterationCallback) => {
-        transaction = transactions[transactionIndex];
-        logger.debug(`Processing transaction #${transactionIndex + 1}:`, transaction.name);
+      return async.timesSeries(
+        transactions.length,
+        (transactionIndex, iterationCallback) => {
+          transaction = transactions[transactionIndex];
+          logger.debug(
+            `Processing transaction #${transactionIndex + 1}:`,
+            transaction.name,
+          );
 
-        logger.debug('Running \'beforeEach\' hooks');
-        this.runHooksForData(hooks.beforeEachHooks, transaction, () => {
-          if (this.hookHandlerError) { return iterationCallback(this.hookHandlerError); }
+          logger.debug("Running 'beforeEach' hooks");
+          this.runHooksForData(hooks.beforeEachHooks, transaction, () => {
+            if (this.hookHandlerError) {
+              return iterationCallback(this.hookHandlerError);
+            }
 
-          logger.debug('Running \'before\' hooks');
-          this.runHooksForData(hooks.beforeHooks[transaction.name], transaction, () => {
-            if (this.hookHandlerError) { return iterationCallback(this.hookHandlerError); }
+            logger.debug("Running 'before' hooks");
+            this.runHooksForData(
+              hooks.beforeHooks[transaction.name],
+              transaction,
+              () => {
+                if (this.hookHandlerError) {
+                  return iterationCallback(this.hookHandlerError);
+                }
 
-            // This method:
-            // - skips and fails based on hooks or options
-            // - executes a request
-            // - recieves a response
-            // - runs beforeEachValidation hooks
-            // - runs beforeValidation hooks
-            // - runs Gavel validation
-            this.executeTransaction(transaction, hooks, () => {
-              if (this.hookHandlerError) { return iterationCallback(this.hookHandlerError); }
+                // This method:
+                // - skips and fails based on hooks or options
+                // - executes a request
+                // - recieves a response
+                // - runs beforeEachValidation hooks
+                // - runs beforeValidation hooks
+                // - runs Gavel validation
+                this.executeTransaction(transaction, hooks, () => {
+                  if (this.hookHandlerError) {
+                    return iterationCallback(this.hookHandlerError);
+                  }
 
-              logger.debug('Running \'afterEach\' hooks');
-              this.runHooksForData(hooks.afterEachHooks, transaction, () => {
-                if (this.hookHandlerError) { return iterationCallback(this.hookHandlerError); }
+                  logger.debug("Running 'afterEach' hooks");
+                  this.runHooksForData(
+                    hooks.afterEachHooks,
+                    transaction,
+                    () => {
+                      if (this.hookHandlerError) {
+                        return iterationCallback(this.hookHandlerError);
+                      }
 
-                logger.debug('Running \'after\' hooks');
-                this.runHooksForData(hooks.afterHooks[transaction.name], transaction, () => {
-                  if (this.hookHandlerError) { return iterationCallback(this.hookHandlerError); }
+                      logger.debug("Running 'after' hooks");
+                      this.runHooksForData(
+                        hooks.afterHooks[transaction.name],
+                        transaction,
+                        () => {
+                          if (this.hookHandlerError) {
+                            return iterationCallback(this.hookHandlerError);
+                          }
 
-                  logger.debug(`Evaluating results of transaction execution #${transactionIndex + 1}:`, transaction.name);
-                  this.emitResult(transaction, iterationCallback);
+                          logger.debug(
+                            `Evaluating results of transaction execution #${transactionIndex +
+                              1}:`,
+                            transaction.name,
+                          );
+                          this.emitResult(transaction, iterationCallback);
+                        },
+                      );
+                    },
+                  );
                 });
-              });
-            });
+              },
+            );
           });
-        });
-      },
-      (iterationError) => {
-        if (iterationError) { return callback(iterationError); }
+        },
+        (iterationError) => {
+          if (iterationError) {
+            return callback(iterationError);
+          }
 
-        logger.debug('Running \'afterAll\' hooks');
-        this.runHooksForData(hooks.afterAllHooks, transactions, () => {
-          if (this.hookHandlerError) { return callback(this.hookHandlerError); }
-          callback();
-        });
-      });
+          logger.debug("Running 'afterAll' hooks");
+          this.runHooksForData(hooks.afterAllHooks, transactions, () => {
+            if (this.hookHandlerError) {
+              return callback(this.hookHandlerError);
+            }
+            callback();
+          });
+        },
+      );
     });
   }
 
@@ -179,7 +241,12 @@ class TransactionRunner {
           // all the flow can be executed twice. We need to reimplement this.
           if (error instanceof chai.AssertionError) {
             const transactions = Array.isArray(data) ? data : [data];
-            for (const transaction of transactions) { this.failTransaction(transaction, `Failed assertion in hooks: ${error.message}`); }
+            for (const transaction of transactions) {
+              this.failTransaction(
+                transaction,
+                `Failed assertion in hooks: ${error.message}`,
+              );
+            }
           } else {
             logger.debug('Hook errored:', error);
             this.emitHookError(error, data);
@@ -201,7 +268,9 @@ class TransactionRunner {
   // function. That probably isn't correct and should be fixed eventually
   // (beware, tests count with the current behavior).
   emitHookError(error, data) {
-    if (!(error instanceof Error)) { error = new Error(error); }
+    if (!(error instanceof Error)) {
+      error = new Error(error);
+    }
     const test = this.createTest(data);
     test.request = data.request;
     this.emitError(error, test);
@@ -223,14 +292,16 @@ class TransactionRunner {
     const { origin, request, response } = transaction;
 
     // Parse the server URL (just once, caching it in @parsedUrl)
-    if (!this.parsedUrl) { this.parsedUrl = this.parseServerUrl(configuration.endpoint); }
+    if (!this.parsedUrl) {
+      this.parsedUrl = this.parseServerUrl(configuration.endpoint);
+    }
     const fullPath = this.getFullPath(this.parsedUrl.path, request.uri);
 
     const headers = headersArrayToObject(request.headers);
 
     // Add Dredd User-Agent (if no User-Agent is already present)
     const hasUserAgent = Object.keys(headers)
-      .map(name => name.toLowerCase())
+      .map((name) => name.toLowerCase())
       .includes('user-agent');
     if (!hasUserAgent) {
       const system = `${os.type()} ${os.release()}; ${os.arch()}`;
@@ -251,22 +322,34 @@ class TransactionRunner {
     // The data models as used here must conform to Gavel.js
     // as defined in `http-response.coffee`
     const expected = { headers: headersArrayToObject(response.headers) };
-    if (response.body) { expected.body = response.body; }
-    if (response.status) { expected.statusCode = response.status; }
-    if (response.schema) { expected.bodySchema = response.schema; }
+    if (response.body) {
+      expected.body = response.body;
+    }
+    if (response.status) {
+      expected.statusCode = response.status;
+    }
+    if (response.schema) {
+      expected.bodySchema = response.schema;
+    }
 
     // Backward compatible transaction name hack. Transaction names will be
     // replaced by Canonical Transaction Paths: https://github.com/apiaryio/dredd/issues/227
     if (!this.multiBlueprint) {
-      transaction.name = transaction.name.replace(`${transaction.origin.apiName} > `, '');
+      transaction.name = transaction.name.replace(
+        `${transaction.origin.apiName} > `,
+        '',
+      );
     }
 
     // Transaction skipping (can be modified in hooks). If the input format
     // is OpenAPI 2, non-2xx transactions should be skipped by default.
     let skip = false;
-    if (transaction.apiDescription && transaction.apiDescription.mediaType.includes('swagger')) {
+    if (
+      transaction.apiDescription &&
+      transaction.apiDescription.mediaType.includes('swagger')
+    ) {
       const status = parseInt(response.status, 10);
-      if ((status < 200) || (status >= 300)) {
+      if (status < 200 || status >= 300) {
         skip = true;
       }
     }
@@ -298,8 +381,12 @@ class TransactionRunner {
   }
 
   getFullPath(serverPath, requestPath) {
-    if (serverPath === '/') { return requestPath; }
-    if (!requestPath) { return serverPath; }
+    if (serverPath === '/') {
+      return requestPath;
+    }
+    if (!requestPath) {
+      return serverPath;
+    }
 
     // Join two paths
     //
@@ -313,10 +400,13 @@ class TransactionRunner {
     // undesirable behavior depending on slashes.
     // See also https://github.com/joyent/node/issues/2216
     let segments = [serverPath, requestPath];
-    segments = (Array.from(segments).map(segment => segment.replace(/^\/|\/$/g, '')));
+    segments = Array.from(segments).map((segment) =>
+      segment.replace(/^\/|\/$/g, ''),
+    );
     // Keep trailing slash at the end if specified in requestPath
     // and if requestPath isn't only '/'
-    const trailingSlash = (requestPath !== '/') && (requestPath.slice(-1) === '/') ? '/' : '';
+    const trailingSlash =
+      requestPath !== '/' && requestPath.slice(-1) === '/' ? '/' : '';
     return `/${segments.join('/')}${trailingSlash}`;
   }
 
@@ -351,11 +441,17 @@ class TransactionRunner {
     transaction.fail = true;
 
     this.ensureTransactionErrors(transaction);
-    if (reason) { transaction.errors.push({ severity: 'error', message: reason }); }
+    if (reason) {
+      transaction.errors.push({ severity: 'error', message: reason });
+    }
 
-    if (!transaction.test) { transaction.test = this.createTest(transaction); }
+    if (!transaction.test) {
+      transaction.test = this.createTest(transaction);
+    }
     transaction.test.status = 'fail';
-    if (reason) { transaction.test.message = reason; }
+    if (reason) {
+      transaction.test.message = reason;
+    }
 
     this.ensureTestStructure(transaction);
   }
@@ -366,13 +462,17 @@ class TransactionRunner {
     transaction.skip = true;
 
     this.ensureTransactionErrors(transaction);
-    if (reason) { transaction.errors.push({ severity: 'warning', message: reason }); }
+    if (reason) {
+      transaction.errors.push({ severity: 'warning', message: reason });
+    }
 
     if (!transaction.test) {
       transaction.test = this.createTest(transaction);
     }
     transaction.test.status = 'skip';
-    if (reason) { transaction.test.message = reason; }
+    if (reason) {
+      transaction.test.message = reason;
+    }
 
     this.ensureTestStructure(transaction);
   }
@@ -380,8 +480,12 @@ class TransactionRunner {
   // Ensures that given transaction object has the "errors" key
   // where custom test run errors (not validation errors) are stored.
   ensureTransactionErrors(transaction) {
-    if (!transaction.results) { transaction.results = {}; }
-    if (!transaction.errors) { transaction.errors = []; }
+    if (!transaction.results) {
+      transaction.results = {};
+    }
+    if (!transaction.errors) {
+      transaction.errors = [];
+    }
 
     return transaction.errors;
   }
@@ -390,31 +494,54 @@ class TransactionRunner {
   // according to the test's status
   emitResult(transaction, callback) {
     if (this.error || !transaction.test) {
-      logger.debug('No emission of test data to reporters', this.error, transaction.test);
+      logger.debug(
+        'No emission of test data to reporters',
+        this.error,
+        transaction.test,
+      );
       this.error = null; // Reset the error indicator
       return callback();
     }
 
     if (transaction.skip) {
       logger.debug('Emitting to reporters: test skip');
-      this.configuration.emitter.emit('test skip', transaction.test, eventCallback);
+      this.configuration.emitter.emit(
+        'test skip',
+        transaction.test,
+        eventCallback,
+      );
       return callback();
     }
 
     if (transaction.test.valid) {
       if (transaction.fail) {
-        this.failTransaction(transaction, `Failed in after hook: ${transaction.fail}`);
+        this.failTransaction(
+          transaction,
+          `Failed in after hook: ${transaction.fail}`,
+        );
         logger.debug('Emitting to reporters: test fail');
-        this.configuration.emitter.emit('test fail', transaction.test, eventCallback);
+        this.configuration.emitter.emit(
+          'test fail',
+          transaction.test,
+          eventCallback,
+        );
       } else {
         logger.debug('Emitting to reporters: test pass');
-        this.configuration.emitter.emit('test pass', transaction.test, eventCallback);
+        this.configuration.emitter.emit(
+          'test pass',
+          transaction.test,
+          eventCallback,
+        );
       }
       return callback();
     }
 
     logger.debug('Emitting to reporters: test fail');
-    this.configuration.emitter.emit('test fail', transaction.test, eventCallback);
+    this.configuration.emitter.emit(
+      'test fail',
+      transaction.test,
+      eventCallback,
+    );
     callback();
   }
 
@@ -431,7 +558,9 @@ class TransactionRunner {
   // This is actually doing more some pre-flight and conditional skipping of
   // the transcation based on the configuration or hooks. TODO rename
   executeTransaction(transaction, hooks, callback) {
-    if (!callback) { [callback, hooks] = Array.from([hooks, undefined]); }
+    if (!callback) {
+      [callback, hooks] = Array.from([hooks, undefined]);
+    }
 
     // Number in miliseconds (UNIX-like timestamp * 1000 precision)
     transaction.startedAt = Date.now();
@@ -443,35 +572,57 @@ class TransactionRunner {
     this.ensureTransactionErrors(transaction);
 
     if (transaction.skip) {
-      logger.debug('HTTP transaction was marked in hooks as to be skipped. Skipping');
+      logger.debug(
+        'HTTP transaction was marked in hooks as to be skipped. Skipping',
+      );
       transaction.test = test;
       this.skipTransaction(transaction, 'Skipped in before hook');
       return callback();
-    } if (transaction.fail) {
-      logger.debug('HTTP transaction was marked in hooks as to be failed. Reporting as failed');
+    }
+    if (transaction.fail) {
+      logger.debug(
+        'HTTP transaction was marked in hooks as to be failed. Reporting as failed',
+      );
       transaction.test = test;
-      this.failTransaction(transaction, `Failed in before hook: ${transaction.fail}`);
+      this.failTransaction(
+        transaction,
+        `Failed in before hook: ${transaction.fail}`,
+      );
       return callback();
-    } if (this.configuration['dry-run']) {
+    }
+    if (this.configuration['dry-run']) {
       reporterOutputLogger.info('Dry run. Not performing HTTP request');
       transaction.test = test;
       this.skipTransaction(transaction);
       return callback();
-    } if (this.configuration.names) {
+    }
+    if (this.configuration.names) {
       reporterOutputLogger.info(transaction.name);
       transaction.test = test;
       this.skipTransaction(transaction);
       return callback();
-    } if ((this.configuration.method.length > 0) && !(Array.from(this.configuration.method).includes(transaction.request.method))) {
+    }
+    if (
+      this.configuration.method.length > 0 &&
+      !Array.from(this.configuration.method).includes(
+        transaction.request.method,
+      )
+    ) {
       logger.debug(`\
-Only ${(Array.from(this.configuration.method).map(m => m.toUpperCase())).join(', ')}\
+Only ${Array.from(this.configuration.method)
+        .map((m) => m.toUpperCase())
+        .join(', ')}\
 requests are set to be executed. \
 Not performing HTTP ${transaction.request.method.toUpperCase()} request.\
 `);
       transaction.test = test;
       this.skipTransaction(transaction);
       return callback();
-    } if ((this.configuration.only.length > 0) && !(Array.from(this.configuration.only).includes(transaction.name))) {
+    }
+    if (
+      this.configuration.only.length > 0 &&
+      !Array.from(this.configuration.only).includes(transaction.name)
+    ) {
       logger.debug(`\
 Only '${this.configuration.only}' transaction is set to be executed. \
 Not performing HTTP request for '${transaction.name}'.\
@@ -486,11 +637,12 @@ Not performing HTTP request for '${transaction.name}'.\
   // An actual HTTP request, before validation hooks triggering
   // and the response validation is invoked here
   performRequestAndValidate(test, transaction, hooks, callback) {
-    const uri = url.format({
-      protocol: transaction.protocol,
-      hostname: transaction.host,
-      port: transaction.port,
-    }) + transaction.fullPath;
+    const uri =
+      url.format({
+        protocol: transaction.protocol,
+        hostname: transaction.host,
+        port: transaction.port,
+      }) + transaction.fullPath;
     const options = { http: this.configuration.http };
 
     performRequest(uri, transaction.request, options, (error, real) => {
@@ -504,20 +656,31 @@ Not performing HTTP request for '${transaction.name}'.\
       }
       transaction.real = real;
 
-      logger.debug('Running \'beforeEachValidation\' hooks');
-      this.runHooksForData(hooks && hooks.beforeEachValidationHooks, transaction, () => {
-        if (this.hookHandlerError) { return callback(this.hookHandlerError); }
+      logger.debug("Running 'beforeEachValidation' hooks");
+      this.runHooksForData(
+        hooks && hooks.beforeEachValidationHooks,
+        transaction,
+        () => {
+          if (this.hookHandlerError) {
+            return callback(this.hookHandlerError);
+          }
 
-        logger.debug('Running \'beforeValidation\' hooks');
-        this.runHooksForData(hooks && hooks.beforeValidationHooks[transaction.name], transaction, () => {
-          if (this.hookHandlerError) { return callback(this.hookHandlerError); }
+          logger.debug("Running 'beforeValidation' hooks");
+          this.runHooksForData(
+            hooks && hooks.beforeValidationHooks[transaction.name],
+            transaction,
+            () => {
+              if (this.hookHandlerError) {
+                return callback(this.hookHandlerError);
+              }
 
-          this.validateTransaction(test, transaction, callback);
-        });
-      });
+              this.validateTransaction(test, transaction, callback);
+            },
+          );
+        },
+      );
     });
   }
-
 
   // TODO Rewrite this entire method.
   // Motivations:
@@ -555,13 +718,18 @@ Not performing HTTP request for '${transaction.name}'.\
     // Warn about empty responses
     // Expected is as string, actual is as integer :facepalm:
     const isExpectedResponseStatusCodeEmpty = ['204', '205'].includes(
-      test.expected.statusCode ? test.expected.statusCode.toString() : undefined
+      test.expected.statusCode
+        ? test.expected.statusCode.toString()
+        : undefined,
     );
     const isActualResponseStatusCodeEmpty = ['204', '205'].includes(
-      test.actual.statusCode ? test.actual.statusCode.toString() : undefined
+      test.actual.statusCode ? test.actual.statusCode.toString() : undefined,
     );
-    const hasBody = (test.expected.body || test.actual.body);
-    if ((isExpectedResponseStatusCodeEmpty || isActualResponseStatusCodeEmpty) && hasBody) {
+    const hasBody = test.expected.body || test.actual.body;
+    if (
+      (isExpectedResponseStatusCodeEmpty || isActualResponseStatusCodeEmpty) &&
+      hasBody
+    ) {
       logger.warn(`\
 ${test.title} HTTP 204 and 205 responses must not \
 include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
@@ -573,8 +741,9 @@ include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
 
     // Order-sensitive list of Gavel validation fields to output in the log
     // Note that Dredd asserts EXACTLY this order. Make sure to adjust tests upon change.
-    const loggedFields = ['headers', 'body', 'statusCode']
-      .filter(fieldName => Object.prototype.hasOwnProperty.call(gavelResult.fields, fieldName));
+    const loggedFields = ['headers', 'body', 'statusCode'].filter((fieldName) =>
+      Object.prototype.hasOwnProperty.call(gavelResult.fields, fieldName),
+    );
 
     loggedFields.forEach((fieldName) => {
       const fieldResult = gavelResult.fields[fieldName];
@@ -601,7 +770,9 @@ include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
     let reporterCount = this.configuration.emitter.listeners('end').length;
     this.configuration.emitter.emit('end', () => {
       reporterCount--;
-      if (reporterCount === 0) { callback(); }
+      if (reporterCount === 0) {
+        callback();
+      }
     });
   }
 }

--- a/lib/addHooks.js
+++ b/lib/addHooks.js
@@ -7,7 +7,6 @@ const logger = require('./logger');
 const reporterOutputLogger = require('./reporters/reporterOutputLogger');
 const resolvePaths = require('./resolvePaths');
 
-
 // The 'addHooks()' function is a strange glue code responsible for various
 // side effects needed as a preparation for loading Node.js hooks. It is
 // asynchronous only because as the last thing, it spawns the hooks handler
@@ -19,38 +18,48 @@ const resolvePaths = require('./resolvePaths');
 // or not. Side effects should get eliminated as much as possible in favor
 // of decoupling.
 
-
 function loadHookFile(hookfile, hooks) {
   try {
     proxyquire(hookfile, { hooks });
   } catch (error) {
-    logger.warn(`Skipping hook loading. Error reading hook file '${hookfile}'. `
-      + 'This probably means one or more of your hook files are invalid.\n'
-      + `Message: ${error.message}\n`
-      + `Stack: \n${error.stack}\n`);
+    logger.warn(
+      `Skipping hook loading. Error reading hook file '${hookfile}'. ` +
+        'This probably means one or more of your hook files are invalid.\n' +
+        `Message: ${error.message}\n` +
+        `Stack: \n${error.stack}\n`,
+    );
   }
 }
 
-
 module.exports = function addHooks(runner, transactions, callback) {
-  if (!runner.logs) { runner.logs = []; }
+  if (!runner.logs) {
+    runner.logs = [];
+  }
   runner.hooks = new Hooks({ logs: runner.logs, logger: reporterOutputLogger });
 
-  if (!runner.hooks.transactions) { runner.hooks.transactions = {}; }
+  if (!runner.hooks.transactions) {
+    runner.hooks.transactions = {};
+  }
 
   Array.from(transactions).forEach((transaction) => {
     runner.hooks.transactions[transaction.name] = transaction;
   });
 
   // No hooks
-  if (!runner.configuration.hookfiles || !runner.configuration.hookfiles.length) {
+  if (
+    !runner.configuration.hookfiles ||
+    !runner.configuration.hookfiles.length
+  ) {
     return callback();
   }
 
   // Loading hookfiles from fs
   let hookfiles;
   try {
-    hookfiles = resolvePaths(runner.configuration.custom.cwd, runner.configuration.hookfiles);
+    hookfiles = resolvePaths(
+      runner.configuration.custom.cwd,
+      runner.configuration.hookfiles,
+    );
   } catch (err) {
     return callback(err);
   }
@@ -66,14 +75,14 @@ module.exports = function addHooks(runner, transactions, callback) {
 
   // If the language is empty or it is nodejs
   if (
-    !runner.configuration.language
-    || runner.configuration.language === 'nodejs'
+    !runner.configuration.language ||
+    runner.configuration.language === 'nodejs'
   ) {
-    hookfiles.forEach(hookfile => loadHookFile(hookfile, runner.hooks));
+    hookfiles.forEach((hookfile) => loadHookFile(hookfile, runner.hooks));
     return callback();
   }
 
   // If other language than nodejs, run hooks worker client
   // Worker client will start the worker server and pass the "hookfiles" options as CLI arguments to it
-  return (new HooksWorkerClient(runner)).start(callback);
+  return new HooksWorkerClient(runner).start(callback);
 };

--- a/lib/annotationToLoggerInfo.js
+++ b/lib/annotationToLoggerInfo.js
@@ -1,6 +1,5 @@
 const compileTransactionName = require('./compileTransactionName');
 
-
 /**
  * Turns annotation type into a log level
  */
@@ -11,7 +10,6 @@ function typeToLogLevel(annotationType) {
   }
   return level;
 }
-
 
 /**
  * Takes a component identifier and turns it into something user can understand
@@ -30,7 +28,6 @@ function formatComponent(component) {
       return 'API description';
   }
 }
-
 
 /**
  * Formats given location data as something user can understand
@@ -51,12 +48,12 @@ function formatLocation(apiDescriptionLocation, annotationLocation) {
     return `${editorLink} (${from})`;
   }
 
-  const to = startLine === endLine
-    ? `column ${endColumn}`
-    : `line ${endLine} column ${endColumn}`;
+  const to =
+    startLine === endLine
+      ? `column ${endColumn}`
+      : `line ${endLine} column ${endColumn}`;
   return `${editorLink} (from ${from} to ${to})`;
 }
-
 
 /**
  * @typedef {Object} LoggerInfo A plain object winston.log() accepts as input
@@ -73,24 +70,27 @@ function formatLocation(apiDescriptionLocation, annotationLocation) {
  * @param {Object} annotation the annotation object from Dredd Transactions
  * @return {LoggerInfo}
  */
-module.exports = function annotationToLoggerInfo(apiDescriptionLocation, annotation) {
+module.exports = function annotationToLoggerInfo(
+  apiDescriptionLocation,
+  annotation,
+) {
   const level = typeToLogLevel(annotation.type);
 
   if (annotation.component === 'apiDescriptionParser') {
-    const message = (
-      `${formatComponent(annotation.component)} ${annotation.type}`
-      + ` in ${formatLocation(apiDescriptionLocation, annotation.location)}:`
-      + ` ${annotation.message}`
-    );
+    const message =
+      `${formatComponent(annotation.component)} ${annotation.type}` +
+      ` in ${formatLocation(apiDescriptionLocation, annotation.location)}:` +
+      ` ${annotation.message}`;
     return { level, message };
   }
 
   // See https://github.com/apiaryio/dredd-transactions/issues/275 why this
   // is handled in a different way than parser annotations
-  const message = (
-    `${formatComponent(annotation.component)} ${annotation.type}`
-    + ` in ${apiDescriptionLocation} (${compileTransactionName(annotation.origin)}):`
-    + ` ${annotation.message}`
-  );
+  const message =
+    `${formatComponent(annotation.component)} ${annotation.type}` +
+    ` in ${apiDescriptionLocation} (${compileTransactionName(
+      annotation.origin,
+    )}):` +
+    ` ${annotation.message}`;
   return { level, message };
 };

--- a/lib/childProcess.js
+++ b/lib/childProcess.js
@@ -2,13 +2,11 @@ const crossSpawn = require('cross-spawn');
 
 const ignorePipeErrors = require('./ignorePipeErrors');
 
-
 const ASCII_CTRL_C = 3;
 const IS_WINDOWS = process.platform === 'win32';
 const TERM_FIRST_CHECK_TIMEOUT_MS = 1;
 const TERM_DEFAULT_TIMEOUT_MS = 1000;
 const TERM_DEFAULT_RETRY_MS = 300;
-
 
 // Signals the child process to forcefully terminate
 function signalKill(childProcess, callback) {
@@ -18,7 +16,9 @@ function signalKill(childProcess, callback) {
     taskkill.on('exit', (exitStatus) => {
       if (exitStatus) {
         return callback(
-          new Error(`Unable to forcefully terminate process ${childProcess.pid}`)
+          new Error(
+            `Unable to forcefully terminate process ${childProcess.pid}`,
+          ),
         );
       }
       callback();
@@ -28,7 +28,6 @@ function signalKill(childProcess, callback) {
     process.nextTick(callback);
   }
 }
-
 
 // Signals the child process to gracefully terminate
 function signalTerm(childProcess, callback) {
@@ -58,7 +57,6 @@ function signalTerm(childProcess, callback) {
   process.nextTick(callback);
 }
 
-
 // Gracefully terminates a child process
 //
 // Sends a signal to the process as a heads up it should terminate.
@@ -75,13 +73,17 @@ function signalTerm(childProcess, callback) {
 // - retryDelay (number) - Delay in ms between termination attempts
 // - force (boolean) - Kills the process forcefully after the timeout
 function terminate(childProcess, options = {}, callback) {
-  if (typeof options === 'function') { [callback, options] = Array.from([options, {}]); }
+  if (typeof options === 'function') {
+    [callback, options] = Array.from([options, {}]);
+  }
   const force = options.force || false;
 
   // If the timeout is zero or less then the delay for waiting between
   // retries, there will be just one termination attempt
   const timeout = options.timeout ? options.timeout : TERM_DEFAULT_TIMEOUT_MS;
-  const retryDelay = options.retryDelay ? options.retryDelay : TERM_DEFAULT_RETRY_MS;
+  const retryDelay = options.retryDelay
+    ? options.retryDelay
+    : TERM_DEFAULT_RETRY_MS;
 
   let terminated = false;
   const onExit = () => {
@@ -101,10 +103,12 @@ function terminate(childProcess, options = {}, callback) {
       clearTimeout(t);
       return callback();
     }
-    if ((Date.now() - start) < timeout) {
+    if (Date.now() - start < timeout) {
       // Still not terminated, try again
       signalTerm(childProcess, (err) => {
-        if (err) { return callback(err); }
+        if (err) {
+          return callback(err);
+        }
         t = setTimeout(check, retryDelay);
       });
     } else {
@@ -115,7 +119,9 @@ function terminate(childProcess, options = {}, callback) {
         signalKill(childProcess, callback);
       } else {
         callback(
-          new Error(`Unable to gracefully terminate process ${childProcess.pid}`)
+          new Error(
+            `Unable to gracefully terminate process ${childProcess.pid}`,
+          ),
         );
       }
     }
@@ -123,11 +129,12 @@ function terminate(childProcess, options = {}, callback) {
 
   // Fire the first termination attempt and check the result
   signalTerm(childProcess, (err) => {
-    if (err) { return callback(err); }
+    if (err) {
+      return callback(err);
+    }
     t = setTimeout(check, TERM_FIRST_CHECK_TIMEOUT_MS);
   });
 }
-
 
 function spawn(...args) {
   const childProcess = crossSpawn.spawn.apply(null, args);
@@ -139,29 +146,39 @@ function spawn(...args) {
   let killedIntentionally = false;
   let terminatedIntentionally = false;
 
-  childProcess.on('signalKill', () => { killedIntentionally = true; });
-  childProcess.on('signalTerm', () => { terminatedIntentionally = true; });
+  childProcess.on('signalKill', () => {
+    killedIntentionally = true;
+  });
+  childProcess.on('signalTerm', () => {
+    terminatedIntentionally = true;
+  });
 
   childProcess.signalKill = () => {
     signalKill(childProcess, (err) => {
-      if (err) { childProcess.emit('error', err); }
+      if (err) {
+        childProcess.emit('error', err);
+      }
     });
   };
 
   childProcess.signalTerm = () => {
     signalTerm(childProcess, (err) => {
-      if (err) { childProcess.emit('error', err); }
+      if (err) {
+        childProcess.emit('error', err);
+      }
     });
   };
 
   childProcess.terminate = (options) => {
     terminate(childProcess, options, (err) => {
-      if (err) { childProcess.emit('error', err); }
+      if (err) {
+        childProcess.emit('error', err);
+      }
     });
   };
 
   childProcess.on('error', (err) => {
-    if (err.syscall && (err.syscall.indexOf('spawn') >= 0)) {
+    if (err.syscall && err.syscall.indexOf('spawn') >= 0) {
       childProcess.spawned = false;
     }
   });
@@ -201,7 +218,6 @@ function spawn(...args) {
 
   return childProcess;
 }
-
 
 module.exports = {
   signalKill,

--- a/lib/compileTransactionName.js
+++ b/lib/compileTransactionName.js
@@ -2,13 +2,22 @@
 // it's also tested. This is a temporary solution,
 // see https://github.com/apiaryio/dredd-transactions/issues/276
 
-
 module.exports = function compileTransactionName(origin) {
   const segments = [];
-  if (origin.apiName) { segments.push(origin.apiName); }
-  if (origin.resourceGroupName) { segments.push(origin.resourceGroupName); }
-  if (origin.resourceName) { segments.push(origin.resourceName); }
-  if (origin.actionName) { segments.push(origin.actionName); }
-  if (origin.exampleName) { segments.push(origin.exampleName); }
+  if (origin.apiName) {
+    segments.push(origin.apiName);
+  }
+  if (origin.resourceGroupName) {
+    segments.push(origin.resourceGroupName);
+  }
+  if (origin.resourceName) {
+    segments.push(origin.resourceName);
+  }
+  if (origin.actionName) {
+    segments.push(origin.actionName);
+  }
+  if (origin.exampleName) {
+    segments.push(origin.exampleName);
+  }
   return segments.join(' > ');
 };

--- a/lib/configUtils.js
+++ b/lib/configUtils.js
@@ -2,9 +2,10 @@ const clone = require('clone');
 const fs = require('fs');
 const yaml = require('js-yaml');
 
-
 function save(argsOrigin, path) {
-  if (!path) { path = './dredd.yml'; }
+  if (!path) {
+    path = './dredd.yml';
+  }
 
   const args = clone(argsOrigin);
 
@@ -12,7 +13,9 @@ function save(argsOrigin, path) {
   args.endpoint = args._[1];
 
   Object.keys(args).forEach((key) => {
-    if (key.length === 1) { delete args[key]; }
+    if (key.length === 1) {
+      delete args[key];
+    }
   });
 
   delete args.$0;
@@ -21,9 +24,10 @@ function save(argsOrigin, path) {
   fs.writeFileSync(path, yaml.dump(args));
 }
 
-
 function load(path) {
-  if (!path) { path = './dredd.yml'; }
+  if (!path) {
+    path = './dredd.yml';
+  }
 
   const yamlData = fs.readFileSync(path);
   const data = yaml.safeLoad(yamlData);
@@ -36,7 +40,6 @@ function load(path) {
   return data;
 }
 
-
 function parseCustom(customArray) {
   const output = {};
   if (Array.isArray(customArray)) {
@@ -47,7 +50,6 @@ function parseCustom(customArray) {
   }
   return output;
 }
-
 
 module.exports = {
   save,

--- a/lib/configuration/applyConfiguration.js
+++ b/lib/configuration/applyConfiguration.js
@@ -64,8 +64,8 @@ function flattenConfig(config) {
     R.has('server'),
     R.compose(
       R.dissoc('server'),
-      R.assoc('endpoint', R.prop('server', config))
-    )
+      R.assoc('endpoint', R.prop('server', config)),
+    ),
   )(config);
 
   const rootOptions = R.omit(['options'], aliasedConfig);
@@ -84,13 +84,13 @@ function resolveConfig(config) {
     // During deep merge Ramda omits prototypes, breaking emitter.
     R.assoc('emitter', R.propOr(new EventEmitter(), 'emitter', config)),
     R.mergeDeepRight(DEFAULT_CONFIG),
-    flattenConfig
+    flattenConfig,
   )(config);
 
   // Validate Dredd configuration
   const { warnings, errors } = validateConfig(inConfig);
-  warnings.forEach(message => logger.warn(message));
-  errors.forEach(message => logger.error(message));
+  warnings.forEach((message) => logger.warn(message));
+  errors.forEach((message) => logger.error(message));
 
   // Fail fast upon any Dredd configuration errors
   if (errors.length > 0) {
@@ -113,9 +113,11 @@ function applyConfiguration(config) {
   const proxySettings = getProxySettings(process.env);
   if (proxySettings.length) {
     logger.warn(
-      `HTTP(S) proxy specified by environment variables: ${proxySettings.join(', ')}. `
-      + 'Please read documentation on how Dredd works with proxies: '
-      + 'https://dredd.org/en/latest/how-it-works/#using-https-proxy'
+      `HTTP(S) proxy specified by environment variables: ${proxySettings.join(
+        ', ',
+      )}. ` +
+        'Please read documentation on how Dredd works with proxies: ' +
+        'https://dredd.org/en/latest/how-it-works/#using-https-proxy',
     );
   }
 

--- a/lib/configuration/applyLoggingOptions.js
+++ b/lib/configuration/applyLoggingOptions.js
@@ -25,8 +25,10 @@ function applyLoggingOptions(config) {
       logger.transports.console.level = loglevel;
     } else {
       logger.transports.console.level = 'warn';
-      throw new Error(`The logging level '${loglevel}' is unsupported, `
-        + 'supported are: silent, error, warning, debug');
+      throw new Error(
+        `The logging level '${loglevel}' is unsupported, ` +
+          'supported are: silent, error, warning, debug',
+      );
     }
   } else {
     logger.transports.console.level = 'warn';

--- a/lib/configuration/normalizeConfig.js
+++ b/lib/configuration/normalizeConfig.js
@@ -11,23 +11,23 @@ const removeUnsupportedOptions = R.compose(
   R.dissoc('timestamp'),
   R.dissoc('blueprintPath'),
   R.dissoc('b'),
-  R.dissoc('sandbox')
+  R.dissoc('sandbox'),
 );
 
 const getUserHeader = R.compose(
-  token => `Authorization: Basic ${token}`,
-  user => Buffer.from(user).toString('base64')
+  (token) => `Authorization: Basic ${token}`,
+  (user) => Buffer.from(user).toString('base64'),
 );
 
 const updateHeaderWithUser = R.compose(
   R.unnest,
   R.adjust(0, getUserHeader),
   R.values,
-  R.pick(['user', 'header'])
+  R.pick(['user', 'header']),
 );
 
 const coerceToArray = R.cond([
-  [R.is(String), v => [v]],
+  [R.is(String), (v) => [v]],
   [R.isNil, R.always([])],
   [R.T, R.identity],
 ]);
@@ -46,11 +46,8 @@ const coerceUserOption = R.when(
   R.propSatisfies(R.complement(R.isNil), 'user'),
   R.compose(
     R.dissoc('user'),
-    R.over(
-      R.lens(updateHeaderWithUser, R.assoc('header')),
-      R.identity
-    )
-  )
+    R.over(R.lens(updateHeaderWithUser, R.assoc('header')), R.identity),
+  ),
 );
 
 const mapIndexed = R.addIndex(R.map);
@@ -60,20 +57,17 @@ const coerceApiDescriptions = R.compose(
     location: `configuration.apiDescriptions[${index}]`,
     content: R.when(R.has('content'), R.prop('content'), content),
   })),
-  coerceToArray
+  coerceToArray,
 );
 
 const coerceLevel = R.compose(
   R.cond([
-    [
-      R.includes(R.__, ['silly', 'debug', 'verbose']),
-      R.always('debug'),
-    ],
+    [R.includes(R.__, ['silly', 'debug', 'verbose']), R.always('debug')],
     [R.equals('error'), R.always('error')],
     [R.equals('silent'), R.always('silent')],
     [R.T, R.always('warn')],
   ]),
-  R.either(R.prop('l'), R.prop('level'))
+  R.either(R.prop('l'), R.prop('level')),
 );
 
 /**
@@ -85,11 +79,8 @@ const coerceDeprecatedLevelOption = R.when(
   R.compose(
     R.dissoc('l'),
     R.dissoc('level'),
-    R.over(
-      R.lens(coerceLevel, R.assoc('loglevel')),
-      R.identity
-    )
-  )
+    R.over(R.lens(coerceLevel, R.assoc('loglevel')), R.identity),
+  ),
 );
 
 const coerceDataToApiDescriptions = R.compose(
@@ -98,19 +89,20 @@ const coerceDataToApiDescriptions = R.compose(
   R.evolve({
     data: R.compose(
       R.map(([location, content]) => {
-        const apiDescription = (typeof content === 'string')
-          ? { location, content }
-          : {
-            location: content.filename,
-            content: content.raw,
-          };
+        const apiDescription =
+          typeof content === 'string'
+            ? { location, content }
+            : {
+                location: content.filename,
+                content: content.raw,
+              };
 
         return apiDescription;
       }),
-      R.toPairs
+      R.toPairs,
     ),
   }),
-  R.pick(['apiDescriptions', 'data'])
+  R.pick(['apiDescriptions', 'data']),
 );
 
 const coerceDeprecatedDataOption = R.when(
@@ -118,30 +110,24 @@ const coerceDeprecatedDataOption = R.when(
   R.compose(
     R.dissoc('data'),
     R.over(
-      R.lens(
-        coerceDataToApiDescriptions,
-        R.assoc('apiDescriptions')
-      ),
-      R.identity
-    )
-  )
+      R.lens(coerceDataToApiDescriptions, R.assoc('apiDescriptions')),
+      R.identity,
+    ),
+  ),
 );
 
 const coerceColorOption = R.when(
   R.has('c'),
   R.compose(
     R.dissoc('c'),
-    R.over(
-      R.lens(R.prop('c'), R.assoc('color')),
-      coerceToBoolean
-    )
-  )
+    R.over(R.lens(R.prop('c'), R.assoc('color')), coerceToBoolean),
+  ),
 );
 
 const coerceDeprecatedOptions = R.compose(
   coerceColorOption,
   coerceDeprecatedDataOption,
-  coerceDeprecatedLevelOption
+  coerceDeprecatedLevelOption,
 );
 
 const coerceOptions = R.compose(
@@ -153,16 +139,19 @@ const coerceOptions = R.compose(
     reporter: coerceToArray,
     output: coerceToArray,
     header: coerceToArray,
-    method: R.compose(R.map(R.toUpper), coerceToArray),
+    method: R.compose(
+      R.map(R.toUpper),
+      coerceToArray,
+    ),
     only: coerceToArray,
     path: coerceToArray,
     hookfiles: coerceToArray,
-  })
+  }),
 );
 
 const normalizeConfig = R.compose(
   coerceOptions,
-  removeUnsupportedOptions
+  removeUnsupportedOptions,
 );
 
 normalizeConfig.removeUnsupportedOptions = removeUnsupportedOptions;

--- a/lib/configuration/validateConfig.js
+++ b/lib/configuration/validateConfig.js
@@ -1,46 +1,54 @@
 const deprecatedOptions = [
   {
     options: ['c'],
-    message: 'DEPRECATED: The -c configuration option is deprecated. Plese use --color instead.',
+    message:
+      'DEPRECATED: The -c configuration option is deprecated. Plese use --color instead.',
   },
   {
     options: ['data'],
-    message: 'DEPRECATED: The --data configuration option is deprecated '
-    + 'in favor of `apiDescriptions`, please see https://dredd.org',
+    message:
+      'DEPRECATED: The --data configuration option is deprecated ' +
+      'in favor of `apiDescriptions`, please see https://dredd.org',
   },
   {
     options: ['blueprintPath'],
-    message: 'DEPRECATED: The --blueprintPath configuration option is deprecated, '
-    + 'please use --path instead.',
+    message:
+      'DEPRECATED: The --blueprintPath configuration option is deprecated, ' +
+      'please use --path instead.',
   },
   {
     options: ['level'],
-    message: 'DEPRECATED: The --level configuration option is deprecated. Please use --loglevel instead.',
+    message:
+      'DEPRECATED: The --level configuration option is deprecated. Please use --loglevel instead.',
   },
 ];
 
 const unsupportedOptions = [
   {
     options: ['timestamp', 't'],
-    message: 'REMOVED: The --timestamp/-t configuration option is no longer supported. Please use --loglevel=debug instead.',
+    message:
+      'REMOVED: The --timestamp/-t configuration option is no longer supported. Please use --loglevel=debug instead.',
   },
   {
     options: ['silent', 'q'],
-    message: 'REMOVED: The --silent/-q configuration option is no longer supported. Please use --loglevel=silent instead.',
+    message:
+      'REMOVED: The --silent/-q configuration option is no longer supported. Please use --loglevel=silent instead.',
   },
   {
     options: ['sandbox', 'b'],
-    message: 'REMOVED: Dredd does not support sandboxed JS hooks anymore, use standard JS hooks instead.',
+    message:
+      'REMOVED: Dredd does not support sandboxed JS hooks anymore, use standard JS hooks instead.',
   },
   {
     options: ['hooksData'],
-    message: 'REMOVED: Dredd does not support sandboxed JS hooks anymore, use standard JS hooks instead.',
+    message:
+      'REMOVED: Dredd does not support sandboxed JS hooks anymore, use standard JS hooks instead.',
   },
 ];
 
 function flushMessages(rules, config) {
   return Object.keys(config).reduce((messages, configKey) => {
-    const warning = rules.find(rule => rule.options.includes(configKey));
+    const warning = rules.find((rule) => rule.options.includes(configKey));
     return warning ? messages.concat(warning.message) : messages;
   }, []);
 }
@@ -48,7 +56,7 @@ function flushMessages(rules, config) {
 /**
  * Returns the errors and warnings relative to the given config.
  */
-const validateConfig = config => ({
+const validateConfig = (config) => ({
   warnings: flushMessages(deprecatedOptions, config),
   errors: flushMessages(unsupportedOptions, config),
 });

--- a/lib/configureReporters.js
+++ b/lib/configureReporters.js
@@ -9,18 +9,15 @@ const XUnitReporter = require('./reporters/XUnitReporter');
 
 const logger = require('./logger');
 
-const fileReporters = [
-  'xunit',
-  'html',
-  'markdown',
-  'apiary',
-];
+const fileReporters = ['xunit', 'html', 'markdown', 'apiary'];
 
 const cliReporters = ['dot', 'nyan'];
 
 function intersection(a, b) {
-  if (a.length > b.length) { [a, b] = Array.from([b, a]); }
-  return Array.from(a).filter(value => Array.from(b).includes(value));
+  if (a.length > b.length) {
+    [a, b] = Array.from([b, a]);
+  }
+  return Array.from(a).filter((value) => Array.from(b).includes(value));
 }
 
 function configureReporters(config, stats, runner) {
@@ -36,13 +33,19 @@ function configureReporters(config, stats, runner) {
       const usedCliReporters = intersection(reportersArr, cliReporters);
       if (usedCliReporters.length === 0) {
         return new CLIReporter(
-          config.emitter, stats, config['inline-errors'], config.details
+          config.emitter,
+          stats,
+          config['inline-errors'],
+          config.details,
         );
       }
       return addReporter(usedCliReporters[0], config.emitter, stats);
     }
     return new CLIReporter(
-      config.emitter, stats, config['inline-errors'], config.details
+      config.emitter,
+      stats,
+      config['inline-errors'],
+      config.details,
     );
   }
 
@@ -63,7 +66,7 @@ function configureReporters(config, stats, runner) {
       default:
         // I don't even know where to begin...
         // TODO: DESIGN / REFACTOR WHOLE REPORTER(S) API FROM SCRATCH, THIS IS MADNESS!!1
-        (new BaseReporter(emitter, statistics));
+        new BaseReporter(emitter, statistics);
     }
   }
 

--- a/lib/getGoBinary.js
+++ b/lib/getGoBinary.js
@@ -9,10 +9,14 @@ module.exports = function getGoBinary(callback) {
   if (goBin) {
     process.nextTick(() => callback(null, goBin));
   } else if (process.env.GOPATH) {
-    process.nextTick(() => callback(null, path.join(process.env.GOPATH, 'bin')));
+    process.nextTick(() =>
+      callback(null, path.join(process.env.GOPATH, 'bin')),
+    );
   } else {
     childProcess.exec('go env GOPATH', (err, stdout) => {
-      if (err) { return callback(err); }
+      if (err) {
+        return callback(err);
+      }
       callback(null, path.join(stdout.trim(), 'bin'));
     });
   }

--- a/lib/getProxySettings.js
+++ b/lib/getProxySettings.js
@@ -1,6 +1,5 @@
 const PROXY_ENV_VARIABLES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 
-
 /**
  * Expects an environment variables object (typically process.env)
  * and returns an array of strings representing HTTP proxy settings,
@@ -16,7 +15,7 @@ const PROXY_ENV_VARIABLES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
  */
 module.exports = function getProxySettings(env) {
   return Object.entries(env)
-    .filter(entry => PROXY_ENV_VARIABLES.includes(entry[0].toUpperCase()))
-    .filter(entry => entry[1] !== '')
-    .map(entry => `${entry[0]}=${entry[1]}`);
+    .filter((entry) => PROXY_ENV_VARIABLES.includes(entry[0].toUpperCase()))
+    .filter((entry) => entry[1] !== '')
+    .map((entry) => `${entry[0]}=${entry[1]}`);
 };

--- a/lib/hooksLog.js
+++ b/lib/hooksLog.js
@@ -2,7 +2,9 @@ const util = require('util');
 
 module.exports = function hooksLog(logs = [], logger, content) {
   // Log to logger
-  if (logger && typeof logger.hook === 'function') { logger.hook(content); }
+  if (logger && typeof logger.hook === 'function') {
+    logger.hook(content);
+  }
 
   // Append to array of logs to allow further operations, e.g. send all hooks logs to Apiary
   logs.push({

--- a/lib/init.js
+++ b/lib/init.js
@@ -8,21 +8,27 @@ const yaml = require('js-yaml');
 
 const packageData = require('../package.json');
 
-
 const INSTALL_DREDD = `npm install dredd@${packageData.version} --global`;
 const RUN_DREDD = 'dredd';
 
-
 function init(config, save, callback) {
-  if (!config) { config = {}; }
-  if (!config._) { config._ = []; }
-  if (!config.custom) { config.custom = {}; }
+  if (!config) {
+    config = {};
+  }
+  if (!config._) {
+    config._ = [];
+  }
+  if (!config.custom) {
+    config.custom = {};
+  }
 
   const files = fs.readdirSync('.');
   const detected = detect(files);
 
   prompt(config, detected, (error, answers) => {
-    if (error) { callback(error); }
+    if (error) {
+      callback(error);
+    }
 
     const updatedConfig = applyAnswers(config, answers);
     save(updatedConfig);
@@ -31,7 +37,6 @@ function init(config, save, callback) {
     callback();
   });
 }
-
 
 function detect(files) {
   return {
@@ -42,131 +47,130 @@ function detect(files) {
   };
 }
 
-
 function prompt(config, detected, callback) {
-  inquirer.prompt([
-    {
-      name: 'apiDescription',
-      message: 'Location of the API description document',
-      type: 'input',
-      default: config.blueprint || detected.apiDescription,
-    },
-    {
-      name: 'server',
-      message: 'Command to start the API server under test',
-      type: 'input',
-      default: config.server || detected.server,
-    },
-    {
-      name: 'apiHost',
-      message: 'Host of the API under test',
-      type: 'input',
-      default: config.endpoint || 'http://127.0.0.1:3000',
-    },
-    {
-      name: 'hooks',
-      message: 'Do you want to use hooks to customize Dredd\'s behavior?',
-      type: 'confirm',
-      default: true,
-      when: () => config.language === 'nodejs',
-    },
-    {
-      name: 'language',
-      message: 'Programming language of the hooks',
-      type: 'list',
-      default: detected.language,
-      choices: [
-        { name: 'Go', value: 'go' },
-        { name: 'JavaScript', value: 'nodejs' },
-        { name: 'Perl', value: 'perl' },
-        { name: 'PHP', value: 'php' },
-        { name: 'Python', value: 'python' },
-        { name: 'Ruby', value: 'ruby' },
-        { name: 'Rust', value: 'rust' },
-      ],
-      when: answers => answers.hooks,
-    },
-    {
-      name: 'apiary',
-      message: 'Do you want to report your tests to the Apiary inspector?',
-      type: 'confirm',
-      default: true,
-      when: () => config.reporter !== 'apiary',
-    },
-    {
-      name: 'apiaryApiKey',
-      message: 'Enter Apiary API key (leave empty for anonymous, disposable test reports)',
-      type: 'input',
-      default: config.custom ? config.custom.apiaryApiKey : undefined,
-      when: answers => (
-        answers.apiary
-        && (!config.custom || !config.custom.apiaryApiKey)
-      ),
-    },
-    {
-      name: 'apiaryApiName',
-      message: 'Enter Apiary API name',
-      type: 'input',
-      default: config.custom ? config.custom.apiaryApiName : undefined,
-      when: answers => (
-        answers.apiary
-        && answers.apiaryApiKey
-        && (!config.custom || !config.custom.apiaryApiName)
-      ),
-    },
-    {
-      name: 'appveyor',
-      message: 'Found AppVeyor configuration, do you want to add Dredd?',
-      type: 'confirm',
-      default: true,
-      when: () => detected.ci.includes('appveyor'),
-    },
-    {
-      name: 'circleci',
-      message: 'Found CircleCI configuration, do you want to add Dredd?',
-      type: 'confirm',
-      default: true,
-      when: () => detected.ci.includes('circleci'),
-    },
-    {
-      name: 'travisci',
-      message: 'Found Travis CI configuration, do you want to add Dredd?',
-      type: 'confirm',
-      default: true,
-      when: () => detected.ci.includes('travisci'),
-    },
-    {
-      name: 'wercker',
-      message: 'Found Wercker configuration, do you want to add Dredd?',
-      type: 'confirm',
-      default: true,
-      when: () => detected.ci.includes('wercker'),
-    },
-    {
-      name: 'ci',
-      message: 'Dredd is best served with Continuous Integration. Do you want to create CI configuration?',
-      type: 'confirm',
-      default: true,
-      when: () => !detected.ci.length,
-    },
-    {
-      name: 'createCI',
-      message: 'Which CI do you want to use?',
-      type: 'list',
-      default: 'travisci',
-      choices: [
-        { name: 'AppVeyor', value: 'appveyor' },
-        { name: 'CircleCI', value: 'circleci' },
-        { name: 'Travis CI', value: 'travisci' },
-        { name: 'Wercker (Oracle Container Pipelines)', value: 'wercker' },
-      ],
-      when: answers => answers.ci,
-    },
-  ]).then((answers) => {
-    callback(null, answers);
-  });
+  inquirer
+    .prompt([
+      {
+        name: 'apiDescription',
+        message: 'Location of the API description document',
+        type: 'input',
+        default: config.blueprint || detected.apiDescription,
+      },
+      {
+        name: 'server',
+        message: 'Command to start the API server under test',
+        type: 'input',
+        default: config.server || detected.server,
+      },
+      {
+        name: 'apiHost',
+        message: 'Host of the API under test',
+        type: 'input',
+        default: config.endpoint || 'http://127.0.0.1:3000',
+      },
+      {
+        name: 'hooks',
+        message: "Do you want to use hooks to customize Dredd's behavior?",
+        type: 'confirm',
+        default: true,
+        when: () => config.language === 'nodejs',
+      },
+      {
+        name: 'language',
+        message: 'Programming language of the hooks',
+        type: 'list',
+        default: detected.language,
+        choices: [
+          { name: 'Go', value: 'go' },
+          { name: 'JavaScript', value: 'nodejs' },
+          { name: 'Perl', value: 'perl' },
+          { name: 'PHP', value: 'php' },
+          { name: 'Python', value: 'python' },
+          { name: 'Ruby', value: 'ruby' },
+          { name: 'Rust', value: 'rust' },
+        ],
+        when: (answers) => answers.hooks,
+      },
+      {
+        name: 'apiary',
+        message: 'Do you want to report your tests to the Apiary inspector?',
+        type: 'confirm',
+        default: true,
+        when: () => config.reporter !== 'apiary',
+      },
+      {
+        name: 'apiaryApiKey',
+        message:
+          'Enter Apiary API key (leave empty for anonymous, disposable test reports)',
+        type: 'input',
+        default: config.custom ? config.custom.apiaryApiKey : undefined,
+        when: (answers) =>
+          answers.apiary && (!config.custom || !config.custom.apiaryApiKey),
+      },
+      {
+        name: 'apiaryApiName',
+        message: 'Enter Apiary API name',
+        type: 'input',
+        default: config.custom ? config.custom.apiaryApiName : undefined,
+        when: (answers) =>
+          answers.apiary &&
+          answers.apiaryApiKey &&
+          (!config.custom || !config.custom.apiaryApiName),
+      },
+      {
+        name: 'appveyor',
+        message: 'Found AppVeyor configuration, do you want to add Dredd?',
+        type: 'confirm',
+        default: true,
+        when: () => detected.ci.includes('appveyor'),
+      },
+      {
+        name: 'circleci',
+        message: 'Found CircleCI configuration, do you want to add Dredd?',
+        type: 'confirm',
+        default: true,
+        when: () => detected.ci.includes('circleci'),
+      },
+      {
+        name: 'travisci',
+        message: 'Found Travis CI configuration, do you want to add Dredd?',
+        type: 'confirm',
+        default: true,
+        when: () => detected.ci.includes('travisci'),
+      },
+      {
+        name: 'wercker',
+        message: 'Found Wercker configuration, do you want to add Dredd?',
+        type: 'confirm',
+        default: true,
+        when: () => detected.ci.includes('wercker'),
+      },
+      {
+        name: 'ci',
+        message:
+          'Dredd is best served with Continuous Integration. Do you want to create CI configuration?',
+        type: 'confirm',
+        default: true,
+        when: () => !detected.ci.length,
+      },
+      {
+        name: 'createCI',
+        message: 'Which CI do you want to use?',
+        type: 'list',
+        default: 'travisci',
+        choices: [
+          { name: 'AppVeyor', value: 'appveyor' },
+          { name: 'CircleCI', value: 'circleci' },
+          { name: 'Travis CI', value: 'travisci' },
+          { name: 'Wercker (Oracle Container Pipelines)', value: 'wercker' },
+        ],
+        when: (answers) => answers.ci,
+      },
+    ])
+    .then((answers) => {
+      callback(null, answers);
+    });
 }
-
 
 function applyAnswers(config, answers, options = {}) {
   const ci = options.ci || {
@@ -182,9 +186,15 @@ function applyAnswers(config, answers, options = {}) {
   config.server = answers.server || null;
   config.language = answers.language || 'nodejs';
 
-  if (answers.apiary) { config.reporter = 'apiary'; }
-  if (answers.apiaryApiKey) { config.custom.apiaryApiKey = answers.apiaryApiKey; }
-  if (answers.apiaryApiName) { config.custom.apiaryApiName = answers.apiaryApiName; }
+  if (answers.apiary) {
+    config.reporter = 'apiary';
+  }
+  if (answers.apiaryApiKey) {
+    config.custom.apiaryApiKey = answers.apiaryApiKey;
+  }
+  if (answers.apiaryApiName) {
+    config.custom.apiaryApiName = answers.apiaryApiName;
+  }
 
   if (answers.createCI) {
     ci[answers.createCI]();
@@ -199,7 +209,6 @@ function applyAnswers(config, answers, options = {}) {
   return config;
 }
 
-
 function printClosingMessage(config, print = console.log) {
   print('\nConfiguration saved to dredd.yml\n');
   if (config.language === 'nodejs') {
@@ -209,22 +218,28 @@ function printClosingMessage(config, print = console.log) {
   }
   switch (config.language) {
     case 'ruby':
-      print('  $ gem install dredd_hooks'); break;
+      print('  $ gem install dredd_hooks');
+      break;
     case 'python':
-      print('  $ pip install dredd_hooks'); break;
+      print('  $ pip install dredd_hooks');
+      break;
     case 'php':
-      print('  $ composer require ddelnano/dredd-hooks-php --dev'); break;
+      print('  $ composer require ddelnano/dredd-hooks-php --dev');
+      break;
     case 'perl':
-      print('  $ cpanm Dredd::Hooks'); break;
+      print('  $ cpanm Dredd::Hooks');
+      break;
     case 'go':
-      print('  $ go get github.com/snikch/goodman/cmd/goodman'); break;
+      print('  $ go get github.com/snikch/goodman/cmd/goodman');
+      break;
     case 'rust':
-      print('  $ cargo install dredd-hooks'); break;
-    default: break;
+      print('  $ cargo install dredd-hooks');
+      break;
+    default:
+      break;
   }
   print('  $ dredd\n');
 }
-
 
 function editYaml(file, update) {
   const contents = fs.existsSync(file)
@@ -237,32 +252,40 @@ function editYaml(file, update) {
   fs.writeFileSync(file, yaml.safeDump(contents));
 }
 
-
 function updateAppVeyor(options = {}) {
   const edit = options.editYaml || editYaml;
 
   edit('appveyor.yml', (contents) => {
-    if (!contents.install) { contents.install = []; }
+    if (!contents.install) {
+      contents.install = [];
+    }
 
     contents.install.push({ ps: 'Install-Product node' });
     contents.install.push('set PATH=%APPDATA%\\npm;%PATH%');
     contents.install.push(INSTALL_DREDD);
 
-    if (!contents.build) { contents.build = false; }
+    if (!contents.build) {
+      contents.build = false;
+    }
 
-    if (!contents.test_script) { contents.test_script = []; }
+    if (!contents.test_script) {
+      contents.test_script = [];
+    }
     contents.test_script.push(RUN_DREDD);
   });
 }
-
 
 function updateCircleCI(options = {}) {
   const edit = options.editYaml || editYaml;
 
   edit('.circleci/config.yml', (contents) => {
-    if (!contents.version) { contents.version = 2; }
+    if (!contents.version) {
+      contents.version = 2;
+    }
 
-    if (!contents.jobs) { contents.jobs = {}; }
+    if (!contents.jobs) {
+      contents.jobs = {};
+    }
     contents.jobs.dredd = {
       docker: [{ image: 'circleci/node:latest' }],
       steps: ['checkout', { run: INSTALL_DREDD }, { run: RUN_DREDD }],
@@ -270,72 +293,84 @@ function updateCircleCI(options = {}) {
   });
 }
 
-
 function updateTravisCI(options = {}) {
   const edit = options.editYaml || editYaml;
 
   edit('.travis.yml', (contents) => {
-    if (!contents.language) { contents.language = 'node_js'; }
+    if (!contents.language) {
+      contents.language = 'node_js';
+    }
 
-    if (!contents.before_install) { contents.before_install = []; }
+    if (!contents.before_install) {
+      contents.before_install = [];
+    }
     contents.before_install.push(INSTALL_DREDD);
 
-    if (!contents.before_script) { contents.before_script = []; }
+    if (!contents.before_script) {
+      contents.before_script = [];
+    }
     contents.before_script.push(RUN_DREDD);
   });
 }
-
 
 function updateWercker(options = {}) {
   const edit = options.editYaml || editYaml;
 
   edit('wercker.yml', (contents) => {
-    if (!contents.box) { contents.box = 'node'; }
+    if (!contents.box) {
+      contents.box = 'node';
+    }
 
-    if (!contents.build) { contents.build = {}; }
+    if (!contents.build) {
+      contents.build = {};
+    }
     contents.build.steps = [].concat(
       [{ script: { name: 'install-dredd', code: INSTALL_DREDD } }],
       contents.build.steps || [],
-      [{ script: { name: 'dredd', code: RUN_DREDD } }]
+      [{ script: { name: 'dredd', code: RUN_DREDD } }],
     );
   });
 }
 
-
 function detectLanguage(files) {
-  const lcFiles = files.map(f => f.toLowerCase());
+  const lcFiles = files.map((f) => f.toLowerCase());
 
   if (lcFiles.includes('cargo.toml')) {
     return 'rust';
   }
-  if (lcFiles.filter(f => f.match(/\.go$/)).length) {
+  if (lcFiles.filter((f) => f.match(/\.go$/)).length) {
     return 'go';
   }
   if (lcFiles.includes('composer.json')) {
     return 'php';
   }
   if (
-    lcFiles.includes('minil.toml') || lcFiles.includes('cpanfile')
-    || lcFiles.includes('meta.json') || lcFiles.includes('build.pl')
+    lcFiles.includes('minil.toml') ||
+    lcFiles.includes('cpanfile') ||
+    lcFiles.includes('meta.json') ||
+    lcFiles.includes('build.pl')
   ) {
     return 'perl';
   }
   if (
-    lcFiles.includes('setup.py') || lcFiles.includes('requirements.txt')
-    || lcFiles.includes('pipfile') || lcFiles.includes('pyproject.toml')
-    || lcFiles.includes('setup.cfg') || lcFiles.includes('manifest.in')
+    lcFiles.includes('setup.py') ||
+    lcFiles.includes('requirements.txt') ||
+    lcFiles.includes('pipfile') ||
+    lcFiles.includes('pyproject.toml') ||
+    lcFiles.includes('setup.cfg') ||
+    lcFiles.includes('manifest.in')
   ) {
     return 'python';
   }
   if (
-    lcFiles.includes('gemfile') || lcFiles.includes('gemfile.lock')
-    || lcFiles.filter(f => f.match(/\.gemspec$/)).length
+    lcFiles.includes('gemfile') ||
+    lcFiles.includes('gemfile.lock') ||
+    lcFiles.filter((f) => f.match(/\.gemspec$/)).length
   ) {
     return 'ruby';
   }
   return 'nodejs';
 }
-
 
 function detectServer(files) {
   const commands = {
@@ -347,20 +382,26 @@ function detectServer(files) {
   return commands[language] || commands.nodejs;
 }
 
-
 function detectApiDescription(files) {
-  const apib = files.filter(f => f.match(/\.apib$/i));
-  if (apib.length) { return apib[0]; }
+  const apib = files.filter((f) => f.match(/\.apib$/i));
+  if (apib.length) {
+    return apib[0];
+  }
 
-  const openapi2 = files.filter(f => f.match(/\.ya?ml$/i) && f.match(/swagger/));
-  if (openapi2.length) { return openapi2[0]; }
+  const openapi2 = files.filter(
+    (f) => f.match(/\.ya?ml$/i) && f.match(/swagger/),
+  );
+  if (openapi2.length) {
+    return openapi2[0];
+  }
 
-  const openapi = files.filter(f => f.match(/\.ya?ml$/i) && f.match(/api/));
-  if (openapi.length) { return openapi[0]; }
+  const openapi = files.filter((f) => f.match(/\.ya?ml$/i) && f.match(/api/));
+  if (openapi.length) {
+    return openapi[0];
+  }
 
   return 'apiary.apib';
 }
-
 
 function detectCI(files) {
   const ci = {
@@ -369,9 +410,8 @@ function detectCI(files) {
     '.travis.yml': 'travisci',
     '.circleci': 'circleci',
   };
-  return files.map(f => ci[f]).filter(f => !!f);
+  return files.map((f) => ci[f]).filter((f) => !!f);
 }
-
 
 // only for the purpose of unit tests
 init._applyAnswers = applyAnswers;
@@ -384,6 +424,5 @@ init._updateAppVeyor = updateAppVeyor;
 init._updateCircleCI = updateCircleCI;
 init._updateTravisCI = updateTravisCI;
 init._updateWercker = updateWercker;
-
 
 module.exports = init;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,9 +1,7 @@
 const winston = require('winston');
 
-module.exports = new (winston.Logger)({
-  transports: [
-    new (winston.transports.Console)({ colorize: true }),
-  ],
+module.exports = new winston.Logger({
+  transports: [new winston.transports.Console({ colorize: true })],
   levels: {
     debug: 2,
     warn: 1,

--- a/lib/performRequest.js
+++ b/lib/performRequest.js
@@ -3,7 +3,6 @@ const caseless = require('caseless');
 
 const defaultLogger = require('./logger');
 
-
 /**
  * Performs the HTTP request as described in the 'transaction.request' object
  *
@@ -19,7 +18,9 @@ const defaultLogger = require('./logger');
  * @param {Function} callback
  */
 function performRequest(uri, transactionReq, options, callback) {
-  if (typeof options === 'function') { [options, callback] = [{}, options]; }
+  if (typeof options === 'function') {
+    [options, callback] = [{}, options];
+  }
   const logger = options.logger || defaultLogger;
   const request = options.request || defaultRequest;
 
@@ -31,12 +32,20 @@ function performRequest(uri, transactionReq, options, callback) {
   httpOptions.uri = uri;
 
   try {
-    httpOptions.body = getBodyAsBuffer(transactionReq.body, transactionReq.bodyEncoding);
-    httpOptions.headers = normalizeContentLengthHeader(transactionReq.headers, httpOptions.body);
+    httpOptions.body = getBodyAsBuffer(
+      transactionReq.body,
+      transactionReq.bodyEncoding,
+    );
+    httpOptions.headers = normalizeContentLengthHeader(
+      transactionReq.headers,
+      httpOptions.body,
+    );
 
     const protocol = httpOptions.uri.split(':')[0].toUpperCase();
-    logger.debug(`Performing ${protocol} request to the server under test: `
-      + `${httpOptions.method} ${httpOptions.uri}`);
+    logger.debug(
+      `Performing ${protocol} request to the server under test: ` +
+        `${httpOptions.method} ${httpOptions.uri}`,
+    );
 
     request(httpOptions, (error, response, responseBody) => {
       logger.debug(`Handling ${protocol} response from the server under test`);
@@ -51,7 +60,6 @@ function performRequest(uri, transactionReq, options, callback) {
   }
 }
 
-
 /**
  * Coerces the HTTP request body to a Buffer
  *
@@ -64,7 +72,6 @@ function getBodyAsBuffer(body, encoding) {
     : Buffer.from(`${body || ''}`, normalizeBodyEncoding(encoding));
 }
 
-
 /**
  * Returns the encoding as either 'utf-8' or 'base64'. Throws
  * an error in case any other encoding is provided.
@@ -72,7 +79,9 @@ function getBodyAsBuffer(body, encoding) {
  * @param {string} encoding
  */
 function normalizeBodyEncoding(encoding) {
-  if (!encoding) { return 'utf-8'; }
+  if (!encoding) {
+    return 'utf-8';
+  }
 
   switch (encoding.toLowerCase()) {
     case 'utf-8':
@@ -81,11 +90,12 @@ function normalizeBodyEncoding(encoding) {
     case 'base64':
       return 'base64';
     default:
-      throw new Error(`Unsupported encoding: '${encoding}' (only UTF-8 and `
-        + 'Base64 are supported)');
+      throw new Error(
+        `Unsupported encoding: '${encoding}' (only UTF-8 and ` +
+          'Base64 are supported)',
+      );
   }
 }
-
 
 /**
  * Detects an existing Content-Length header and overrides the user-provided
@@ -106,15 +116,16 @@ function normalizeContentLengthHeader(headers, body, options = {}) {
     const value = parseInt(modifiedHeaders[name], 10);
     if (value !== calculatedValue) {
       modifiedHeaders[name] = `${calculatedValue}`;
-      logger.warn(`Specified Content-Length header is ${value}, but the real `
-        + `body length is ${calculatedValue}. Using ${calculatedValue} instead.`);
+      logger.warn(
+        `Specified Content-Length header is ${value}, but the real ` +
+          `body length is ${calculatedValue}. Using ${calculatedValue} instead.`,
+      );
     }
   } else {
     modifiedHeaders['Content-Length'] = `${calculatedValue}`;
   }
   return modifiedHeaders;
 }
-
 
 /**
  * Real transaction response object factory. Serializes binary responses
@@ -135,7 +146,6 @@ function createTransactionResponse(response, body) {
   return transactionRes;
 }
 
-
 /**
  * @param {Buffer} body
  */
@@ -148,13 +158,11 @@ function detectBodyEncoding(body) {
   return body.toString().includes('\ufffd') ? 'base64' : 'utf-8';
 }
 
-
 // only for the purpose of unit tests
 performRequest._normalizeBodyEncoding = normalizeBodyEncoding;
 performRequest._getBodyAsBuffer = getBodyAsBuffer;
 performRequest._normalizeContentLengthHeader = normalizeContentLengthHeader;
 performRequest._createTransactionResponse = createTransactionResponse;
 performRequest._detectBodyEncoding = detectBodyEncoding;
-
 
 module.exports = performRequest;

--- a/lib/prettifyResponse.js
+++ b/lib/prettifyResponse.js
@@ -29,7 +29,8 @@ module.exports = function prettifyResponse(response) {
   }
 
   if (response && response.headers) {
-    contentType = response.headers['content-type'] || response.headers['Content-Type'];
+    contentType =
+      response.headers['content-type'] || response.headers['Content-Type'];
   }
 
   let stringRepresentation = '';

--- a/lib/readLocation.js
+++ b/lib/readLocation.js
@@ -3,19 +3,25 @@ const defaultRequest = require('request');
 
 const isURL = require('./isURL');
 
-
 function getErrorFromResponse(response, hasBody) {
   const contentType = response.headers['content-type'];
   if (hasBody) {
-    const bodyDescription = contentType ? `'${contentType}' body` : 'body without Content-Type';
-    return new Error(`Dredd got HTTP ${response.statusCode} response with ${bodyDescription}`);
+    const bodyDescription = contentType
+      ? `'${contentType}' body`
+      : 'body without Content-Type';
+    return new Error(
+      `Dredd got HTTP ${response.statusCode} response with ${bodyDescription}`,
+    );
   }
-  return new Error(`Dredd got HTTP ${response.statusCode} response without body`);
+  return new Error(
+    `Dredd got HTTP ${response.statusCode} response without body`,
+  );
 }
 
-
 function readRemoteFile(uri, options, callback) {
-  if (typeof options === 'function') { [options, callback] = [{}, options]; }
+  if (typeof options === 'function') {
+    [options, callback] = [{}, options];
+  }
   const request = options.request || defaultRequest;
 
   const httpOptions = Object.assign({}, options.http || {});
@@ -28,7 +34,11 @@ function readRemoteFile(uri, options, callback) {
         callback(error);
       } else if (!response) {
         callback(new Error('Unexpected error'));
-      } else if (!responseBody || response.statusCode < 200 || response.statusCode >= 300) {
+      } else if (
+        !responseBody ||
+        response.statusCode < 200 ||
+        response.statusCode >= 300
+      ) {
         callback(getErrorFromResponse(response, !!responseBody));
       } else {
         callback(null, responseBody);
@@ -39,17 +49,20 @@ function readRemoteFile(uri, options, callback) {
   }
 }
 
-
 function readLocalFile(path, callback) {
   fs.readFile(path, 'utf8', (error, data) => {
-    if (error) { callback(error); return; }
+    if (error) {
+      callback(error);
+      return;
+    }
     callback(null, data);
   });
 }
 
-
 module.exports = function readLocation(location, options, callback) {
-  if (typeof options === 'function') { [options, callback] = [{}, options]; }
+  if (typeof options === 'function') {
+    [options, callback] = [{}, options];
+  }
   if (isURL(location)) {
     readRemoteFile(location, options, callback);
   } else {

--- a/lib/reporters/ApiaryReporter.js
+++ b/lib/reporters/ApiaryReporter.js
@@ -7,7 +7,6 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const packageData = require('../../package.json');
 
-
 const CONNECTION_ERRORS = [
   'ECONNRESET',
   'ENOTFOUND',
@@ -17,7 +16,6 @@ const CONNECTION_ERRORS = [
   'EHOSTUNREACH',
   'EPIPE',
 ];
-
 
 function ApiaryReporter(emitter, stats, config, runner) {
   this.type = 'apiary';
@@ -32,7 +30,11 @@ function ApiaryReporter(emitter, stats, config, runner) {
   this.errors = [];
   this.serverError = false;
   this.configuration = {
-    apiUrl: (this._get('apiaryApiUrl', 'APIARY_API_URL', 'https://api.apiary.io')).replace(/\/$/, ''),
+    apiUrl: this._get(
+      'apiaryApiUrl',
+      'APIARY_API_URL',
+      'https://api.apiary.io',
+    ).replace(/\/$/, ''),
     apiToken: this._get('apiaryApiKey', 'APIARY_API_KEY', null),
     apiSuite: this._get('apiaryApiName', 'APIARY_API_NAME', null),
   };
@@ -48,31 +50,44 @@ Configure Dredd to be able to save test reports alongside your Apiary API projec
 https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
 `);
   }
-  if (!this.configuration.apiSuite) { this.configuration.apiSuite = 'public'; }
+  if (!this.configuration.apiSuite) {
+    this.configuration.apiSuite = 'public';
+  }
 }
 
-
 // THIS IS HIIIIGHWAY TO HELL, HIIIIIGHWAY TO HELL. Everything should have one single interface
-ApiaryReporter.prototype._get = function _get(customProperty, envProperty, defaultVal) {
+ApiaryReporter.prototype._get = function _get(
+  customProperty,
+  envProperty,
+  defaultVal,
+) {
   let returnVal = defaultVal;
 
   // This will be deprecated
   if (this.config.custom && this.config.custom[customProperty]) {
     returnVal = this.config.custom[customProperty];
 
-  // This will be the ONLY supported way how to configure this reporter
+    // This will be the ONLY supported way how to configure this reporter
   } else if (this.config.custom && this.config.custom[customProperty]) {
     returnVal = this.config.custom[customProperty];
 
-  // This will be deprecated
-  } else if (this.config.custom && this.config.custom.apiaryReporterEnv && this.config.custom.apiaryReporterEnv[customProperty]) {
+    // This will be deprecated
+  } else if (
+    this.config.custom &&
+    this.config.custom.apiaryReporterEnv &&
+    this.config.custom.apiaryReporterEnv[customProperty]
+  ) {
     returnVal = this.config.custom.apiaryReporterEnv[customProperty];
 
-  // This will be deprecated
-  } else if (this.config.custom && this.config.custom.apiaryReporterEnv && this.config.custom.apiaryReporterEnv[envProperty]) {
+    // This will be deprecated
+  } else if (
+    this.config.custom &&
+    this.config.custom.apiaryReporterEnv &&
+    this.config.custom.apiaryReporterEnv[envProperty]
+  ) {
     returnVal = this.config.custom.apiaryReporterEnv[envProperty];
 
-  // This will be supported for backward compatibility, but can be removed in future.
+    // This will be supported for backward compatibility, but can be removed in future.
   } else if (process.env[envProperty]) {
     returnVal = process.env[envProperty];
   }
@@ -80,17 +95,21 @@ ApiaryReporter.prototype._get = function _get(customProperty, envProperty, defau
   return returnVal;
 };
 
-
 ApiaryReporter.prototype._getKeys = function _getKeys() {
   let returnKeys = [];
-  returnKeys = returnKeys.concat(Object.keys((this.config.custom && this.config.custom.apiaryReporterEnv) || {}));
+  returnKeys = returnKeys.concat(
+    Object.keys(
+      (this.config.custom && this.config.custom.apiaryReporterEnv) || {},
+    ),
+  );
   return returnKeys.concat(Object.keys(process.env));
 };
 
-
 ApiaryReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (apiDescriptions, callback) => {
-    if (this.serverError === true) { return callback(); }
+    if (this.serverError === true) {
+      return callback();
+    }
     this.uuid = generateUuid();
     this.startedAt = Math.round(new Date().getTime() / 1000);
 
@@ -108,13 +127,14 @@ ApiaryReporter.prototype.configureEmitter = function configureEmitter(emitter) {
 
     // Transform blueprints data to array
     const data = {
-      blueprints: apiDescriptions.map(apiDescription => ({
+      blueprints: apiDescriptions.map((apiDescription) => ({
         filename: apiDescription.location,
         raw: apiDescription.content,
         annotations: apiDescription.annotations,
       })),
       endpoint: this.config.server,
-      agent: this._get('dreddAgent', 'DREDD_AGENT') || this._get('user', 'USER'),
+      agent:
+        this._get('dreddAgent', 'DREDD_AGENT') || this._get('user', 'USER'),
       agentRunUuid: this.uuid,
       hostname: this._get('dreddHostname', 'DREDD_HOSTNAME') || os.hostname(),
       startedAt: this.startedAt,
@@ -129,15 +149,22 @@ ApiaryReporter.prototype.configureEmitter = function configureEmitter(emitter) {
 
     const path = `/apis/${this.configuration.apiSuite}/tests/runs`;
 
-    this._performRequestAsync(path, 'POST', data, (error, response, parsedBody) => {
-      if (error) {
-        callback(error);
-      } else {
-        this.remoteId = parsedBody._id;
-        if (parsedBody.reportUrl) { this.reportUrl = parsedBody.reportUrl; }
-        callback();
-      }
-    });
+    this._performRequestAsync(
+      path,
+      'POST',
+      data,
+      (error, response, parsedBody) => {
+        if (error) {
+          callback(error);
+        } else {
+          this.remoteId = parsedBody._id;
+          if (parsedBody.reportUrl) {
+            this.reportUrl = parsedBody.reportUrl;
+          }
+          callback();
+        }
+      },
+    );
   });
 
   emitter.on('test pass', this._createStep.bind(this));
@@ -147,60 +174,83 @@ ApiaryReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('test skip', this._createStep.bind(this));
 
   emitter.on('test error', (error, test, callback) => {
-    if (this.serverError === true) { return callback(); }
+    if (this.serverError === true) {
+      return callback();
+    }
     const data = this._transformTestToReporter(test);
 
     if (Array.from(CONNECTION_ERRORS).includes(error.code)) {
       data.results.errors.push({
-        severity: 'error', message: 'Error connecting to server under test!',
+        severity: 'error',
+        message: 'Error connecting to server under test!',
       });
     } else {
       data.results.errors.push({
-        severity: 'error', message: 'Unhandled error occured when executing the transaction.',
+        severity: 'error',
+        message: 'Unhandled error occured when executing the transaction.',
       });
     }
 
     const path = `/apis/${this.configuration.apiSuite}/tests/steps?testRunId=${this.remoteId}`;
     this._performRequestAsync(path, 'POST', data, (err) => {
-      if (err) { return callback(err); }
+      if (err) {
+        return callback(err);
+      }
       callback();
     });
   });
 
   emitter.on('end', (callback) => {
-    if (this.serverError === true) { return callback(); }
+    if (this.serverError === true) {
+      return callback();
+    }
 
     const data = {
       endedAt: Math.round(new Date().getTime() / 1000),
       result: this.stats,
-      status: (this.stats.failures > 0 || this.stats.errors > 0) ? 'failed' : 'passed',
-      logs: (this.runner && this.runner.logs && this.runner.logs.length) ? this.runner.logs : undefined,
+      status:
+        this.stats.failures > 0 || this.stats.errors > 0 ? 'failed' : 'passed',
+      logs:
+        this.runner && this.runner.logs && this.runner.logs.length
+          ? this.runner.logs
+          : undefined,
     };
 
     const path = `/apis/${this.configuration.apiSuite}/tests/run/${this.remoteId}`;
 
     this._performRequestAsync(path, 'PATCH', data, (error) => {
-      if (error) { return callback(error); }
-      const reportUrl = this.reportUrl || `https://app.apiary.io/${this.configuration.apiSuite}/tests/run/${this.remoteId}`;
+      if (error) {
+        return callback(error);
+      }
+      const reportUrl =
+        this.reportUrl ||
+        `https://app.apiary.io/${this.configuration.apiSuite}/tests/run/${this.remoteId}`;
       reporterOutputLogger.complete(`See results in Apiary at: ${reportUrl}`);
       callback();
     });
   });
 };
 
-
 ApiaryReporter.prototype._createStep = function _createStep(test, callback) {
-  if (this.serverError === true) { return callback(); }
+  if (this.serverError === true) {
+    return callback();
+  }
   const data = this._transformTestToReporter(test);
   const path = `/apis/${this.configuration.apiSuite}/tests/steps?testRunId=${this.remoteId}`;
   this._performRequestAsync(path, 'POST', data, (error) => {
-    if (error) { return callback(error); }
+    if (error) {
+      return callback(error);
+    }
     callback();
   });
 };
 
-
-ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(path, method, reqBody, callback) {
+ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(
+  path,
+  method,
+  reqBody,
+  callback,
+) {
   const handleRequest = (err, res, resBody) => {
     let parsedBody;
     if (err) {
@@ -208,7 +258,9 @@ ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(pa
       logger.debug('Requesting Apiary API errored:', `${err}` || err.code);
 
       if (Array.from(CONNECTION_ERRORS).includes(err.code)) {
-        return callback(new Error('Apiary reporter could not connect to Apiary API'));
+        return callback(
+          new Error('Apiary reporter could not connect to Apiary API'),
+        );
       }
       return callback(err);
     }
@@ -226,7 +278,11 @@ ${error.message}\n${resBody}
       return callback(err);
     }
 
-    const info = { headers: res.headers, statusCode: res.statusCode, body: parsedBody };
+    const info = {
+      headers: res.headers,
+      statusCode: res.statusCode,
+      body: parsedBody,
+    };
 
     logger.debug('Apiary reporter response:', JSON.stringify(info, null, 2));
 
@@ -257,7 +313,10 @@ About to perform an ${protocol} request from Apiary reporter
 to Apiary API: ${options.method} ${options.uri} \
 (${body ? 'with' : 'without'} body)
 `);
-    logger.debug('Request details:', JSON.stringify({ options, body }, null, 2));
+    logger.debug(
+      'Request details:',
+      JSON.stringify({ options, body }, null, 2),
+    );
     return request(options, handleRequest);
   } catch (error) {
     this.serverError = true;
@@ -266,8 +325,9 @@ to Apiary API: ${options.method} ${options.uri} \
   }
 };
 
-
-ApiaryReporter.prototype._transformTestToReporter = function _transformTestToReporter(test) {
+ApiaryReporter.prototype._transformTestToReporter = function _transformTestToReporter(
+  test,
+) {
   return {
     testRunId: this.remoteId,
     origin: test.origin,
@@ -283,6 +343,5 @@ ApiaryReporter.prototype._transformTestToReporter = function _transformTestToRep
     },
   };
 };
-
 
 module.exports = ApiaryReporter;

--- a/lib/reporters/CLIReporter.js
+++ b/lib/reporters/CLIReporter.js
@@ -2,7 +2,6 @@ const logger = require('../logger');
 const reporterOutputLogger = require('./reporterOutputLogger');
 const prettifyResponse = require('../prettifyResponse');
 
-
 const CONNECTION_ERRORS = [
   'ECONNRESET',
   'ENOTFOUND',
@@ -12,7 +11,6 @@ const CONNECTION_ERRORS = [
   'EHOSTUNREACH',
   'EPIPE',
 ];
-
 
 function CLIReporter(emitter, stats, inlineErrors, details) {
   this.type = 'cli';
@@ -40,18 +38,25 @@ CLIReporter.prototype.configureEmitter = function configureEmitter(emitter) {
       this.errors.forEach((test) => {
         reporterOutputLogger.fail(`${test.title} duration: ${test.duration}ms`);
         reporterOutputLogger.fail(test.message);
-        if (test.request) reporterOutputLogger.request(`\n${prettifyResponse(test.request)}\n`);
-        if (test.expected) reporterOutputLogger.expected(`\n${prettifyResponse(test.expected)}\n`);
-        if (test.actual) reporterOutputLogger.actual(`\n${prettifyResponse(test.actual)}\n\n`);
+        if (test.request)
+          reporterOutputLogger.request(`\n${prettifyResponse(test.request)}\n`);
+        if (test.expected)
+          reporterOutputLogger.expected(
+            `\n${prettifyResponse(test.expected)}\n`,
+          );
+        if (test.actual)
+          reporterOutputLogger.actual(`\n${prettifyResponse(test.actual)}\n\n`);
       });
     }
 
     if (this.stats.tests > 0) {
-      reporterOutputLogger.complete(`${this.stats.passes} passing, `
-        + `${this.stats.failures} failing, `
-        + `${this.stats.errors} errors, `
-        + `${this.stats.skipped} skipped, `
-        + `${this.stats.tests} total`);
+      reporterOutputLogger.complete(
+        `${this.stats.passes} passing, ` +
+          `${this.stats.failures} failing, ` +
+          `${this.stats.errors} errors, ` +
+          `${this.stats.skipped} skipped, ` +
+          `${this.stats.tests} total`,
+      );
     }
 
     reporterOutputLogger.complete(`Tests took ${this.stats.duration}ms`);
@@ -67,15 +72,21 @@ CLIReporter.prototype.configureEmitter = function configureEmitter(emitter) {
     }
   });
 
-  emitter.on('test skip', test => reporterOutputLogger.skip(test.title));
+  emitter.on('test skip', (test) => reporterOutputLogger.skip(test.title));
 
   emitter.on('test fail', (test) => {
     reporterOutputLogger.fail(`${test.title} duration: ${test.duration}ms`);
     if (this.inlineErrors) {
       reporterOutputLogger.fail(test.message);
-      if (test.request) { reporterOutputLogger.request(`\n${prettifyResponse(test.request)}\n`); }
-      if (test.expected) { reporterOutputLogger.expected(`\n${prettifyResponse(test.expected)}\n`); }
-      if (test.actual) { reporterOutputLogger.actual(`\n${prettifyResponse(test.actual)}\n\n`); }
+      if (test.request) {
+        reporterOutputLogger.request(`\n${prettifyResponse(test.request)}\n`);
+      }
+      if (test.expected) {
+        reporterOutputLogger.expected(`\n${prettifyResponse(test.expected)}\n`);
+      }
+      if (test.actual) {
+        reporterOutputLogger.actual(`\n${prettifyResponse(test.actual)}\n\n`);
+      }
     } else {
       this.errors.push(test);
     }
@@ -90,7 +101,9 @@ CLIReporter.prototype.configureEmitter = function configureEmitter(emitter) {
     }
 
     reporterOutputLogger.error(`${test.title} duration: ${test.duration}ms`);
-    if (!this.inlineErrors) { this.errors.push(test); }
+    if (!this.inlineErrors) {
+      this.errors.push(test);
+    }
   });
 };
 

--- a/lib/reporters/DotReporter.js
+++ b/lib/reporters/DotReporter.js
@@ -24,10 +24,14 @@ DotReporter.prototype.configureEmitter = function configureEmitter(emitter) {
         this.write('\n');
         reporterOutputLogger.info('Displaying failed tests...');
         for (const test of this.errors) {
-          reporterOutputLogger.fail(`${test.title} duration: ${test.duration}ms`);
+          reporterOutputLogger.fail(
+            `${test.title} duration: ${test.duration}ms`,
+          );
           reporterOutputLogger.fail(test.message);
           reporterOutputLogger.request(`\n${prettifyResponse(test.request)}\n`);
-          reporterOutputLogger.expected(`\n${prettifyResponse(test.expected)}\n`);
+          reporterOutputLogger.expected(
+            `\n${prettifyResponse(test.expected)}\n`,
+          );
           reporterOutputLogger.actual(`\n${prettifyResponse(test.actual)}\n\n`);
         }
       }

--- a/lib/reporters/HTMLReporter.js
+++ b/lib/reporters/HTMLReporter.js
@@ -26,7 +26,9 @@ function HTMLReporter(emitter, stats, path, details) {
   logger.debug(`Using '${this.type}' reporter.`);
 }
 
-HTMLReporter.prototype.sanitizedPath = function sanitizedPath(path = './report.html') {
+HTMLReporter.prototype.sanitizedPath = function sanitizedPath(
+  path = './report.html',
+) {
   const filePath = pathmodule.resolve(untildify(path));
   if (fs.existsSync(filePath)) {
     logger.warn(`File exists at ${filePath}, will be overwritten...`);
@@ -35,7 +37,7 @@ HTMLReporter.prototype.sanitizedPath = function sanitizedPath(path = './report.h
 };
 
 HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
-  const title = str => `${Array(this.level).join('#')} ${str}`;
+  const title = (str) => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (apiDescriptions, callback) => {
     this.level++;
@@ -58,7 +60,9 @@ HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
     makeDir(pathmodule.dirname(this.path))
       .then(() => {
         fs.writeFile(this.path, html, (error) => {
-          if (error) { reporterOutputLogger.error(error); }
+          if (error) {
+            reporterOutputLogger.error(error);
+          }
           callback();
         });
       })
@@ -77,9 +81,15 @@ HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
 
     if (this.details) {
       this.level++;
-      this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(test.request)}\n\`\`\`\n\n`;
-      this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(test.expected)}\n\`\`\`\n\n`;
-      this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(test.actual)}\n\`\`\`\n\n`;
+      this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(
+        test.request,
+      )}\n\`\`\`\n\n`;
+      this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(
+        test.expected,
+      )}\n\`\`\`\n\n`;
+      this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(
+        test.actual,
+      )}\n\`\`\`\n\n`;
       this.level--;
     }
 
@@ -96,9 +106,15 @@ HTMLReporter.prototype.configureEmitter = function configureEmitter(emitter) {
 
     this.level++;
     this.buf += `${title('Message')}\n\`\`\`\n${test.message}\n\`\`\`\n\n`;
-    this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(test.request)}\n\`\`\`\n\n`;
-    this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(test.expected)}\n\`\`\`\n\n`;
-    this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(test.actual)}\n\`\`\`\n\n`;
+    this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(
+      test.request,
+    )}\n\`\`\`\n\n`;
+    this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(
+      test.expected,
+    )}\n\`\`\`\n\n`;
+    this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(
+      test.actual,
+    )}\n\`\`\`\n\n`;
     this.level--;
 
     this.level--;

--- a/lib/reporters/MarkdownReporter.js
+++ b/lib/reporters/MarkdownReporter.js
@@ -25,7 +25,9 @@ function MarkdownReporter(emitter, stats, path, details) {
   logger.debug(`Using '${this.type}' reporter.`);
 }
 
-MarkdownReporter.prototype.sanitizedPath = function sanitizedPath(path = './report.md') {
+MarkdownReporter.prototype.sanitizedPath = function sanitizedPath(
+  path = './report.md',
+) {
   const filePath = pathmodule.resolve(untildify(path));
   if (fs.existsSync(filePath)) {
     logger.warn(`File exists at ${filePath}, will be overwritten...`);
@@ -33,8 +35,10 @@ MarkdownReporter.prototype.sanitizedPath = function sanitizedPath(path = './repo
   return filePath;
 };
 
-MarkdownReporter.prototype.configureEmitter = function configureEmitter(emitter) {
-  const title = str => `${Array(this.level).join('#')} ${str}`;
+MarkdownReporter.prototype.configureEmitter = function configureEmitter(
+  emitter,
+) {
+  const title = (str) => `${Array(this.level).join('#')} ${str}`;
 
   emitter.on('start', (apiDescriptions, callback) => {
     this.level++;
@@ -46,7 +50,9 @@ MarkdownReporter.prototype.configureEmitter = function configureEmitter(emitter)
     makeDir(pathmodule.dirname(this.path))
       .then(() => {
         fs.writeFile(this.path, this.buf, (error) => {
-          if (error) { reporterOutputLogger.error(error); }
+          if (error) {
+            reporterOutputLogger.error(error);
+          }
           callback();
         });
       })
@@ -65,9 +71,15 @@ MarkdownReporter.prototype.configureEmitter = function configureEmitter(emitter)
 
     if (this.details) {
       this.level++;
-      this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(test.request)}\n\`\`\`\n\n`;
-      this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(test.expected)}\n\`\`\`\n\n`;
-      this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(test.actual)}\n\`\`\`\n\n`;
+      this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(
+        test.request,
+      )}\n\`\`\`\n\n`;
+      this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(
+        test.expected,
+      )}\n\`\`\`\n\n`;
+      this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(
+        test.actual,
+      )}\n\`\`\`\n\n`;
       this.level--;
     }
 
@@ -84,9 +96,15 @@ MarkdownReporter.prototype.configureEmitter = function configureEmitter(emitter)
 
     this.level++;
     this.buf += `${title('Message')}\n\`\`\`\n${test.message}\n\`\`\`\n\n`;
-    this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(test.request)}\n\`\`\`\n\n`;
-    this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(test.expected)}\n\`\`\`\n\n`;
-    this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(test.actual)}\n\`\`\`\n\n`;
+    this.buf += `${title('Request')}\n\`\`\`\n${prettifyResponse(
+      test.request,
+    )}\n\`\`\`\n\n`;
+    this.buf += `${title('Expected')}\n\`\`\`\n${prettifyResponse(
+      test.expected,
+    )}\n\`\`\`\n\n`;
+    this.buf += `${title('Actual')}\n\`\`\`\n${prettifyResponse(
+      test.actual,
+    )}\n\`\`\`\n\n`;
     this.level--;
 
     this.level--;

--- a/lib/reporters/NyanReporter.js
+++ b/lib/reporters/NyanReporter.js
@@ -26,7 +26,7 @@ function NyanCatReporter(emitter, stats) {
   this.numberOfLines = 4;
   this.trajectories = [[], [], [], []];
   this.nyanCatWidth = 11;
-  this.trajectoryWidthMax = (((windowWidth * 0.75) | 0) - this.nyanCatWidth); // eslint-disable-line no-bitwise
+  this.trajectoryWidthMax = ((windowWidth * 0.75) | 0) - this.nyanCatWidth; // eslint-disable-line no-bitwise
   this.scoreboardWidth = 5;
   this.tick = 0;
   this.errors = [];
@@ -36,7 +36,9 @@ function NyanCatReporter(emitter, stats) {
   logger.debug(`Using '${this.type}' reporter.`);
 }
 
-NyanCatReporter.prototype.configureEmitter = function configureEmitter(emitter) {
+NyanCatReporter.prototype.configureEmitter = function configureEmitter(
+  emitter,
+) {
   emitter.on('start', (apiDescriptions, callback) => {
     this.cursorHide();
     this.draw();
@@ -64,7 +66,9 @@ NyanCatReporter.prototype.configureEmitter = function configureEmitter(emitter) 
       }
     }
 
-    reporterOutputLogger.complete(`${this.stats.passes} passing, ${this.stats.failures} failing, ${this.stats.errors} errors, ${this.stats.skipped} skipped`);
+    reporterOutputLogger.complete(
+      `${this.stats.passes} passing, ${this.stats.failures} failing, ${this.stats.errors} errors, ${this.stats.skipped} skipped`,
+    );
     reporterOutputLogger.complete(`Tests took ${this.stats.duration}ms`);
     callback();
   });
@@ -121,14 +125,16 @@ NyanCatReporter.prototype.drawScoreboard = function drawScoreboard() {
 };
 
 NyanCatReporter.prototype.appendRainbow = function appendRainbow() {
-  const segment = (this.tick ? '_' : '-');
+  const segment = this.tick ? '_' : '-';
   const rainbowified = this.rainbowify(segment);
   const result = [];
 
   let index = 0;
   while (index < this.numberOfLines) {
     const trajectory = this.trajectories[index];
-    if (trajectory.length >= this.trajectoryWidthMax) { trajectory.shift(); }
+    if (trajectory.length >= this.trajectoryWidthMax) {
+      trajectory.shift();
+    }
     trajectory.push(rainbowified);
     result.push(index++);
   }
@@ -153,16 +159,16 @@ NyanCatReporter.prototype.drawNyanCat = function drawNyanCat() {
   this.write('_,------,');
   this.write('\n');
   this.write(color);
-  padding = (this.tick ? '  ' : '   ');
+  padding = this.tick ? '  ' : '   ';
   this.write(`_|${padding}/\\_/\\ `);
   this.write('\n');
   this.write(color);
-  padding = (this.tick ? '_' : '__');
-  const tail = (this.tick ? '~' : '^');
+  padding = this.tick ? '_' : '__';
+  const tail = this.tick ? '~' : '^';
   this.write(`${tail}|${padding}${this.face()} `);
   this.write('\n');
   this.write(color);
-  padding = (this.tick ? ' ' : '  ');
+  padding = this.tick ? ' ' : '  ';
   this.write(`${padding}''  '' `);
   this.write('\n');
   this.cursorUp(this.numberOfLines);
@@ -171,9 +177,11 @@ NyanCatReporter.prototype.drawNyanCat = function drawNyanCat() {
 NyanCatReporter.prototype.face = function face() {
   if (this.stats.failures) {
     return '( x .x)';
-  } if (this.stats.skipped) {
+  }
+  if (this.stats.skipped) {
     return '( o .o)';
-  } if (this.stats.passes) {
+  }
+  if (this.stats.passes) {
     return '( ^ .^)';
   }
   return '( - .-)';
@@ -188,24 +196,28 @@ NyanCatReporter.prototype.cursorDown = function cursorDown(n) {
 };
 
 NyanCatReporter.prototype.cursorShow = function cursorShow() {
-  if (this.isatty) { this.write('\u001b[?25h'); }
+  if (this.isatty) {
+    this.write('\u001b[?25h');
+  }
 };
 
 NyanCatReporter.prototype.cursorHide = function cursorHide() {
-  if (this.isatty) { this.write('\u001b[?25l'); }
+  if (this.isatty) {
+    this.write('\u001b[?25l');
+  }
 };
 
 NyanCatReporter.prototype.generateColors = function generateColors() {
   const colors = [];
   let i = 0;
 
-  while (i < (6 * 7)) {
+  while (i < 6 * 7) {
     const pi3 = Math.floor(Math.PI / 3);
-    const n = (i * (1.0 / 6));
-    const r = Math.floor((3 * Math.sin(n)) + 3);
-    const g = Math.floor((3 * Math.sin(n + (2 * pi3))) + 3);
-    const b = Math.floor((3 * Math.sin(n + (4 * pi3))) + 3);
-    colors.push((36 * r) + (6 * g) + b + 16);
+    const n = i * (1.0 / 6);
+    const r = Math.floor(3 * Math.sin(n) + 3);
+    const g = Math.floor(3 * Math.sin(n + 2 * pi3) + 3);
+    const b = Math.floor(3 * Math.sin(n + 4 * pi3) + 3);
+    colors.push(36 * r + 6 * g + b + 16);
     i++;
   }
   return colors;

--- a/lib/reporters/XUnitReporter.js
+++ b/lib/reporters/XUnitReporter.js
@@ -24,27 +24,41 @@ function XUnitReporter(emitter, stats, path, details) {
   logger.debug(`Using '${this.type}' reporter.`);
 }
 
-XUnitReporter.prototype.updateSuiteStats = function updateSuiteStats(path, stats, callback) {
+XUnitReporter.prototype.updateSuiteStats = function updateSuiteStats(
+  path,
+  stats,
+  callback,
+) {
   fs.readFile(path, (err, data) => {
     if (!err) {
       data = data.toString();
       const position = data.toString().indexOf('\n');
       if (position !== -1) {
         const restOfFile = data.substr(position + 1);
-        const newStats = this.toTag('testsuite', {
-          name: 'Dredd Tests',
-          tests: stats.tests,
-          failures: stats.failures,
-          errors: stats.errors,
-          skip: stats.skipped,
-          timestamp: (new Date()).toUTCString(),
-          time: stats.duration / 1000,
-        }, false);
+        const newStats = this.toTag(
+          'testsuite',
+          {
+            name: 'Dredd Tests',
+            tests: stats.tests,
+            failures: stats.failures,
+            errors: stats.errors,
+            skip: stats.skipped,
+            timestamp: new Date().toUTCString(),
+            time: stats.duration / 1000,
+          },
+          false,
+        );
         const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
-        fs.writeFile(path, `${xmlHeader}\n${newStats}\n${restOfFile}</testsuite>`, (error) => {
-          if (error) { reporterOutputLogger.error(error); }
-          callback();
-        });
+        fs.writeFile(
+          path,
+          `${xmlHeader}\n${newStats}\n${restOfFile}</testsuite>`,
+          (error) => {
+            if (error) {
+              reporterOutputLogger.error(error);
+            }
+            callback();
+          },
+        );
       } else {
         callback();
       }
@@ -67,14 +81,18 @@ XUnitReporter.prototype.toTag = function toTag(name, attrs, close, content) {
   const end = close ? '/>' : '>';
   const pairs = [];
   if (attrs) {
-    Object.keys(attrs).forEach(key => pairs.push(`${key}="${attrs[key]}"`));
+    Object.keys(attrs).forEach((key) => pairs.push(`${key}="${attrs[key]}"`));
   }
   let tag = `<${name}${pairs.length ? ` ${pairs.join(' ')}` : ''}${end}`;
-  if (content) { tag += `${content}</${name}${end}`; }
+  if (content) {
+    tag += `${content}</${name}${end}`;
+  }
   return tag;
 };
 
-XUnitReporter.prototype.sanitizedPath = function sanitizedPath(path = './report.xml') {
+XUnitReporter.prototype.sanitizedPath = function sanitizedPath(
+  path = './report.xml',
+) {
   const filePath = pathmodule.resolve(untildify(path));
   if (fs.existsSync(filePath)) {
     logger.warn(`File exists at ${filePath}, will be overwritten...`);
@@ -87,15 +105,22 @@ XUnitReporter.prototype.configureEmitter = function configureEmitter(emitter) {
   emitter.on('start', (apiDescriptions, callback) => {
     makeDir(pathmodule.dirname(this.path))
       .then(() => {
-        this.appendLine(this.path, this.toTag('testsuite', {
-          name: 'Dredd Tests',
-          tests: this.stats.tests,
-          failures: this.stats.failures,
-          errors: this.stats.errors,
-          skip: this.stats.skipped,
-          timestamp: (new Date()).toUTCString(),
-          time: this.stats.duration / 1000,
-        }, false));
+        this.appendLine(
+          this.path,
+          this.toTag(
+            'testsuite',
+            {
+              name: 'Dredd Tests',
+              tests: this.stats.tests,
+              failures: this.stats.failures,
+              errors: this.stats.errors,
+              skip: this.stats.skipped,
+              timestamp: new Date().toUTCString(),
+              time: this.stats.duration / 1000,
+            },
+            false,
+          ),
+        );
         callback();
       })
       .catch((err) => {
@@ -125,7 +150,12 @@ ${prettifyResponse(test.actual)}\
 `;
       this.appendLine(
         this.path,
-        this.toTag('testcase', attrs, false, this.toTag('system-out', null, false, this.cdata(deets)))
+        this.toTag(
+          'testcase',
+          attrs,
+          false,
+          this.toTag('system-out', null, false, this.cdata(deets)),
+        ),
       );
     } else {
       this.appendLine(this.path, this.toTag('testcase', attrs, true));
@@ -137,7 +167,10 @@ ${prettifyResponse(test.actual)}\
       name: htmlencode.htmlEncode(test.title),
       time: test.duration / 1000,
     };
-    this.appendLine(this.path, this.toTag('testcase', attrs, false, this.toTag('skipped', null, true)));
+    this.appendLine(
+      this.path,
+      this.toTag('testcase', attrs, false, this.toTag('skipped', null, true)),
+    );
   });
 
   emitter.on('test fail', (test) => {
@@ -157,7 +190,12 @@ ${prettifyResponse(test.actual)}\
 `;
     this.appendLine(
       this.path,
-      this.toTag('testcase', attrs, false, this.toTag('failure', null, false, this.cdata(diff)))
+      this.toTag(
+        'testcase',
+        attrs,
+        false,
+        this.toTag('failure', null, false, this.cdata(diff)),
+      ),
     );
   });
 
@@ -169,7 +207,12 @@ ${prettifyResponse(test.actual)}\
     const errorMessage = `\nError: \n${error}\nStacktrace: \n${error.stack}`;
     this.appendLine(
       this.path,
-      this.toTag('testcase', attrs, false, this.toTag('failure', null, false, this.cdata(errorMessage)))
+      this.toTag(
+        'testcase',
+        attrs,
+        false,
+        this.toTag('failure', null, false, this.cdata(errorMessage)),
+      ),
     );
   });
 };

--- a/lib/reporters/reporterOutputLogger.js
+++ b/lib/reporters/reporterOutputLogger.js
@@ -1,8 +1,8 @@
 const winston = require('winston');
 
-module.exports = new (winston.Logger)({
+module.exports = new winston.Logger({
   transports: [
-    new (winston.transports.Console)({ colorize: true, level: 'info' }),
+    new winston.transports.Console({ colorize: true, level: 'info' }),
   ],
   levels: {
     info: 10,

--- a/lib/resolveLocations.js
+++ b/lib/resolveLocations.js
@@ -1,7 +1,6 @@
 const resolvePaths = require('./resolvePaths');
 const isURL = require('./isURL');
 
-
 /**
  * Takes an array of strings representing API description document locations
  * and resolves all relative paths and globs
@@ -16,11 +15,9 @@ const isURL = require('./isURL');
 module.exports = function resolveLocations(workingDirectory, locations) {
   const resolvedLocations = locations
     // resolves paths to local files, produces an array of arrays
-    .map(location => (
-      isURL(location)
-        ? [location]
-        : resolvePaths(workingDirectory, [location])
-    ))
+    .map((location) =>
+      isURL(location) ? [location] : resolvePaths(workingDirectory, [location]),
+    )
     // flattens the array of arrays
     .reduce((flatArray, array) => flatArray.concat(array), []);
 

--- a/lib/resolveModule.js
+++ b/lib/resolveModule.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-
 module.exports = function resolveModule(workingDirectory, moduleName) {
   const absolutePath = path.resolve(workingDirectory, moduleName);
   return fs.existsSync(absolutePath) || fs.existsSync(`${absolutePath}.js`)

--- a/lib/resolvePaths.js
+++ b/lib/resolvePaths.js
@@ -2,21 +2,20 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 
-
 // Ensure platform-agnostic 'path.basename' function
-const basename = process.platform === 'win32' ? path.win32.basename : path.basename;
-
+const basename =
+  process.platform === 'win32' ? path.win32.basename : path.basename;
 
 function resolveGlob(workingDirectory, pattern) {
   // 'glob.sync()' does not resolve paths, only glob patterns
   if (glob.hasMagic(pattern)) {
-    return glob.sync(pattern, { cwd: workingDirectory })
-      .map(matchingPath => path.resolve(workingDirectory, matchingPath));
+    return glob
+      .sync(pattern, { cwd: workingDirectory })
+      .map((matchingPath) => path.resolve(workingDirectory, matchingPath));
   }
   const resolvedPath = path.resolve(workingDirectory, pattern);
   return fs.existsSync(resolvedPath) ? [resolvedPath] : [];
 }
-
 
 /**
  * Resolve paths to files
@@ -25,7 +24,9 @@ function resolveGlob(workingDirectory, pattern) {
  * Throws in case there's a pattern which doesn't resolve to any existing files.
  */
 module.exports = function resolvePaths(workingDirectory, patterns) {
-  if (!patterns || patterns.length < 1) { return []; }
+  if (!patterns || patterns.length < 1) {
+    return [];
+  }
 
   const resolvedPaths = patterns
     .map((pattern) => {

--- a/lib/sortTransactions.js
+++ b/lib/sortTransactions.js
@@ -7,24 +7,36 @@
 // By sorting the transactions by their methods, it is possible to ensure that
 // objects are created before they are read, updated, or deleted.
 module.exports = function sortTransactions(arr) {
-  arr.forEach((a, i) => { a._index = i; });
+  arr.forEach((a, i) => {
+    a._index = i;
+  });
 
   arr.sort((a, b) => {
     const sortedMethods = [
-      'CONNECT', 'OPTIONS',
-      'POST', 'GET', 'HEAD', 'PUT', 'PATCH', 'DELETE',
+      'CONNECT',
+      'OPTIONS',
+      'POST',
+      'GET',
+      'HEAD',
+      'PUT',
+      'PATCH',
+      'DELETE',
       'TRACE',
     ];
 
     const methodIndexA = sortedMethods.indexOf(a.request.method);
     const methodIndexB = sortedMethods.indexOf(b.request.method);
 
-    if (methodIndexA < methodIndexB) { return -1; }
-    if (methodIndexA > methodIndexB) { return 1; }
+    if (methodIndexA < methodIndexB) {
+      return -1;
+    }
+    if (methodIndexA > methodIndexB) {
+      return 1;
+    }
     return a._index - b._index;
   });
 
-  arr.forEach(a => delete a._index);
+  arr.forEach((a) => delete a._index);
 
   return arr;
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "docs:build": "sphinx-build -nW -b html ./docs ./docs/_build",
     "docs:serve": "sphinx-autobuild ./docs ./docs/_build",
     "lint": "./scripts/commitlint.sh && eslint . bin/dredd",
+    "prettify": "prettier --write 'lib/**/*.js' 'test/**/*.js'",
+    "prettify:check": "prettier --check 'lib/**/*.js' 'test/**/*.js'",
     "test": "mocha \"./test/**/*-test.js\"",
     "test:debug": "mocha --debug-brk \"./test/**/*-test.js\"",
     "e2e": "npm run e2e:apib && npm run e2e:openapi2",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    'mocha': true,
-    'node': true
+    mocha: true,
+    node: true,
   },
 };

--- a/test/fixtures/apiDescriptions.js
+++ b/test/fixtures/apiDescriptions.js
@@ -1,12 +1,14 @@
 module.exports = [
   {
-    content: 'FORMAT: 1A\n\n# Machines API\n\n# Group Machines\n\n# Machines collection [/machines/{id}]\n  + Parameters\n    - id (number, `1`)\n\n## Get Machines [GET]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `2`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `3`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n',
+    content:
+      'FORMAT: 1A\n\n# Machines API\n\n# Group Machines\n\n# Machines collection [/machines/{id}]\n  + Parameters\n    - id (number, `1`)\n\n## Get Machines [GET]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `2`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `3`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n',
     location: './test/fixtures/multiple-examples.apib',
     annotations: [
       {
         component: 'apiDescriptionParser',
         code: 3,
-        message: 'no parameters specified, expected a nested list of parameters, one parameter per list item',
+        message:
+          'no parameters specified, expected a nested list of parameters, one parameter per list item',
         location: [[178, 13]],
         type: 'warning',
       },
@@ -20,14 +22,23 @@ module.exports = [
       {
         component: 'apiDescriptionParser',
         code: 10,
-        message: 'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
-        location: [[269, 2], [275, 4], [283, 25], [312, 20], [336, 4], [344, 2]],
+        message:
+          'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
+        location: [
+          [269, 2],
+          [275, 4],
+          [283, 25],
+          [312, 20],
+          [336, 4],
+          [344, 2],
+        ],
         type: 'warning',
       },
       {
         component: 'apiDescriptionParser',
         code: 3,
-        message: 'no parameters specified, expected a nested list of parameters, one parameter per list item',
+        message:
+          'no parameters specified, expected a nested list of parameters, one parameter per list item',
         location: [[378, 13]],
         type: 'warning',
       },
@@ -41,8 +52,16 @@ module.exports = [
       {
         component: 'apiDescriptionParser',
         code: 10,
-        message: 'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
-        location: [[469, 2], [475, 4], [483, 25], [512, 20], [536, 4], [544, 2]],
+        message:
+          'message-body asset is expected to be a pre-formatted code block, every of its line indented by exactly 8 spaces or 2 tabs',
+        location: [
+          [469, 2],
+          [475, 4],
+          [483, 25],
+          [512, 20],
+          [536, 4],
+          [544, 2],
+        ],
         type: 'warning',
       },
     ],

--- a/test/fixtures/blog/app.js
+++ b/test/fixtures/blog/app.js
@@ -1,19 +1,21 @@
 const express = require('express');
 
-
 const app = express();
 
 app.get('/articles', (req, res) => {
-  res.json([{ id: 1, title: 'Creamy cucumber salad', text: 'Slice cucumbers…' }]);
+  res.json([
+    { id: 1, title: 'Creamy cucumber salad', text: 'Slice cucumbers…' },
+  ]);
 });
 
 app.post('/articles', (req, res) => {
   if (req.headers.authorization) {
-    res.status(201).json({ id: 2, title: 'Crispy schnitzel', text: 'Prepare eggs…' });
+    res
+      .status(201)
+      .json({ id: 2, title: 'Crispy schnitzel', text: 'Prepare eggs…' });
   } else {
     res.status(403).json({ error: 'Forbidden' });
   }
 });
-
 
 app.listen(3000, () => console.log('http://127.0.0.1:3000'));

--- a/test/fixtures/blog/hooks.openapi2.js
+++ b/test/fixtures/blog/hooks.openapi2.js
@@ -1,5 +1,9 @@
 const hooks = require('hooks');
 
-hooks.before('Articles > Publish an article > 201 > application/json; charset=utf-8', (transaction) => {
-  transaction.request.headers.Authorization = 'Basic: YWxhZGRpbjpvcGVuc2VzYW1l';
-});
+hooks.before(
+  'Articles > Publish an article > 201 > application/json; charset=utf-8',
+  (transaction) => {
+    transaction.request.headers.Authorization =
+      'Basic: YWxhZGRpbjpvcGVuc2VzYW1l';
+  },
+);

--- a/test/fixtures/request/application-octet-stream-hooks.js
+++ b/test/fixtures/request/application-octet-stream-hooks.js
@@ -1,7 +1,9 @@
 const hooks = require('hooks');
 
 hooks.beforeEach((transaction, done) => {
-  transaction.request.body = Buffer.from([0xFF, 0xEF, 0xBF, 0xBE]).toString('base64');
+  transaction.request.body = Buffer.from([0xff, 0xef, 0xbf, 0xbe]).toString(
+    'base64',
+  );
   transaction.request.bodyEncoding = 'base64';
   done();
 });

--- a/test/fixtures/sanitation/any-content-guard-pattern-matching.js
+++ b/test/fixtures/sanitation/any-content-guard-pattern-matching.js
@@ -5,7 +5,10 @@ const tokenPattern = /([0-9]|[a-f]){24,}/g;
 
 hooks.beforeEach((transaction, done) => {
   transaction.id = transaction.id.replace(tokenPattern, 'CENSORED');
-  transaction.origin.resourceName = transaction.origin.resourceName.replace(tokenPattern, 'CENSORED');
+  transaction.origin.resourceName = transaction.origin.resourceName.replace(
+    tokenPattern,
+    'CENSORED',
+  );
   done();
 });
 

--- a/test/fixtures/sanitation/any-content-pattern-matching.js
+++ b/test/fixtures/sanitation/any-content-pattern-matching.js
@@ -4,7 +4,10 @@ const tokenPattern = /([0-9]|[a-f]){24,}/g;
 
 hooks.beforeEach((transaction, done) => {
   transaction.id = transaction.id.replace(tokenPattern, 'CENSORED');
-  transaction.origin.resourceName = transaction.origin.resourceName.replace(tokenPattern, 'CENSORED');
+  transaction.origin.resourceName = transaction.origin.resourceName.replace(
+    tokenPattern,
+    'CENSORED',
+  );
   done();
 });
 

--- a/test/fixtures/sanitation/plain-text-response-body.js
+++ b/test/fixtures/sanitation/plain-text-response-body.js
@@ -3,7 +3,7 @@ const hooks = require('hooks');
 const tokenPattern = /([0-9]|[a-f]){24,}/g;
 
 hooks.after('Resource > Update Resource', (transaction, done) => {
-  const replaceToken = body => body.replace(tokenPattern, '--- CENSORED ---');
+  const replaceToken = (body) => body.replace(tokenPattern, '--- CENSORED ---');
 
   // Remove sensitive data from Dredd transaction
   transaction.test.actual.body = replaceToken(transaction.test.actual.body);

--- a/test/fixtures/sanitation/response-body-attribute.js
+++ b/test/fixtures/sanitation/response-body-attribute.js
@@ -1,6 +1,7 @@
 const hooks = require('hooks');
 
-const unfold = (jsonString, transform) => JSON.stringify(transform(JSON.parse(jsonString)));
+const unfold = (jsonString, transform) =>
+  JSON.stringify(transform(JSON.parse(jsonString)));
 
 hooks.after('Resource > Update Resource', (transaction, done) => {
   const deleteToken = (obj) => {
@@ -9,8 +10,14 @@ hooks.after('Resource > Update Resource', (transaction, done) => {
   };
 
   // Removes sensitive data from the Dredd transaction
-  transaction.test.actual.body = unfold(transaction.test.actual.body, deleteToken);
-  transaction.test.expected.body = unfold(transaction.test.expected.body, deleteToken);
+  transaction.test.actual.body = unfold(
+    transaction.test.actual.body,
+    deleteToken,
+  );
+  transaction.test.expected.body = unfold(
+    transaction.test.expected.body,
+    deleteToken,
+  );
 
   // Sanitation of the attribute in JSON Schema
   const bodySchema = JSON.parse(transaction.test.expected.bodySchema);
@@ -19,7 +26,9 @@ hooks.after('Resource > Update Resource', (transaction, done) => {
 
   // Removes sensitive data from the Gavel validation result
   const bodyResult = transaction.test.results.fields.body;
-  bodyResult.errors = bodyResult.errors.filter(error => error.location.pointer !== '/token');
+  bodyResult.errors = bodyResult.errors.filter(
+    (error) => error.location.pointer !== '/token',
+  );
   bodyResult.values.expected = unfold(bodyResult.values.expected, deleteToken);
   bodyResult.values.actual = unfold(bodyResult.values.actual, deleteToken);
 

--- a/test/fixtures/sanitation/response-headers.js
+++ b/test/fixtures/sanitation/response-headers.js
@@ -9,13 +9,24 @@ hooks.after('Resource > Update Resource', (transaction, done) => {
   };
 
   // Remove sensitive data from the Dredd transaction
-  transaction.test.actual.headers = deleteSensitiveHeader('authorization', transaction.test.actual.headers);
-  transaction.test.expected.headers = deleteSensitiveHeader('authorization', transaction.test.expected.headers);
+  transaction.test.actual.headers = deleteSensitiveHeader(
+    'authorization',
+    transaction.test.actual.headers,
+  );
+  transaction.test.expected.headers = deleteSensitiveHeader(
+    'authorization',
+    transaction.test.expected.headers,
+  );
 
   // Remove sensitive data from the Gavel validation result
   const headersResult = transaction.test.results.fields.headers;
-  headersResult.errors = headersResult.errors.filter(error => error.location.pointer.toLowerCase() !== '/authorization');
-  headersResult.values.expected = deleteSensitiveHeader('authorization', headersResult.values.expected);
+  headersResult.errors = headersResult.errors.filter(
+    (error) => error.location.pointer.toLowerCase() !== '/authorization',
+  );
+  headersResult.values.expected = deleteSensitiveHeader(
+    'authorization',
+    headersResult.values.expected,
+  );
 
   transaction.test.message = '';
   done();

--- a/test/fixtures/sanitation/uri-parameters.js
+++ b/test/fixtures/sanitation/uri-parameters.js
@@ -4,11 +4,17 @@ const tokenPattern = /([0-9]|[a-f]){24,}/g;
 
 hooks.beforeEach((transaction, done) => {
   transaction.id = transaction.id.replace(tokenPattern, 'CENSORED');
-  transaction.origin.resourceName = transaction.origin.resourceName.replace(tokenPattern, 'CENSORED');
+  transaction.origin.resourceName = transaction.origin.resourceName.replace(
+    tokenPattern,
+    'CENSORED',
+  );
   done();
 });
 
 hooks.afterEach((transaction, done) => {
-  transaction.test.request.uri = transaction.test.request.uri.replace(tokenPattern, 'CENSORED');
+  transaction.test.request.uri = transaction.test.request.uri.replace(
+    tokenPattern,
+    'CENSORED',
+  );
   done();
 });

--- a/test/fixtures/test2_all.js
+++ b/test/fixtures/test2_all.js
@@ -5,7 +5,10 @@ hooks.beforeAll((done) => {
   done();
 });
 
-hooks.before('Machines > Machines collection > Get Machines', (transaction, done) => {
-  console.log('*** before');
-  done();
-});
+hooks.before(
+  'Machines > Machines collection > Get Machines',
+  (transaction, done) => {
+    console.log('*** before');
+    done();
+  },
+);

--- a/test/fixtures/test2_hooks.js
+++ b/test/fixtures/test2_hooks.js
@@ -1,7 +1,10 @@
 const hooks = require('hooks');
 
-hooks.before('Machines > Machines collection > Get Machines', (transaction, done) => {
-  transaction.request.headers.header = '123232323';
-  console.log('before');
-  done();
-});
+hooks.before(
+  'Machines > Machines collection > Get Machines',
+  (transaction, done) => {
+    transaction.request.headers.header = '123232323';
+    console.log('before');
+    done();
+  },
+);

--- a/test/integration/annotations-test.js
+++ b/test/integration/annotations-test.js
@@ -3,7 +3,6 @@ const { assert } = require('chai');
 
 const Dredd = require('../../lib/Dredd');
 
-
 function compileTransactions(apiDescription, logger, callback) {
   const dredd = new Dredd({ apiDescriptions: [apiDescription] });
   dredd.logger = logger;
@@ -11,22 +10,25 @@ function compileTransactions(apiDescription, logger, callback) {
   dredd.run(callback);
 }
 
-
 describe('Parser and compiler annotations', () => {
   describe('when processing a file with parser warnings', () => {
     const logger = { debug: sinon.spy(), log: sinon.spy() };
     let error;
 
     before((done) => {
-      compileTransactions(`
+      compileTransactions(
+        `
 FORMAT: 1A
 # Dummy API
 ## Index [GET /]
 + Response
-      `, logger, (compileError) => {
-        error = compileError;
-        done();
-      });
+      `,
+        logger,
+        (compileError) => {
+          error = compileError;
+          done();
+        },
+      );
     });
 
     it("doesn't abort Dredd", () => {
@@ -38,7 +40,7 @@ FORMAT: 1A
     it('logs the warnings with line numbers', () => {
       assert.match(
         logger.log.getCall(0).args[1],
-        /parser warning in configuration\.apiDescriptions\[0\]:5 \(from line 5 column 3 to column 11\)/i
+        /parser warning in configuration\.apiDescriptions\[0\]:5 \(from line 5 column 3 to column 11\)/i,
       );
     });
   });
@@ -48,16 +50,20 @@ FORMAT: 1A
     let error;
 
     before((done) => {
-      compileTransactions(`
+      compileTransactions(
+        `
 FORMAT: 1A
 # Dummy API
 ## Index [GET /]
 + Response
 \t+ Body
-      `, logger, (compileError) => {
-        error = compileError;
-        done();
-      });
+      `,
+        logger,
+        (compileError) => {
+          error = compileError;
+          done();
+        },
+      );
     });
 
     it('aborts Dredd', () => {
@@ -69,7 +75,7 @@ FORMAT: 1A
     it('logs the errors with line numbers', () => {
       assert.match(
         logger.log.getCall(0).args[1],
-        /parser error in configuration\.apiDescriptions\[0\]:6 \(line 6 column 1\)/i
+        /parser error in configuration\.apiDescriptions\[0\]:6 \(line 6 column 1\)/i,
       );
     });
   });
@@ -79,15 +85,19 @@ FORMAT: 1A
     let error;
 
     before((done) => {
-      compileTransactions(`
+      compileTransactions(
+        `
 FORMAT: 1A
 # Dummy API
 ## Index [GET /{foo}]
 + Response 200
-      `, logger, (compileError) => {
-        error = compileError;
-        done();
-      });
+      `,
+        logger,
+        (compileError) => {
+          error = compileError;
+          done();
+        },
+      );
     });
 
     it("doesn't abort Dredd", () => {
@@ -99,7 +109,7 @@ FORMAT: 1A
     it('logs the warnings with a transaction path', () => {
       assert.match(
         logger.log.getCall(0).args[1],
-        /uri template expansion warning in configuration\.apiDescriptions\[0\] \(Dummy API > Index > Index\)/i
+        /uri template expansion warning in configuration\.apiDescriptions\[0\] \(Dummy API > Index > Index\)/i,
       );
     });
   });
@@ -109,17 +119,21 @@ FORMAT: 1A
     let error;
 
     before((done) => {
-      compileTransactions(`
+      compileTransactions(
+        `
 FORMAT: 1A
 # Dummy API
 ## Index [DELETE /{?param}]
 + Parameters
     + param (required)
 + Response 204
-      `, logger, (compileError) => {
-        error = compileError;
-        done();
-      });
+      `,
+        logger,
+        (compileError) => {
+          error = compileError;
+          done();
+        },
+      );
     });
 
     it('aborts Dredd', () => {
@@ -131,7 +145,7 @@ FORMAT: 1A
     it('logs the errors with a transaction path', () => {
       assert.match(
         logger.log.getCall(0).args[1],
-        /uri parameters validation error in configuration\.apiDescriptions\[0\] \(Dummy API > Index > Index\)/i
+        /uri parameters validation error in configuration\.apiDescriptions\[0\] \(Dummy API > Index > Index\)/i,
       );
     });
   });

--- a/test/integration/apiary-reporter-test.js
+++ b/test/integration/apiary-reporter-test.js
@@ -34,17 +34,15 @@ function execCommand(options = {}, cb) {
       if (error ? error.message : undefined) {
         output += error.message;
       }
-      exitStatus = (error || (((1 * stats.failures) + (1 * stats.errors)) > 0)) ? 1 : 0;
+      exitStatus = error || 1 * stats.failures + 1 * stats.errors > 0 ? 1 : 0;
       cb();
     }
   });
 }
 
-
 function record(transport, level, message) {
   output += `\n${level}: ${message}`;
 }
-
 
 // These tests were separated out from a larger file. They deserve a rewrite,
 // see https://github.com/apiaryio/dredd/issues/1288
@@ -97,14 +95,18 @@ describe('Apiary reporter', () => {
       apiary.use(bodyParser.json({ size: '5mb' }));
 
       apiary.post('/apis/*', (req, res) => {
-        if (req.body && (req.url.indexOf('/tests/steps') > -1)) {
-          if (!receivedRequest) { receivedRequest = clone(req.body); }
+        if (req.body && req.url.indexOf('/tests/steps') > -1) {
+          if (!receivedRequest) {
+            receivedRequest = clone(req.body);
+          }
           Object.keys(req.headers).forEach((name) => {
             receivedHeaders[name.toLowerCase()] = req.headers[name];
           });
         }
-        if (req.body && (req.url.indexOf('/tests/runs') > -1)) {
-          if (!receivedRequestTestRuns) { receivedRequestTestRuns = clone(req.body); }
+        if (req.body && req.url.indexOf('/tests/runs') > -1) {
+          if (!receivedRequestTestRuns) {
+            receivedRequestTestRuns = clone(req.body);
+          }
           Object.keys(req.headers).forEach((name) => {
             receivedHeadersRuns[name.toLowerCase()] = req.headers[name];
           });
@@ -118,20 +120,32 @@ describe('Apiary reporter', () => {
 
       apiary.all('*', (req, res) => res.json({}));
 
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       server = app.listen(PORT, () => {
-        server2 = apiary.listen((PORT + 1), () => {
-          execCommand(cmd, () => server2.close(() => server.close(() => done())));
+        server2 = apiary.listen(PORT + 1, () => {
+          execCommand(cmd, () =>
+            server2.close(() => server.close(() => done())),
+          );
         });
       });
     });
 
-    it('should not print warning about missing Apiary API settings', () => assert.notInclude(output, 'Apiary API Key or API Project Subdomain were not provided.'));
+    it('should not print warning about missing Apiary API settings', () =>
+      assert.notInclude(
+        output,
+        'Apiary API Key or API Project Subdomain were not provided.',
+      ));
 
     it('should contain Authentication header thanks to apiaryApiKey and apiaryApiName configuration', () => {
       assert.propertyVal(receivedHeaders, 'authentication', 'Token the-key');
-      assert.propertyVal(receivedHeadersRuns, 'authentication', 'Token the-key');
+      assert.propertyVal(
+        receivedHeadersRuns,
+        'authentication',
+        'Token the-key',
+      );
     });
 
     it('should send the test-run as a non-public one', () => {
@@ -139,16 +153,26 @@ describe('Apiary reporter', () => {
       assert.propertyVal(receivedRequestTestRuns, 'public', false);
     });
 
-    it('should print using the new reporter', () => assert.include(output, 'http://url.me/test/run/1234_id'));
+    it('should print using the new reporter', () =>
+      assert.include(output, 'http://url.me/test/run/1234_id'));
 
     it('should send results from Gavel', () => {
       assert.isObject(receivedRequest);
       assert.nestedProperty(receivedRequest, 'results.request');
       assert.nestedProperty(receivedRequest, 'results.realResponse');
       assert.nestedProperty(receivedRequest, 'results.expectedResponse');
-      assert.nestedProperty(receivedRequest, 'results.validationResult.fields.body.kind');
-      assert.nestedProperty(receivedRequest, 'results.validationResult.fields.headers.kind');
-      assert.nestedProperty(receivedRequest, 'results.validationResult.fields.statusCode.kind');
+      assert.nestedProperty(
+        receivedRequest,
+        'results.validationResult.fields.body.kind',
+      );
+      assert.nestedProperty(
+        receivedRequest,
+        'results.validationResult.fields.headers.kind',
+      );
+      assert.nestedProperty(
+        receivedRequest,
+        'results.validationResult.fields.statusCode.kind',
+      );
 
       it('prints out an error message', () => assert.notEqual(exitStatus, 0));
     });
@@ -179,8 +203,10 @@ describe('Apiary reporter', () => {
         apiary.use(bodyParser.json({ size: '5mb' }));
 
         apiary.post('/apis/*', (req, res) => {
-          if (req.body && (req.url.indexOf('/tests/steps') > -1)) {
-            if (!receivedRequest) { receivedRequest = clone(req.body); }
+          if (req.body && req.url.indexOf('/tests/steps') > -1) {
+            if (!receivedRequest) {
+              receivedRequest = clone(req.body);
+            }
           }
           res.status(201).json({
             _id: '1234_id',
@@ -191,12 +217,15 @@ describe('Apiary reporter', () => {
 
         apiary.all('*', (req, res) => res.json({}));
 
-        server2 = apiary.listen((PORT + 1), () => execCommand(cmd, () => server2.close(() => {})));
+        server2 = apiary.listen(PORT + 1, () =>
+          execCommand(cmd, () => server2.close(() => {})),
+        );
 
         server2.on('close', done);
       });
 
-      it('should print using the reporter', () => assert.include(output, 'http://url.me/test/run/1234_id'));
+      it('should print using the reporter', () =>
+        assert.include(output, 'http://url.me/test/run/1234_id'));
 
       it('should send results from gavel', () => {
         assert.isObject(receivedRequest);
@@ -237,8 +266,10 @@ describe('Apiary reporter', () => {
         apiary.use(bodyParser.json({ size: '5mb' }));
 
         apiary.post('/apis/*', (req, res) => {
-          if (req.body && (req.url.indexOf('/tests/steps') > -1)) {
-            if (!receivedRequest) { receivedRequest = clone(req.body); }
+          if (req.body && req.url.indexOf('/tests/steps') > -1) {
+            if (!receivedRequest) {
+              receivedRequest = clone(req.body);
+            }
           }
           res.status(201).json({
             _id: '1234_id',
@@ -249,29 +280,51 @@ describe('Apiary reporter', () => {
 
         apiary.all('*', (req, res) => res.json({}));
 
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
-        server = app.listen(PORT, () => { server2 = apiary.listen((PORT + 1), () => {}); });
+        server = app.listen(PORT, () => {
+          server2 = apiary.listen(PORT + 1, () => {});
+        });
 
         execCommand(cmd, () => server2.close(() => server.close(() => {})));
 
         server.on('close', done);
       });
 
-      it('should print warning about missing Apiary API settings', () => assert.include(output, 'Apiary API Key or API Project Subdomain were not provided.'));
+      it('should print warning about missing Apiary API settings', () =>
+        assert.include(
+          output,
+          'Apiary API Key or API Project Subdomain were not provided.',
+        ));
 
-      it('should print link to documentation', () => assert.include(output, 'https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests'));
+      it('should print link to documentation', () =>
+        assert.include(
+          output,
+          'https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests',
+        ));
 
-      it('should print using the new reporter', () => assert.include(output, 'http://url.me/test/run/1234_id'));
+      it('should print using the new reporter', () =>
+        assert.include(output, 'http://url.me/test/run/1234_id'));
 
       it('should send results from Gavel', () => {
         assert.isObject(receivedRequest);
         assert.nestedProperty(receivedRequest, 'results.request');
         assert.nestedProperty(receivedRequest, 'results.realResponse');
         assert.nestedProperty(receivedRequest, 'results.expectedResponse');
-        assert.nestedProperty(receivedRequest, 'results.validationResult.fields.body.kind');
-        assert.nestedProperty(receivedRequest, 'results.validationResult.fields.headers.kind');
-        assert.nestedProperty(receivedRequest, 'results.validationResult.fields.statusCode.kind');
+        assert.nestedProperty(
+          receivedRequest,
+          'results.validationResult.fields.body.kind',
+        );
+        assert.nestedProperty(
+          receivedRequest,
+          'results.validationResult.fields.headers.kind',
+        );
+        assert.nestedProperty(
+          receivedRequest,
+          'results.validationResult.fields.statusCode.kind',
+        );
       });
     });
   });
@@ -302,7 +355,9 @@ describe('Apiary reporter', () => {
       },
     };
 
-    afterEach(() => { connectedToServer = null; });
+    afterEach(() => {
+      connectedToServer = null;
+    });
 
     before((done) => {
       app = express();
@@ -320,7 +375,9 @@ describe('Apiary reporter', () => {
         fs.createReadStream('./test/fixtures/single-get.apib').pipe(res);
       });
 
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       app.get('/not-found.apib', (req, res) => {
         notFound = true;
@@ -330,18 +387,23 @@ describe('Apiary reporter', () => {
       server = app.listen(PORT, () => done());
     });
 
-    after(done => server.close(() => {
-      app = null;
-      server = null;
-      done();
-    }));
+    after((done) =>
+      server.close(() => {
+        app = null;
+        server = null;
+        done();
+      }),
+    );
 
     describe('and I try to load a file from bad hostname at all', () => {
-      before(done => execCommand(errorCmd, () => done()));
+      before((done) => execCommand(errorCmd, () => done()));
 
-      after(() => { connectedToServer = null; });
+      after(() => {
+        connectedToServer = null;
+      });
 
-      it('should not send a GET to the server', () => assert.isNull(connectedToServer));
+      it('should not send a GET to the server', () =>
+        assert.isNull(connectedToServer));
 
       it('should exit with status 1', () => assert.equal(exitStatus, 1));
 
@@ -352,13 +414,17 @@ describe('Apiary reporter', () => {
     });
 
     describe('and I try to load a file that does not exist from an existing server', () => {
-      before(done => execCommand(wrongCmd, () => done()));
+      before((done) => execCommand(wrongCmd, () => done()));
 
-      after(() => { connectedToServer = null; });
+      after(() => {
+        connectedToServer = null;
+      });
 
-      it('should connect to the right server', () => assert.isTrue(connectedToServer));
+      it('should connect to the right server', () =>
+        assert.isTrue(connectedToServer));
 
-      it('should send a GET to server at wrong URL', () => assert.isTrue(notFound));
+      it('should send a GET to server at wrong URL', () =>
+        assert.isTrue(notFound));
 
       it('should exit with status 1', () => assert.equal(exitStatus, 1));
 
@@ -370,11 +436,13 @@ describe('Apiary reporter', () => {
     });
 
     describe('and I try to load a file that actually is there', () => {
-      before(done => execCommand(goodCmd, () => done()));
+      before((done) => execCommand(goodCmd, () => done()));
 
-      it('should send a GET to the right server', () => assert.isTrue(connectedToServer));
+      it('should send a GET to the right server', () =>
+        assert.isTrue(connectedToServer));
 
-      it('should send a GET to server at good URL', () => assert.isTrue(fileFound));
+      it('should send a GET to server at good URL', () =>
+        assert.isTrue(fileFound));
 
       it('should exit with status 0', () => assert.equal(exitStatus, 0));
     });

--- a/test/integration/childProcess-test.js
+++ b/test/integration/childProcess-test.js
@@ -23,8 +23,12 @@ function runChildProcess(command, fn, callback) {
 
   const childProcess = spawn(COFFEE_BIN, [command]);
 
-  childProcess.stdout.on('data', (data) => { processInfo.stdout += data.toString(); });
-  childProcess.stderr.on('data', (data) => { processInfo.stderr += data.toString(); });
+  childProcess.stdout.on('data', (data) => {
+    processInfo.stdout += data.toString();
+  });
+  childProcess.stderr.on('data', (data) => {
+    processInfo.stderr += data.toString();
+  });
 
   function onExit(exitStatus, signal) {
     processInfo.terminated = true;
@@ -33,7 +37,9 @@ function runChildProcess(command, fn, callback) {
   }
   childProcess.on('exit', onExit);
 
-  const onError = (err) => { processInfo.error = err; };
+  const onError = (err) => {
+    processInfo.error = err;
+  };
   childProcess.on('error', onError);
 
   childProcess.on('crash', onCrash);
@@ -48,10 +54,8 @@ function runChildProcess(command, fn, callback) {
 
       processInfo.childProcess = childProcess;
       callback(null, processInfo);
-    },
-    WAIT_AFTER_COMMAND_TERMINATED_MS);
-  },
-  WAIT_AFTER_COMMAND_SPAWNED_MS);
+    }, WAIT_AFTER_COMMAND_TERMINATED_MS);
+  }, WAIT_AFTER_COMMAND_SPAWNED_MS);
 }
 
 describe('Babysitting Child Processes', () => {
@@ -59,20 +63,28 @@ describe('Babysitting Child Processes', () => {
     describe('process with support for graceful termination', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', childProcess => childProcess.signalKill(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => childProcess.signalKill(),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('does not log a message about being gracefully terminated', () => assert.notInclude(processInfo.stdout, 'exiting'));
+      it('does not log a message about being gracefully terminated', () =>
+        assert.notInclude(processInfo.stdout, 'exiting'));
       it('gets terminated', () => assert.isTrue(processInfo.terminated));
       if (process.platform === 'win32') {
-        it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
+        it('returns non-zero status code', () =>
+          assert.isAbove(processInfo.exitStatus, 0));
       } else {
         it('gets killed', () => assert.equal(processInfo.signal, 'SIGKILL'));
-        it('returns no status code', () => assert.isNull(processInfo.exitStatus));
+        it('returns no status code', () =>
+          assert.isNull(processInfo.exitStatus));
       }
       it('does not emit an error', () => assert.isUndefined(processInfo.error));
     });
@@ -80,105 +92,151 @@ describe('Babysitting Child Processes', () => {
     describe('process without support for graceful termination', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/endless-ignore-term.coffee', childProcess => childProcess.signalKill(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/endless-ignore-term.coffee',
+          (childProcess) => childProcess.signalKill(),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('does not log a message about ignoring graceful termination', () => assert.notInclude(processInfo.stdout, 'ignoring'));
+      it('does not log a message about ignoring graceful termination', () =>
+        assert.notInclude(processInfo.stdout, 'ignoring'));
       it('gets terminated', () => assert.isTrue(processInfo.terminated));
       if (process.platform === 'win32') {
-        it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
+        it('returns non-zero status code', () =>
+          assert.isAbove(processInfo.exitStatus, 0));
       } else {
         it('gets killed', () => assert.equal(processInfo.signal, 'SIGKILL'));
-        it('returns no status code', () => assert.isNull(processInfo.exitStatus));
+        it('returns no status code', () =>
+          assert.isNull(processInfo.exitStatus));
       }
       it('does not emit an error', () => assert.isUndefined(processInfo.error));
     });
   });
 
-  ['signalTerm', 'terminate'].forEach(functionName => describe(`when gracefully terminated by childProcess.${functionName}()`, () => {
+  ['signalTerm', 'terminate'].forEach((functionName) =>
+    describe(`when gracefully terminated by childProcess.${functionName}()`, () => {
+      describe('process with support for graceful termination', () => {
+        let processInfo;
+
+        before((done) =>
+          runChildProcess(
+            'test/fixtures/scripts/stdout.coffee',
+            (childProcess) => childProcess[functionName](),
+            (err, info) => {
+              processInfo = info;
+              done(err);
+            },
+          ),
+        );
+        after((done) => helpers.kill(processInfo.childProcess.pid, done));
+
+        it('logs a message about being gracefully terminated', () =>
+          assert.include(processInfo.stdout, 'exiting'));
+        it('gets terminated', () => assert.isTrue(processInfo.terminated));
+        if (process.platform !== 'win32') {
+          // Windows does not have signals
+          it('does not get terminated directly by the signal', () =>
+            assert.isNull(processInfo.signal));
+        }
+        it('returns zero status code', () =>
+          assert.equal(processInfo.exitStatus, 0));
+        it('does not emit an error', () =>
+          assert.isUndefined(processInfo.error));
+      });
+
+      describe('process without support for graceful termination', () => {
+        let processInfo;
+
+        before((done) =>
+          runChildProcess(
+            'test/fixtures/scripts/endless-ignore-term.coffee',
+            (childProcess) => childProcess.terminate(),
+            (err, info) => {
+              processInfo = info;
+              done(err);
+            },
+          ),
+        );
+        after((done) => helpers.kill(processInfo.childProcess.pid, done));
+
+        it('logs a message about ignoring the graceful termination attempt', () =>
+          assert.include(processInfo.stdout, 'ignoring'));
+        it('does not get terminated', () =>
+          assert.isFalse(processInfo.terminated));
+        it('has undefined status code', () =>
+          assert.isUndefined(processInfo.exitStatus));
+        it('emits an error', () => assert.instanceOf(processInfo.error, Error));
+        it('the error has a message about unsuccessful termination', () =>
+          assert.equal(
+            processInfo.error.message,
+            `Unable to gracefully terminate process ${processInfo.childProcess.pid}`,
+          ));
+      });
+    }),
+  );
+
+  describe("when gracefully terminated by childProcess.terminate({'force': true})", () => {
     describe('process with support for graceful termination', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', childProcess => childProcess[functionName](),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => childProcess.terminate({ force: true }),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('logs a message about being gracefully terminated', () => assert.include(processInfo.stdout, 'exiting'));
+      it('logs a message about being gracefully terminated', () =>
+        assert.include(processInfo.stdout, 'exiting'));
       it('gets terminated', () => assert.isTrue(processInfo.terminated));
-      if (process.platform !== 'win32') { // Windows does not have signals
-        it('does not get terminated directly by the signal', () => assert.isNull(processInfo.signal));
+      if (process.platform !== 'win32') {
+        // Windows does not have signals
+        it('does not get terminated directly by the signal', () =>
+          assert.isNull(processInfo.signal));
       }
-      it('returns zero status code', () => assert.equal(processInfo.exitStatus, 0));
+      it('returns zero status code', () =>
+        assert.equal(processInfo.exitStatus, 0));
       it('does not emit an error', () => assert.isUndefined(processInfo.error));
     });
 
     describe('process without support for graceful termination', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/endless-ignore-term.coffee', childProcess => childProcess.terminate(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/endless-ignore-term.coffee',
+          (childProcess) => childProcess.terminate({ force: true }),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('logs a message about ignoring the graceful termination attempt', () => assert.include(processInfo.stdout, 'ignoring'));
-      it('does not get terminated', () => assert.isFalse(processInfo.terminated));
-      it('has undefined status code', () => assert.isUndefined(processInfo.exitStatus));
-      it('emits an error', () => assert.instanceOf(processInfo.error, Error));
-      it('the error has a message about unsuccessful termination', () => assert.equal(
-        processInfo.error.message,
-        `Unable to gracefully terminate process ${processInfo.childProcess.pid}`
-      ));
-    });
-  }));
-
-  describe('when gracefully terminated by childProcess.terminate({\'force\': true})', () => {
-    describe('process with support for graceful termination', () => {
-      let processInfo;
-
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', childProcess => childProcess.terminate({ force: true }),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
-
-      it('logs a message about being gracefully terminated', () => assert.include(processInfo.stdout, 'exiting'));
-      it('gets terminated', () => assert.isTrue(processInfo.terminated));
-      if (process.platform !== 'win32') { // Windows does not have signals
-        it('does not get terminated directly by the signal', () => assert.isNull(processInfo.signal));
-      }
-      it('returns zero status code', () => assert.equal(processInfo.exitStatus, 0));
-      it('does not emit an error', () => assert.isUndefined(processInfo.error));
-    });
-
-    describe('process without support for graceful termination', () => {
-      let processInfo;
-
-      before(done => runChildProcess('test/fixtures/scripts/endless-ignore-term.coffee', childProcess => childProcess.terminate({ force: true }),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
-
-      it('logs a message about ignoring the graceful termination attempt', () => assert.include(processInfo.stdout, 'ignoring'));
+      it('logs a message about ignoring the graceful termination attempt', () =>
+        assert.include(processInfo.stdout, 'ignoring'));
       it('gets terminated', () => assert.isTrue(processInfo.terminated));
       if (process.platform === 'win32') {
         // Windows does not have signals and when a process gets
         // forcefully terminated, it has a non-zero status code.
-        it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
+        it('returns non-zero status code', () =>
+          assert.isAbove(processInfo.exitStatus, 0));
       } else {
         it('gets killed', () => assert.equal(processInfo.signal, 'SIGKILL'));
-        it('returns no status code', () => assert.isNull(processInfo.exitStatus));
+        it('returns no status code', () =>
+          assert.isNull(processInfo.exitStatus));
       }
       it('does not emit an error', () => assert.isUndefined(processInfo.error));
     });
@@ -188,177 +246,265 @@ describe('Babysitting Child Processes', () => {
     describe('normally with zero status code', () => {
       let processInfo;
 
-      before(done =>
+      before((done) =>
         // eslint-disable-next-line
-        runChildProcess('test/fixtures/scripts/exit-0.coffee', childProcess => true,
+        runChildProcess(
+          'test/fixtures/scripts/exit-0.coffee',
+          () => true,
           (err, info) => {
             processInfo = info;
             done(err);
-          }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns zero status code', () => assert.equal(processInfo.exitStatus, 0));
-      it('does not emit the \'crash\' event', () => assert.isFalse(processInfo.onCrash.called));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it('returns zero status code', () =>
+        assert.equal(processInfo.exitStatus, 0));
+      it("does not emit the 'crash' event", () =>
+        assert.isFalse(processInfo.onCrash.called));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('normally with non-zero status code', () => {
       let processInfo;
 
-      before(done =>
+      before((done) =>
         // eslint-disable-next-line
-        runChildProcess('test/fixtures/scripts/exit-3.coffee', childProcess => true,
+        runChildProcess(
+          'test/fixtures/scripts/exit-3.coffee',
+          () => true,
           (err, info) => {
             processInfo = info;
             done(err);
-          }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
-      it('does emit the \'crash\' event', () => assert.isTrue(processInfo.onCrash.called));
-      it('the \'crash\' event is provided with non-zero status code', () => assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
-      it('the \'crash\' event is not provided with killed flag', () => assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it('returns non-zero status code', () =>
+        assert.isAbove(processInfo.exitStatus, 0));
+      it("does emit the 'crash' event", () =>
+        assert.isTrue(processInfo.onCrash.called));
+      it("the 'crash' event is provided with non-zero status code", () =>
+        assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
+      it("the 'crash' event is not provided with killed flag", () =>
+        assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('intentionally gracefully with zero status code', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', childProcess => childProcess.signalTerm(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => childProcess.signalTerm(),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns zero status code', () => assert.equal(processInfo.exitStatus, 0));
-      it('does not emit the \'crash\' event', () => assert.isFalse(processInfo.onCrash.called));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is flagged as intentionally terminated', () => assert.isTrue(processInfo.childProcess.terminatedIntentionally));
+      it('returns zero status code', () =>
+        assert.equal(processInfo.exitStatus, 0));
+      it("does not emit the 'crash' event", () =>
+        assert.isFalse(processInfo.onCrash.called));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is flagged as intentionally terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('intentionally gracefully with non-zero status code', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout-exit-3.coffee', childProcess => childProcess.signalTerm(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout-exit-3.coffee',
+          (childProcess) => childProcess.signalTerm(),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
-      it('does not emit the \'crash\' event', () => assert.isFalse(processInfo.onCrash.called));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is flagged as intentionally terminated', () => assert.isTrue(processInfo.childProcess.terminatedIntentionally));
+      it('returns non-zero status code', () =>
+        assert.isAbove(processInfo.exitStatus, 0));
+      it("does not emit the 'crash' event", () =>
+        assert.isFalse(processInfo.onCrash.called));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is flagged as intentionally terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('intentionally forcefully', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', childProcess => childProcess.signalKill(),
-        (err, info) => {
-          processInfo = info;
-          done(err);
-        }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => childProcess.signalKill(),
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
       if (process.platform === 'win32') {
-        it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
+        it('returns non-zero status code', () =>
+          assert.isAbove(processInfo.exitStatus, 0));
       } else {
         it('gets killed', () => assert.equal(processInfo.signal, 'SIGKILL'));
-        it('returns no status code', () => assert.isNull(processInfo.exitStatus));
+        it('returns no status code', () =>
+          assert.isNull(processInfo.exitStatus));
       }
-      it('does not emit the \'crash\' event', () => assert.isFalse(processInfo.onCrash.called));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is flagged as intentionally killed', () => assert.isTrue(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it("does not emit the 'crash' event", () =>
+        assert.isFalse(processInfo.onCrash.called));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is flagged as intentionally killed', () =>
+        assert.isTrue(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('gracefully with zero status code', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', (childProcess) => {
-        // Simulate that the process was terminated externally
-        const emit = sinon.stub(childProcess, 'emit');
-        signalTerm(childProcess, () => {});
-        emit.restore();
-      },
-      (err, info) => {
-        processInfo = info;
-        done(err);
-      }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => {
+            // Simulate that the process was terminated externally
+            const emit = sinon.stub(childProcess, 'emit');
+            signalTerm(childProcess, () => {});
+            emit.restore();
+          },
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns zero status code', () => assert.equal(processInfo.exitStatus, 0));
-      it('does not emit the \'crash\' event', () => assert.isFalse(processInfo.onCrash.called));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it('returns zero status code', () =>
+        assert.equal(processInfo.exitStatus, 0));
+      it("does not emit the 'crash' event", () =>
+        assert.isFalse(processInfo.onCrash.called));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('gracefully with non-zero status code', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout-exit-3.coffee', (childProcess) => {
-        // Simulate that the process was terminated externally
-        const emit = sinon.stub(childProcess, 'emit');
-        signalTerm(childProcess, () => {});
-        emit.restore();
-      },
-      (err, info) => {
-        processInfo = info;
-        done(err);
-      }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout-exit-3.coffee',
+          (childProcess) => {
+            // Simulate that the process was terminated externally
+            const emit = sinon.stub(childProcess, 'emit');
+            signalTerm(childProcess, () => {});
+            emit.restore();
+          },
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
-      it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
-      it('does emit the \'crash\' event', () => assert.isTrue(processInfo.onCrash.called));
-      it('the \'crash\' event is provided with non-zero status code', () => assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
-      it('the \'crash\' event is not provided with killed flag', () => assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it('returns non-zero status code', () =>
+        assert.isAbove(processInfo.exitStatus, 0));
+      it("does emit the 'crash' event", () =>
+        assert.isTrue(processInfo.onCrash.called));
+      it("the 'crash' event is provided with non-zero status code", () =>
+        assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
+      it("the 'crash' event is not provided with killed flag", () =>
+        assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
 
     describe('forcefully', () => {
       let processInfo;
 
-      before(done => runChildProcess('test/fixtures/scripts/stdout.coffee', (childProcess) => {
-        // Simulate that the process was killed externally
-        const emit = sinon.stub(childProcess, 'emit');
-        signalKill(childProcess, () => {});
-        emit.restore();
-      },
-      (err, info) => {
-        processInfo = info;
-        done(err);
-      }));
-      after(done => helpers.kill(processInfo.childProcess.pid, done));
+      before((done) =>
+        runChildProcess(
+          'test/fixtures/scripts/stdout.coffee',
+          (childProcess) => {
+            // Simulate that the process was killed externally
+            const emit = sinon.stub(childProcess, 'emit');
+            signalKill(childProcess, () => {});
+            emit.restore();
+          },
+          (err, info) => {
+            processInfo = info;
+            done(err);
+          },
+        ),
+      );
+      after((done) => helpers.kill(processInfo.childProcess.pid, done));
 
       if (process.platform === 'win32') {
-        it('returns non-zero status code', () => assert.isAbove(processInfo.exitStatus, 0));
+        it('returns non-zero status code', () =>
+          assert.isAbove(processInfo.exitStatus, 0));
       } else {
         it('gets killed', () => assert.equal(processInfo.signal, 'SIGKILL'));
-        it('returns no status code', () => assert.isNull(processInfo.exitStatus));
+        it('returns no status code', () =>
+          assert.isNull(processInfo.exitStatus));
       }
-      it('does emit the \'crash\' event', () => assert.isTrue(processInfo.onCrash.called));
+      it("does emit the 'crash' event", () =>
+        assert.isTrue(processInfo.onCrash.called));
       if (process.platform === 'win32') {
-        it('the \'crash\' event is provided with non-zero status code', () => assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
-        it('the \'crash\' event is not provided with killed flag (cannot be detected on Windows)', () => assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
+        it("the 'crash' event is provided with non-zero status code", () =>
+          assert.isAbove(processInfo.onCrash.getCall(0).args[0], 0));
+        it("the 'crash' event is not provided with killed flag (cannot be detected on Windows)", () =>
+          assert.isFalse(processInfo.onCrash.getCall(0).args[1]));
       } else {
-        it('the \'crash\' event is provided with no status code', () => assert.isNull(processInfo.onCrash.getCall(0).args[0]));
-        it('the \'crash\' event is provided with killed flag', () => assert.isTrue(processInfo.onCrash.getCall(0).args[1]));
+        it("the 'crash' event is provided with no status code", () =>
+          assert.isNull(processInfo.onCrash.getCall(0).args[0]));
+        it("the 'crash' event is provided with killed flag", () =>
+          assert.isTrue(processInfo.onCrash.getCall(0).args[1]));
       }
-      it('is flagged as terminated', () => assert.isTrue(processInfo.childProcess.terminated));
-      it('is not flagged as intentionally killed', () => assert.isFalse(processInfo.childProcess.killedIntentionally));
-      it('is not flagged as intentionally terminated', () => assert.isFalse(processInfo.childProcess.terminatedIntentionally));
+      it('is flagged as terminated', () =>
+        assert.isTrue(processInfo.childProcess.terminated));
+      it('is not flagged as intentionally killed', () =>
+        assert.isFalse(processInfo.childProcess.killedIntentionally));
+      it('is not flagged as intentionally terminated', () =>
+        assert.isFalse(processInfo.childProcess.terminatedIntentionally));
     });
   });
 });

--- a/test/integration/cli/api-blueprint-cli-test.js
+++ b/test/integration/cli/api-blueprint-cli-test.js
@@ -1,16 +1,25 @@
 const { assert } = require('chai');
 
-const { runCLIWithServer, createServer, DEFAULT_SERVER_PORT } = require('../helpers');
+const {
+  runCLIWithServer,
+  createServer,
+  DEFAULT_SERVER_PORT,
+} = require('../helpers');
 
 describe('CLI - API Blueprint Document', () => {
   describe('when loaded from file', () => {
     describe('when successfully loaded', () => {
       let runtimeInfo;
-      const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+      const args = [
+        './test/fixtures/single-get.apib',
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+      ];
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -18,8 +27,10 @@ describe('CLI - API Blueprint Document', () => {
         });
       });
 
-      it('should request /machines', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when API Blueprint is loaded with errors', () => {
@@ -37,8 +48,13 @@ describe('CLI - API Blueprint Document', () => {
         });
       });
 
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr, 'API description processing error'));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should print error message to stderr', () =>
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          'API description processing error',
+        ));
     });
 
     describe('when API Blueprint is loaded with warnings', () => {
@@ -57,8 +73,13 @@ describe('CLI - API Blueprint Document', () => {
         });
       });
 
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
-      it('should print warning to stdout', () => assert.include(runtimeInfo.dredd.stdout, 'API description URI template expansion warning'));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should print warning to stdout', () =>
+        assert.include(
+          runtimeInfo.dredd.stdout,
+          'API description URI template expansion warning',
+        ));
     });
   });
 });

--- a/test/integration/cli/api-description-cli-test.js
+++ b/test/integration/cli/api-description-cli-test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const os = require('os');
 const { assert } = require('chai');
 
-const { runCLIWithServer, createServer, DEFAULT_SERVER_PORT } = require('../helpers');
+const {
+  runCLIWithServer,
+  createServer,
+  DEFAULT_SERVER_PORT,
+} = require('../helpers');
 
 const NON_EXISTENT_PORT = DEFAULT_SERVER_PORT + 1;
 
@@ -10,11 +14,16 @@ describe('CLI - API Description Document', () => {
   describe('when loaded from file', () => {
     describe('when loaded by glob pattern', () => {
       let runtimeInfo;
-      const args = ['./test/fixtures/single-g*t.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+      const args = [
+        './test/fixtures/single-g*t.apib',
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+      ];
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -22,8 +31,10 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should request /machines', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when file not found', () => {
@@ -41,16 +52,18 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr.toLowerCase(), 'could not find'));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should print error message to stderr', () =>
+        assert.include(
+          runtimeInfo.dredd.stderr.toLowerCase(),
+          'could not find',
+        ));
     });
 
-    describe('when given path exists, but can\'t be read', () => {
+    describe("when given path exists, but can't be read", () => {
       let runtimeInfo;
-      const args = [
-        os.homedir(),
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-      ];
+      const args = [os.homedir(), `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
 
       before((done) => {
         const app = createServer();
@@ -60,11 +73,15 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr, 'Unable to load API description document'));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should print error message to stderr', () =>
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          'Unable to load API description document',
+        ));
     });
   });
-
 
   describe('when loaded from URL', () => {
     describe('when successfully loaded from URL', () => {
@@ -80,7 +97,9 @@ describe('CLI - API Description Document', () => {
           res.type('text/vnd.apiblueprint');
           fs.createReadStream('./test/fixtures/single-get.apib').pipe(res);
         });
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -88,9 +107,15 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should download API Description Document from server', () => assert.equal(runtimeInfo.server.requestCounts['/single-get.apib'], 1));
-      it('should request /machines', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1, '/single-get.apib': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should download API Description Document from server', () =>
+        assert.equal(runtimeInfo.server.requestCounts['/single-get.apib'], 1));
+      it('should request /machines', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, {
+          '/machines': 1,
+          '/single-get.apib': 1,
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when URL points to non-existent server', () => {
@@ -108,11 +133,19 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should not request server', () => assert.isFalse(runtimeInfo.server.requested));
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should not request server', () =>
+        assert.isFalse(runtimeInfo.server.requested));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
       it('should print error message to stderr', () => {
-        assert.include(runtimeInfo.dredd.stderr, 'Unable to load API description document from');
-        assert.include(runtimeInfo.dredd.stderr, `http://127.0.0.1:${NON_EXISTENT_PORT}/single-get.apib`);
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          'Unable to load API description document from',
+        );
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          `http://127.0.0.1:${NON_EXISTENT_PORT}/single-get.apib`,
+        );
       });
     });
 
@@ -133,16 +166,26 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should request server', () => assert.isTrue(runtimeInfo.server.requested));
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should request server', () =>
+        assert.isTrue(runtimeInfo.server.requested));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
       it('should print error message to stderr', () => {
-        assert.include(runtimeInfo.dredd.stderr, 'Unable to load API description document from');
-        assert.include(runtimeInfo.dredd.stderr, "Dredd got HTTP 404 response with 'text/plain; charset=utf-8' body");
-        assert.include(runtimeInfo.dredd.stderr, `http://127.0.0.1:${DEFAULT_SERVER_PORT}/__non-existent__.apib`);
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          'Unable to load API description document from',
+        );
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          "Dredd got HTTP 404 response with 'text/plain; charset=utf-8' body",
+        );
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}/__non-existent__.apib`,
+        );
       });
     });
   });
-
 
   describe('when loaded by -p/--path', () => {
     describe('when loaded from file', () => {
@@ -155,8 +198,12 @@ describe('CLI - API Description Document', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
-        app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
+        app.get('/machines/willy', (req, res) =>
+          res.json({ type: 'bulldozer', name: 'willy' }),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -164,8 +211,13 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should request /machines, /machines/willy', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1, '/machines/willy': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines, /machines/willy', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, {
+          '/machines': 1,
+          '/machines/willy': 1,
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when loaded from URL', () => {
@@ -182,8 +234,12 @@ describe('CLI - API Description Document', () => {
           res.type('application/yaml');
           fs.createReadStream('./test/fixtures/single-get.yaml').pipe(res);
         });
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
-        app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
+        app.get('/machines/willy', (req, res) =>
+          res.json({ type: 'bulldozer', name: 'willy' }),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -191,9 +247,16 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should download API Description Document from server', () => assert.equal(runtimeInfo.server.requestCounts['/single-get.yaml'], 1));
-      it('should request /machines, /machines/willy', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1, '/machines/willy': 1, '/single-get.yaml': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should download API Description Document from server', () =>
+        assert.equal(runtimeInfo.server.requestCounts['/single-get.yaml'], 1));
+      it('should request /machines, /machines/willy', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, {
+          '/machines': 1,
+          '/machines/willy': 1,
+          '/single-get.yaml': 1,
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when used multiple times', () => {
@@ -207,9 +270,15 @@ describe('CLI - API Description Document', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
-        app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
-        app.get('/machines/caterpillar', (req, res) => res.json({ type: 'bulldozer', name: 'caterpillar' }));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
+        app.get('/machines/willy', (req, res) =>
+          res.json({ type: 'bulldozer', name: 'willy' }),
+        );
+        app.get('/machines/caterpillar', (req, res) =>
+          res.json({ type: 'bulldozer', name: 'caterpillar' }),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -217,8 +286,14 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should request /machines, /machines/willy, /machines/caterpillar', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1, '/machines/willy': 1, '/machines/caterpillar': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines, /machines/willy, /machines/caterpillar', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, {
+          '/machines': 1,
+          '/machines/willy': 1,
+          '/machines/caterpillar': 1,
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when loaded by glob pattern', () => {
@@ -231,8 +306,12 @@ describe('CLI - API Description Document', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
-        app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
+        app.get('/machines/willy', (req, res) =>
+          res.json({ type: 'bulldozer', name: 'willy' }),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -240,8 +319,13 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should request /machines, /machines/willy', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1, '/machines/willy': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines, /machines/willy', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, {
+          '/machines': 1,
+          '/machines/willy': 1,
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when additional file not found', () => {
@@ -254,7 +338,9 @@ describe('CLI - API Description Document', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -262,9 +348,15 @@ describe('CLI - API Description Document', () => {
         });
       });
 
-      it('should not request server', () => assert.isFalse(runtimeInfo.server.requested));
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr.toLowerCase(), 'could not find'));
+      it('should not request server', () =>
+        assert.isFalse(runtimeInfo.server.requested));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should print error message to stderr', () =>
+        assert.include(
+          runtimeInfo.dredd.stderr.toLowerCase(),
+          'could not find',
+        ));
     });
   });
 });

--- a/test/integration/cli/configuration-cli-test.js
+++ b/test/integration/cli/configuration-cli-test.js
@@ -38,13 +38,13 @@ function execCommand(custom = {}, cb) {
   stderr = '';
   exitStatus = null;
   let finished = false;
-  const cli = new CLIStub({ custom }, ((exitStatusCode) => {
+  const cli = new CLIStub({ custom }, (exitStatusCode) => {
     if (!finished) {
       finished = true;
-      exitStatus = (exitStatusCode != null ? exitStatusCode : 0);
+      exitStatus = exitStatusCode != null ? exitStatusCode : 0;
       cb();
     }
-  }));
+  });
 
   cli.run();
 }
@@ -52,9 +52,9 @@ function execCommand(custom = {}, cb) {
 describe('CLI class Integration', () => {
   before(() => {
     ['warn', 'error', 'debug'].forEach((method) => {
-      sinon
-        .stub(loggerStub, method)
-        .callsFake((chunk) => { stderr += `\n${method}: ${chunk}`; });
+      sinon.stub(loggerStub, method).callsFake((chunk) => {
+        stderr += `\n${method}: ${chunk}`;
+      });
     });
   });
 
@@ -75,7 +75,9 @@ describe('CLI class Integration', () => {
 
       before((done) => {
         fsExistsSync = sinon.stub(fs, 'existsSync').callsFake(() => true);
-        configUtilsLoad = sinon.stub(configUtils, 'load').callsFake(() => options);
+        configUtilsLoad = sinon
+          .stub(configUtils, 'load')
+          .callsFake(() => options);
         execCommand(cmd, done);
       });
       after(() => {
@@ -83,9 +85,12 @@ describe('CLI class Integration', () => {
         configUtilsLoad.restore();
       });
 
-      it('should call fs.existsSync with given path', () => assert.isTrue(fsExistsSync.calledWith(configPath)));
-      it('should call configUtils.load with given path', () => assert.isTrue(configUtilsLoad.calledWith(configPath)));
-      it('should print message about using given configuration file', () => assert.include(stderr, `debug: Configuration '${configPath}' found`));
+      it('should call fs.existsSync with given path', () =>
+        assert.isTrue(fsExistsSync.calledWith(configPath)));
+      it('should call configUtils.load with given path', () =>
+        assert.isTrue(configUtilsLoad.calledWith(configPath)));
+      it('should print message about using given configuration file', () =>
+        assert.include(stderr, `debug: Configuration '${configPath}' found`));
     });
 
     describe('When dredd.yml exists', () => {
@@ -98,7 +103,9 @@ describe('CLI class Integration', () => {
 
       before((done) => {
         fsExistsSync = sinon.stub(fs, 'existsSync').callsFake(() => true);
-        configUtilsLoad = sinon.stub(configUtils, 'load').callsFake(() => options);
+        configUtilsLoad = sinon
+          .stub(configUtils, 'load')
+          .callsFake(() => options);
         execCommand(cmd, done);
       });
       after(() => {
@@ -106,9 +113,12 @@ describe('CLI class Integration', () => {
         configUtilsLoad.restore();
       });
 
-      it('should call fs.existsSync with dredd.yml', () => assert.isTrue(fsExistsSync.calledWith(configPath)));
-      it('should call configUtils.load with dredd.yml', () => assert.isTrue(configUtilsLoad.calledWith(configPath)));
-      it('should print message about using dredd.yml', () => assert.include(stderr, `debug: Configuration '${configPath}' found`));
+      it('should call fs.existsSync with dredd.yml', () =>
+        assert.isTrue(fsExistsSync.calledWith(configPath)));
+      it('should call configUtils.load with dredd.yml', () =>
+        assert.isTrue(configUtilsLoad.calledWith(configPath)));
+      it('should print message about using dredd.yml', () =>
+        assert.include(stderr, `debug: Configuration '${configPath}' found`));
     });
 
     describe('When dredd.yml does not exist', () => {
@@ -128,9 +138,12 @@ describe('CLI class Integration', () => {
         configUtilsLoad.restore();
       });
 
-      it('should call fs.existsSync with dredd.yml', () => assert.isTrue(fsExistsSync.calledWith(configPath)));
-      it('should never call configUtils.load', () => assert.isFalse(configUtilsLoad.called));
-      it('should not print message about using configuration file', () => assert.notInclude(stderr, 'debug: Configuration'));
+      it('should call fs.existsSync with dredd.yml', () =>
+        assert.isTrue(fsExistsSync.calledWith(configPath)));
+      it('should never call configUtils.load', () =>
+        assert.isFalse(configUtilsLoad.called));
+      it('should not print message about using configuration file', () =>
+        assert.notInclude(stderr, 'debug: Configuration'));
     });
   });
 
@@ -151,10 +164,7 @@ describe('CLI class Integration', () => {
       ],
     };
     const goodCmd = {
-      argv: [
-        `http://127.0.0.1:${PORT}/file.apib`,
-        `http://127.0.0.1:${PORT}`,
-      ],
+      argv: [`http://127.0.0.1:${PORT}/file.apib`, `http://127.0.0.1:${PORT}`],
     };
 
     before((done) => {
@@ -163,24 +173,30 @@ describe('CLI class Integration', () => {
       app.get('/', (req, res) => res.sendStatus(404));
 
       app.get('/file.apib', (req, res) => {
-        fs.createReadStream('./test/fixtures/single-get.apib').pipe(res.type('text'));
+        fs.createReadStream('./test/fixtures/single-get.apib').pipe(
+          res.type('text'),
+        );
       });
 
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       app.get('/not-found.apib', (req, res) => res.status(404).end());
 
       server = app.listen(PORT, () => done());
     });
 
-    after(done => server.close(() => {
-      app = null;
-      server = null;
-      done();
-    }));
+    after((done) =>
+      server.close(() => {
+        app = null;
+        server = null;
+        done();
+      }),
+    );
 
     describe('and I try to load a file from bad hostname at all', () => {
-      before(done => execCommand(errorCmd, done));
+      before((done) => execCommand(errorCmd, done));
 
       it('should exit with status 1', () => assert.equal(exitStatus, 1));
 
@@ -191,7 +207,7 @@ describe('CLI class Integration', () => {
     });
 
     describe('and I try to load a file that does not exist from an existing server', () => {
-      before(done => execCommand(wrongCmd, done));
+      before((done) => execCommand(wrongCmd, done));
 
       it('should exit with status 1', () => assert.equal(exitStatus, 1));
 
@@ -203,7 +219,7 @@ describe('CLI class Integration', () => {
     });
 
     describe('and I try to load a file that actually is there', () => {
-      before(done => execCommand(goodCmd, done));
+      before((done) => execCommand(goodCmd, done));
 
       it('should exit with status 0', () => assert.equal(exitStatus, 0));
     });

--- a/test/integration/cli/hookfiles-cli-test.js
+++ b/test/integration/cli/hookfiles-cli-test.js
@@ -3,7 +3,12 @@ const path = require('path');
 const { assert } = require('chai');
 
 const {
-  isProcessRunning, killAll, createServer, runCLIWithServer, runCLI, DEFAULT_SERVER_PORT,
+  isProcessRunning,
+  killAll,
+  createServer,
+  runCLIWithServer,
+  runCLI,
+  DEFAULT_SERVER_PORT,
 } = require('../helpers');
 
 const COFFEE_BIN = 'node_modules/.bin/coffee';
@@ -16,16 +21,22 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
-        const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+        const args = [
+          './test/fixtures/single-get.apib',
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+        ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
           done(err);
         });
       });
 
-      it('exit status should be 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('exit status should be 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when executing the command and the server is responding as specified in the API description, endpoint with path', () => {
@@ -33,16 +44,22 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/v2/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/v2/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
-        const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}/v2/`];
+        const args = [
+          './test/fixtures/single-get.apib',
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}/v2/`,
+        ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
           done(err);
         });
       });
 
-      it('exit status should be 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('exit status should be 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when executing the command and the server is sending different response', () => {
@@ -50,16 +67,24 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.status(201).json([{ kind: 'bulldozer', imatriculation: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res
+            .status(201)
+            .json([{ kind: 'bulldozer', imatriculation: 'willy' }]),
+        );
 
-        const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+        const args = [
+          './test/fixtures/single-get.apib',
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+        ];
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
           done(err);
         });
       });
 
-      it('exit status should be 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('exit status should be 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
     });
   });
 
@@ -70,7 +95,9 @@ describe('CLI', () => {
 
         before((done) => {
           const app = createServer();
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           const args = [
             './test/fixtures/single-get.apib',
@@ -85,23 +112,29 @@ describe('CLI', () => {
           });
         });
 
-        after(done => killAll('test/fixtures/scripts/', done));
+        after((done) => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+        it('should return with status 1', () =>
+          assert.equal(runtimeInfo.dredd.exitStatus, 1));
 
         it('should not return message containing exited or killed', () => {
           assert.notInclude(runtimeInfo.dredd.stderr, 'exited');
           assert.notInclude(runtimeInfo.dredd.stderr, 'killed');
         });
 
-        it('should not return message announcing the fact', () => assert.include(runtimeInfo.dredd.stderr, 'not found'));
+        it('should not return message announcing the fact', () =>
+          assert.include(runtimeInfo.dredd.stderr, 'not found'));
 
-        it('should term or kill the server', done => isProcessRunning('endless-ignore-term', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
+        it('should term or kill the server', (done) =>
+          isProcessRunning('endless-ignore-term', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
 
-        it('should not execute any transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, {}));
+        it('should not execute any transaction', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {}));
       });
 
       describe('and handler crashes before execution', () => {
@@ -109,7 +142,9 @@ describe('CLI', () => {
 
         before((done) => {
           const app = createServer();
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           const args = [
             './test/fixtures/single-get.apib',
@@ -124,18 +159,24 @@ describe('CLI', () => {
           });
         });
 
-        after(done => killAll('test/fixtures/scripts/', done));
+        after((done) => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+        it('should return with status 1', () =>
+          assert.equal(runtimeInfo.dredd.exitStatus, 1));
 
-        it('should return message announcing the fact', () => assert.include(runtimeInfo.dredd.stderr, 'exited'));
+        it('should return message announcing the fact', () =>
+          assert.include(runtimeInfo.dredd.stderr, 'exited'));
 
-        it('should term or kill the server', done => isProcessRunning('endless-ignore-term', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
+        it('should term or kill the server', (done) =>
+          isProcessRunning('endless-ignore-term', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
 
-        it('should not execute any transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, {}));
+        it('should not execute any transaction', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {}));
       });
 
       describe('and handler is killed before execution', () => {
@@ -143,7 +184,9 @@ describe('CLI', () => {
 
         before((done) => {
           const app = createServer();
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           const args = [
             './test/fixtures/single-get.apib',
@@ -159,9 +202,10 @@ describe('CLI', () => {
           });
         });
 
-        after(done => killAll('test/fixtures/scripts/', done));
+        after((done) => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+        it('should return with status 1', () =>
+          assert.equal(runtimeInfo.dredd.exitStatus, 1));
 
         it('should return message announcing the fact', () => {
           if (process.platform === 'win32') {
@@ -171,12 +215,16 @@ describe('CLI', () => {
           assert.include(runtimeInfo.dredd.stderr, 'killed');
         });
 
-        it('should term or kill the server', done => isProcessRunning('endless-ignore-term', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
+        it('should term or kill the server', (done) =>
+          isProcessRunning('endless-ignore-term', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
 
-        it('should not execute any transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, {}));
+        it('should not execute any transaction', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {}));
       });
 
       describe('and handler is killed during execution', () => {
@@ -187,17 +235,21 @@ describe('CLI', () => {
           app.get('/machines', (req, res) => {
             // path.posix|win32.normalize and path.join do not do the job in this case,
             // hence this ingenious hack
-            const normalizedPath = path.normalize('test/fixtures/hooks.js').replace(/\\/g, '\\\\');
+            const normalizedPath = path
+              .normalize('test/fixtures/hooks.js')
+              .replace(/\\/g, '\\\\');
             killAll(`endless-ignore-term.+[^=]${normalizedPath}`, (err) => {
-              if (err) { done(err); }
+              if (err) {
+                done(err);
+              }
               res.json([{ type: 'bulldozer', name: 'willy' }]);
             });
           });
 
           // TCP server echoing transactions back
           const hookHandler = net.createServer((socket) => {
-            socket.on('data', data => socket.write(data));
-            socket.on('error', err => console.error(err));
+            socket.on('data', (data) => socket.write(data));
+            socket.on('error', (err) => console.error(err));
           });
 
           const args = [
@@ -208,16 +260,19 @@ describe('CLI', () => {
             `--language=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
             '--hookfiles=test/fixtures/hooks.js',
           ];
-          hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () => runCLIWithServer(args, app, (err, info) => {
-            hookHandler.close();
-            runtimeInfo = info;
-            done(err);
-          }));
+          hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () =>
+            runCLIWithServer(args, app, (err, info) => {
+              hookHandler.close();
+              runtimeInfo = info;
+              done(err);
+            }),
+          );
         });
 
-        after(done => killAll('test/fixtures/scripts/', done));
+        after((done) => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+        it('should return with status 1', () =>
+          assert.equal(runtimeInfo.dredd.exitStatus, 1));
 
         it('should return message announcing the fact', () => {
           if (process.platform === 'win32') {
@@ -227,12 +282,18 @@ describe('CLI', () => {
           assert.include(runtimeInfo.dredd.stderr, 'killed');
         });
 
-        it('should term or kill the server', done => isProcessRunning('endless-ignore-term', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
+        it('should term or kill the server', (done) =>
+          isProcessRunning('endless-ignore-term', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
 
-        it('should execute the transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+        it('should execute the transaction', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {
+            '/machines': 1,
+          }));
       });
 
       describe("and handler didn't quit but all Dredd tests were OK", () => {
@@ -241,12 +302,14 @@ describe('CLI', () => {
         before((done) => {
           const app = createServer();
 
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           // TCP server echoing transactions back
           const hookHandler = net.createServer((socket) => {
-            socket.on('data', data => socket.write(data));
-            socket.on('error', err => console.error(err));
+            socket.on('data', (data) => socket.write(data));
+            socket.on('error', (err) => console.error(err));
           });
 
           const args = [
@@ -257,28 +320,37 @@ describe('CLI', () => {
             `--language=${COFFEE_BIN} ./test/fixtures/scripts/endless-ignore-term.coffee`,
             '--hookfiles=./test/fixtures/scripts/emptyfile',
           ];
-          hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () => runCLIWithServer(args, app, (err, info) => {
-            hookHandler.close();
-            runtimeInfo = info;
-            done(err);
-          }));
+          hookHandler.listen(DEFAULT_HOOK_HANDLER_PORT, () =>
+            runCLIWithServer(args, app, (err, info) => {
+              hookHandler.close();
+              runtimeInfo = info;
+              done(err);
+            }),
+          );
         });
 
-        after(done => killAll('test/fixtures/scripts/', done));
+        after((done) => killAll('test/fixtures/scripts/', done));
 
-        it('should return with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+        it('should return with status 0', () =>
+          assert.equal(runtimeInfo.dredd.exitStatus, 0));
 
         it('should not return any killed or exited message', () => {
           assert.notInclude(runtimeInfo.dredd.stderr, 'killed');
           assert.notInclude(runtimeInfo.dredd.stderr, 'exited');
         });
 
-        it('should kill both the handler and the server', done => isProcessRunning('endless-ignore-term', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
+        it('should kill both the handler and the server', (done) =>
+          isProcessRunning('endless-ignore-term', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
 
-        it('should execute some transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+        it('should execute some transaction', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {
+            '/machines': 1,
+          }));
       });
     });
 
@@ -287,7 +359,9 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -301,16 +375,22 @@ describe('CLI', () => {
         });
       });
 
-      it('should have an additional header in the request', () => assert.nestedPropertyVal(runtimeInfo.server.requests['/machines'][0], 'headers.accept', 'application/json'));
+      it('should have an additional header in the request', () =>
+        assert.nestedPropertyVal(
+          runtimeInfo.server.requests['/machines'][0],
+          'headers.accept',
+          'application/json',
+        ));
     });
-
 
     describe('when adding basic auth credentials with -u', () => {
       let runtimeInfo;
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -324,18 +404,26 @@ describe('CLI', () => {
         });
       });
 
-      it('should have an authorization header in the request', () => assert.isOk(runtimeInfo.server.requests['/machines'][0].headers.authorization));
+      it('should have an authorization header in the request', () =>
+        assert.isOk(
+          runtimeInfo.server.requests['/machines'][0].headers.authorization,
+        ));
 
-      it('should contain a base64 encoded string of the username and password', () => assert.isOk(runtimeInfo.server.requests['/machines'][0].headers.authorization === (`Basic ${Buffer.from('username:password').toString('base64')}`)));
+      it('should contain a base64 encoded string of the username and password', () =>
+        assert.isOk(
+          runtimeInfo.server.requests['/machines'][0].headers.authorization ===
+            `Basic ${Buffer.from('username:password').toString('base64')}`,
+        ));
     });
-
 
     describe('when sorting requests with -s', () => {
       let runtimeInfo;
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/apiary.apib',
@@ -350,10 +438,10 @@ describe('CLI', () => {
 
       it('should perform the POST, GET, PUT, DELETE in order', () => {
         assert.isOk(
-          runtimeInfo.dredd.stdout.indexOf('POST')
-          < runtimeInfo.dredd.stdout.indexOf('GET')
-          < runtimeInfo.dredd.stdout.indexOf('PUT')
-          < runtimeInfo.dredd.stdout.indexOf('DELETE')
+          runtimeInfo.dredd.stdout.indexOf('POST') <
+            runtimeInfo.dredd.stdout.indexOf('GET') <
+            runtimeInfo.dredd.stdout.indexOf('PUT') <
+            runtimeInfo.dredd.stdout.indexOf('DELETE'),
         );
       });
     });
@@ -363,7 +451,11 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.status(201).json([{ kind: 'bulldozer', imatriculation: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res
+            .status(201)
+            .json([{ kind: 'bulldozer', imatriculation: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -389,7 +481,9 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -414,7 +508,9 @@ describe('CLI', () => {
 
         before((done) => {
           const app = createServer();
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           const args = [
             './test/fixtures/single-get.apib',
@@ -428,7 +524,8 @@ describe('CLI', () => {
           });
         });
 
-        it('should not send the request request', () => assert.deepEqual(runtimeInfo.server.requestCounts, {}));
+        it('should not send the request request', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {}));
       });
 
       describe('when not blocking a request', () => {
@@ -436,7 +533,9 @@ describe('CLI', () => {
 
         before((done) => {
           const app = createServer();
-          app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+          app.get('/machines', (req, res) =>
+            res.json([{ type: 'bulldozer', name: 'willy' }]),
+          );
 
           const args = [
             './test/fixtures/single-get.apib',
@@ -450,7 +549,10 @@ describe('CLI', () => {
           });
         });
 
-        it('should allow the request to go through', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+        it('should allow the request to go through', () =>
+          assert.deepEqual(runtimeInfo.server.requestCounts, {
+            '/machines': 1,
+          }));
       });
     });
 
@@ -459,9 +561,13 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
-        app.get('/message', (req, res) => res.type('text/plain').send('Hello World!\n'));
+        app.get('/message', (req, res) =>
+          res.type('text/plain').send('Hello World!\n'),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -476,11 +582,14 @@ describe('CLI', () => {
         });
       });
 
-      it('should notify skipping to the stdout', () => assert.include(runtimeInfo.dredd.stdout, 'skip: GET (200) /machines'));
+      it('should notify skipping to the stdout', () =>
+        assert.include(runtimeInfo.dredd.stdout, 'skip: GET (200) /machines'));
 
-      it('should hit the only transaction', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/message': 1 }));
+      it('should hit the only transaction', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, { '/message': 1 }));
 
-      it('exit status should be 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('exit status should be 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when suppressing color with --no-color', () => {
@@ -488,7 +597,9 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -513,7 +624,9 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -537,7 +650,9 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         const args = [
           './test/fixtures/single-get.apib',
@@ -562,7 +677,9 @@ describe('CLI', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       const args = [
         './test/fixtures/single-get.apib',
@@ -575,7 +692,11 @@ describe('CLI', () => {
       });
     });
 
-    it('should modify the transaction with hooks', () => assert.equal(runtimeInfo.server.requests['/machines'][0].headers.header, '123232323'));
+    it('should modify the transaction with hooks', () =>
+      assert.equal(
+        runtimeInfo.server.requests['/machines'][0].headers.header,
+        '123232323',
+      ));
   });
 
   describe('when describing events in hookfiles', () => {
@@ -593,7 +714,9 @@ describe('CLI', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       const args = [
         './test/fixtures/single-get.apib',
@@ -607,8 +730,14 @@ describe('CLI', () => {
     });
 
     it('should execute the before and after events', () => {
-      assert.isOk(containsLine(runtimeInfo.dredd.stdout, 'hooks.beforeAll'), (runtimeInfo.dredd.stdout));
-      assert.isOk(containsLine(runtimeInfo.dredd.stdout, 'hooks.afterAll'), (runtimeInfo.dredd.stdout));
+      assert.isOk(
+        containsLine(runtimeInfo.dredd.stdout, 'hooks.beforeAll'),
+        runtimeInfo.dredd.stdout,
+      );
+      assert.isOk(
+        containsLine(runtimeInfo.dredd.stdout, 'hooks.afterAll'),
+        runtimeInfo.dredd.stdout,
+      );
     });
   });
 
@@ -628,7 +757,9 @@ describe('CLI', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
       const args = [
         './test/fixtures/single-get.apib',
@@ -654,12 +785,14 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/', (req, res) => res.json({
-          data: {
-            expires: 1234,
-            token: 'this should pass since it is a string',
-          },
-        }));
+        app.get('/', (req, res) =>
+          res.json({
+            data: {
+              expires: 1234,
+              token: 'this should pass since it is a string',
+            },
+          }),
+        );
 
         const args = [
           './test/fixtures/schema.apib',
@@ -671,7 +804,8 @@ describe('CLI', () => {
         });
       });
 
-      it('exit status should be 0 (success)', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('exit status should be 0 (success)', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('and server is NOT responding in accordance with the schema', () => {
@@ -679,12 +813,14 @@ describe('CLI', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/', (req, res) => res.json({
-          data: {
-            expires: 'this should fail since it is a string',
-            token: 'this should pass since it is a string',
-          },
-        }));
+        app.get('/', (req, res) =>
+          res.json({
+            data: {
+              expires: 'this should fail since it is a string',
+              token: 'this should pass since it is a string',
+            },
+          }),
+        );
 
         const args = [
           './test/fixtures/schema.apib',
@@ -696,7 +832,8 @@ describe('CLI', () => {
         });
       });
 
-      it('exit status should be 1 (failure)', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('exit status should be 1 (failure)', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
     });
   });
 
@@ -723,7 +860,8 @@ describe('CLI', () => {
         assert.include(cliInfo.stdout, '> /name > GET');
       });
 
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
     });
 
     describe('and called with hooks', () => {
@@ -733,9 +871,13 @@ describe('CLI', () => {
         const app = createServer();
         app.get('/name', (req, res) => res.type('text/plain').send('Adam\n'));
 
-        app.get('/greeting', (req, res) => res.type('text/plain').send('Howdy!\n'));
+        app.get('/greeting', (req, res) =>
+          res.type('text/plain').send('Howdy!\n'),
+        );
 
-        app.get('/message', (req, res) => res.type('text/plain').send('Hello World!\n'));
+        app.get('/message', (req, res) =>
+          res.type('text/plain').send('Hello World!\n'),
+        );
 
         const args = [
           './test/fixtures/multifile/*.apib',
@@ -755,7 +897,12 @@ describe('CLI', () => {
         assert.include(runtimeInfo.dredd.stdout, 'after message');
       });
 
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0, (runtimeInfo.dredd.output)));
+      it('should exit with status 0', () =>
+        assert.equal(
+          runtimeInfo.dredd.exitStatus,
+          0,
+          runtimeInfo.dredd.output,
+        ));
 
       it('server should receive 3 requests', () => {
         assert.deepEqual(runtimeInfo.server.requestCounts, {
@@ -767,32 +914,39 @@ describe('CLI', () => {
     });
   });
 
+  describe('when called with additional --path argument which is a glob', () =>
+    describe('and called with --names options', () => {
+      let cliInfo;
 
-  describe('when called with additional --path argument which is a glob', () => describe('and called with --names options', () => {
-    let cliInfo;
-
-    before((done) => {
-      const args = [
-        './test/fixtures/multiple-examples.apib',
-        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
-        '--path=./test/fixtures/multifile/*.apib',
-        '--loglevel=debug',
-        '--names',
-      ];
-      runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
+      before((done) => {
+        const args = [
+          './test/fixtures/multiple-examples.apib',
+          `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+          '--path=./test/fixtures/multifile/*.apib',
+          '--loglevel=debug',
+          '--names',
+        ];
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        });
       });
-    });
 
-    it('it should include all paths from all API description documents matching all paths and globs', () => {
-      assert.include(cliInfo.stdout, 'Greeting API > /greeting > GET');
-      assert.include(cliInfo.stdout, 'Message API > /message > GET');
-      assert.include(cliInfo.stdout, 'Name API > /name > GET');
-      assert.include(cliInfo.stdout, 'Machines API > Machines > Machines collection > Get Machines > Example 1');
-      assert.include(cliInfo.stdout, 'Machines API > Machines > Machines collection > Get Machines > Example 2');
-    });
+      it('it should include all paths from all API description documents matching all paths and globs', () => {
+        assert.include(cliInfo.stdout, 'Greeting API > /greeting > GET');
+        assert.include(cliInfo.stdout, 'Message API > /message > GET');
+        assert.include(cliInfo.stdout, 'Name API > /name > GET');
+        assert.include(
+          cliInfo.stdout,
+          'Machines API > Machines > Machines collection > Get Machines > Example 1',
+        );
+        assert.include(
+          cliInfo.stdout,
+          'Machines API > Machines > Machines collection > Get Machines > Example 2',
+        );
+      });
 
-    it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
-  }));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
+    }));
 });

--- a/test/integration/cli/openapi2-cli-test.js
+++ b/test/integration/cli/openapi2-cli-test.js
@@ -1,16 +1,25 @@
 const { assert } = require('chai');
 
-const { runCLIWithServer, createServer, DEFAULT_SERVER_PORT } = require('../helpers');
+const {
+  runCLIWithServer,
+  createServer,
+  DEFAULT_SERVER_PORT,
+} = require('../helpers');
 
 describe('CLI - OpenAPI 2 Document', () => {
   describe('when loaded from file', () => {
     describe('when successfully loaded', () => {
       let runtimeInfo;
-      const args = ['./test/fixtures/single-get.yaml', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+      const args = [
+        './test/fixtures/single-get.yaml',
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+      ];
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -18,8 +27,10 @@ describe('CLI - OpenAPI 2 Document', () => {
         });
       });
 
-      it('should request /machines', () => assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should request /machines', () =>
+        assert.deepEqual(runtimeInfo.server.requestCounts, { '/machines': 1 }));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
     });
 
     describe('when OpenAPI 2 is loaded with errors', () => {
@@ -37,8 +48,13 @@ describe('CLI - OpenAPI 2 Document', () => {
         });
       });
 
-      it('should exit with status 1', () => assert.equal(runtimeInfo.dredd.exitStatus, 1));
-      it('should print error message to stderr', () => assert.include(runtimeInfo.dredd.stderr, 'API description processing error'));
+      it('should exit with status 1', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 1));
+      it('should print error message to stderr', () =>
+        assert.include(
+          runtimeInfo.dredd.stderr,
+          'API description processing error',
+        ));
     });
 
     describe('when OpenAPI 2 is loaded with warnings', () => {
@@ -51,7 +67,9 @@ describe('CLI - OpenAPI 2 Document', () => {
 
       before((done) => {
         const app = createServer();
-        app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+        app.get('/machines', (req, res) =>
+          res.json([{ type: 'bulldozer', name: 'willy' }]),
+        );
 
         runCLIWithServer(args, app, (err, info) => {
           runtimeInfo = info;
@@ -59,8 +77,13 @@ describe('CLI - OpenAPI 2 Document', () => {
         });
       });
 
-      it('should exit with status 0', () => assert.equal(runtimeInfo.dredd.exitStatus, 0));
-      it('should print warning to stdout', () => assert.include(runtimeInfo.dredd.stdout, 'API description parser warning'));
+      it('should exit with status 0', () =>
+        assert.equal(runtimeInfo.dredd.exitStatus, 0));
+      it('should print warning to stdout', () =>
+        assert.include(
+          runtimeInfo.dredd.stdout,
+          'API description parser warning',
+        ));
     });
   });
 });

--- a/test/integration/cli/reporters-cli-test.js
+++ b/test/integration/cli/reporters-cli-test.js
@@ -12,15 +12,16 @@ describe('CLI - Reporters', () => {
   before((done) => {
     const app = createServer();
 
-    app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+    app.get('/machines', (req, res) =>
+      res.json([{ type: 'bulldozer', name: 'willy' }]),
+    );
 
     server = app.listen((err) => {
       done(err);
     });
   });
 
-  after(done => server.close(done));
-
+  after((done) => server.close(done));
 
   describe('when -r/--reporter is provided to use additional reporters', () => {
     let cliInfo;
@@ -42,7 +43,6 @@ describe('CLI - Reporters', () => {
       assert.include(cliInfo.stdout, '/\\_/\\');
     });
   });
-
 
   describe('when apiary reporter is used', () => {
     let apiary;
@@ -70,7 +70,7 @@ describe('CLI - Reporters', () => {
       });
     });
 
-    after(done => apiary.close(done));
+    after((done) => apiary.close(done));
 
     describe('when Dredd successfully performs requests to Apiary', () => {
       let cliInfo;
@@ -85,14 +85,23 @@ describe('CLI - Reporters', () => {
         apiaryRuntimeInfo.reset();
         runCLI(args, { env }, (err, info) => {
           cliInfo = info;
-          stepRequest = apiaryRuntimeInfo.requests['/apis/public/tests/steps?testRunId=1234_id'][0];
+          stepRequest =
+            apiaryRuntimeInfo.requests[
+              '/apis/public/tests/steps?testRunId=1234_id'
+            ][0];
           done(err);
         });
       });
 
-      it('should print URL of the test report', () => assert.include(cliInfo.stdout, 'http://example.com/test/run/1234_id'));
-      it('should print warning about missing Apiary API settings', () => assert.include(cliInfo.stdout, 'Apiary API Key or API Project Subdomain were not provided.'));
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('should print URL of the test report', () =>
+        assert.include(cliInfo.stdout, 'http://example.com/test/run/1234_id'));
+      it('should print warning about missing Apiary API settings', () =>
+        assert.include(
+          cliInfo.stdout,
+          'Apiary API Key or API Project Subdomain were not provided.',
+        ));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
       it('should perform 3 requests to Apiary', () => {
         assert.deepEqual(apiaryRuntimeInfo.requestCounts, {
           '/apis/public/tests/runs': 1,
@@ -105,9 +114,18 @@ describe('CLI - Reporters', () => {
         assert.nestedProperty(stepRequest.body, 'results.request');
         assert.nestedProperty(stepRequest.body, 'results.realResponse');
         assert.nestedProperty(stepRequest.body, 'results.expectedResponse');
-        assert.nestedProperty(stepRequest.body, 'results.validationResult.fields.body');
-        assert.nestedProperty(stepRequest.body, 'results.validationResult.fields.headers');
-        assert.nestedProperty(stepRequest.body, 'results.validationResult.fields.statusCode');
+        assert.nestedProperty(
+          stepRequest.body,
+          'results.validationResult.fields.body',
+        );
+        assert.nestedProperty(
+          stepRequest.body,
+          'results.validationResult.fields.headers',
+        );
+        assert.nestedProperty(
+          stepRequest.body,
+          'results.validationResult.fields.statusCode',
+        );
       });
     });
 
@@ -127,8 +145,12 @@ describe('CLI - Reporters', () => {
         apiaryRuntimeInfo.reset();
         runCLI(args, { env }, (err, info) => {
           cliInfo = info;
-          updateRequest = apiaryRuntimeInfo.requests['/apis/public/tests/run/1234_id'][0];
-          stepRequest = apiaryRuntimeInfo.requests['/apis/public/tests/steps?testRunId=1234_id'][0];
+          updateRequest =
+            apiaryRuntimeInfo.requests['/apis/public/tests/run/1234_id'][0];
+          stepRequest =
+            apiaryRuntimeInfo.requests[
+              '/apis/public/tests/steps?testRunId=1234_id'
+            ][0];
           return done(err);
         });
       });
@@ -136,20 +158,45 @@ describe('CLI - Reporters', () => {
       it('hooks.log should print also to console', () => {
         assert.include(cliInfo.output, 'using hooks.log to debug');
       });
-      it('hooks.log should use toString on objects', () => assert.include(cliInfo.output, 'Error object!'));
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('hooks.log should use toString on objects', () =>
+        assert.include(cliInfo.output, 'Error object!'));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
 
       it('should request Apiary API to start a test run', () => {
-        assert.equal(apiaryRuntimeInfo.requestCounts['/apis/public/tests/runs'], 1);
-        assert.equal(apiaryRuntimeInfo.requests['/apis/public/tests/runs'][0].method, 'POST');
+        assert.equal(
+          apiaryRuntimeInfo.requestCounts['/apis/public/tests/runs'],
+          1,
+        );
+        assert.equal(
+          apiaryRuntimeInfo.requests['/apis/public/tests/runs'][0].method,
+          'POST',
+        );
       });
       it('should request Apiary API to create a test step', () => {
-        assert.equal(apiaryRuntimeInfo.requestCounts['/apis/public/tests/steps?testRunId=1234_id'], 1);
-        assert.equal(apiaryRuntimeInfo.requests['/apis/public/tests/steps?testRunId=1234_id'][0].method, 'POST');
+        assert.equal(
+          apiaryRuntimeInfo.requestCounts[
+            '/apis/public/tests/steps?testRunId=1234_id'
+          ],
+          1,
+        );
+        assert.equal(
+          apiaryRuntimeInfo.requests[
+            '/apis/public/tests/steps?testRunId=1234_id'
+          ][0].method,
+          'POST',
+        );
       });
       it('should request Apiary API to update the test run', () => {
-        assert.equal(apiaryRuntimeInfo.requestCounts['/apis/public/tests/run/1234_id'], 1);
-        assert.equal(apiaryRuntimeInfo.requests['/apis/public/tests/run/1234_id'][0].method, 'PATCH');
+        assert.equal(
+          apiaryRuntimeInfo.requestCounts['/apis/public/tests/run/1234_id'],
+          1,
+        );
+        assert.equal(
+          apiaryRuntimeInfo.requests['/apis/public/tests/run/1234_id'][0]
+            .method,
+          'PATCH',
+        );
       });
 
       context('the update request', () => {
@@ -163,9 +210,17 @@ describe('CLI - Reporters', () => {
           assert.property(updateRequest.body.logs[0], 'timestamp');
           assert.include(updateRequest.body.logs[0].content, 'Error object!');
           assert.property(updateRequest.body.logs[1], 'timestamp');
-          assert.nestedPropertyVal(updateRequest.body.logs[1], 'content', 'true');
+          assert.nestedPropertyVal(
+            updateRequest.body.logs[1],
+            'content',
+            'true',
+          );
           assert.property(updateRequest.body.logs[2], 'timestamp');
-          assert.nestedPropertyVal(updateRequest.body.logs[2], 'content', 'using hooks.log to debug');
+          assert.nestedPropertyVal(
+            updateRequest.body.logs[2],
+            'content',
+            'using hooks.log to debug',
+          );
           assert.nestedProperty(updateRequest.body, 'result.tests');
           assert.nestedProperty(updateRequest.body, 'result.failures');
           assert.nestedProperty(updateRequest.body, 'result.errors');
@@ -173,16 +228,28 @@ describe('CLI - Reporters', () => {
           assert.nestedProperty(updateRequest.body, 'result.start');
           assert.nestedProperty(updateRequest.body, 'result.end');
         });
-        it('should have startedAt larger than \'before\' hook log timestamp', () => {
+        it("should have startedAt larger than 'before' hook log timestamp", () => {
           assert.isObject(stepRequest.body);
           assert.isNumber(stepRequest.body.startedAt);
-          assert.operator(stepRequest.body.startedAt, '>=', updateRequest.body.logs[0].timestamp);
-          assert.operator(stepRequest.body.startedAt, '>=', updateRequest.body.logs[1].timestamp);
+          assert.operator(
+            stepRequest.body.startedAt,
+            '>=',
+            updateRequest.body.logs[0].timestamp,
+          );
+          assert.operator(
+            stepRequest.body.startedAt,
+            '>=',
+            updateRequest.body.logs[1].timestamp,
+          );
         });
-        it('should have startedAt smaller than \'after\' hook log timestamp', () => {
+        it("should have startedAt smaller than 'after' hook log timestamp", () => {
           assert.isObject(stepRequest.body);
           assert.isNumber(stepRequest.body.startedAt);
-          assert.operator(stepRequest.body.startedAt, '<=', updateRequest.body.logs[2].timestamp);
+          assert.operator(
+            stepRequest.body.startedAt,
+            '<=',
+            updateRequest.body.logs[2].timestamp,
+          );
         });
       });
     });
@@ -196,13 +263,16 @@ describe('CLI - Reporters', () => {
       '--output=__test_file_output__.xml',
     ];
 
-    before(done => runCLI(args, (err) => {
-      done(err);
-    }));
+    before((done) =>
+      runCLI(args, (err) => {
+        done(err);
+      }),
+    );
 
     after(() => fs.unlinkSync(`${process.cwd()}/__test_file_output__.xml`));
 
-    it('should create given file', () => assert.isOk(fs.existsSync(`${process.cwd()}/__test_file_output__.xml`)));
+    it('should create given file', () =>
+      assert.isOk(fs.existsSync(`${process.cwd()}/__test_file_output__.xml`)));
   });
 
   describe('when -o/--output is used multiple times to specify output files', () => {
@@ -215,9 +285,11 @@ describe('CLI - Reporters', () => {
       '--output=__test_file_output2__.xml',
     ];
 
-    before(done => runCLI(args, (err) => {
-      done(err);
-    }));
+    before((done) =>
+      runCLI(args, (err) => {
+        done(err);
+      }),
+    );
 
     after(() => {
       fs.unlinkSync(`${process.cwd()}/__test_file_output1__.xml`);
@@ -240,7 +312,9 @@ describe('CLI - Reporters', () => {
 
     before((done) => {
       try {
-        fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`);
+        fs.unlinkSync(
+          `${process.cwd()}/__test_directory/__test_file_output__.xml`,
+        );
       } catch (error) {
         // Do nothing
       }
@@ -251,14 +325,21 @@ describe('CLI - Reporters', () => {
     });
 
     after(() => {
-      fs.unlinkSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`);
+      fs.unlinkSync(
+        `${process.cwd()}/__test_directory/__test_file_output__.xml`,
+      );
       fs.rmdirSync(`${process.cwd()}/__test_directory`);
     });
 
-    it('should create given file', () => assert.isOk(fs.existsSync(`${process.cwd()}/__test_directory/__test_file_output__.xml`)));
+    it('should create given file', () =>
+      assert.isOk(
+        fs.existsSync(
+          `${process.cwd()}/__test_directory/__test_file_output__.xml`,
+        ),
+      ));
   });
 
-  describe('when the \'apiary\' reporter fails', () => {
+  describe("when the 'apiary' reporter fails", () => {
     let apiaryApiUrl;
     let cliInfo;
     const args = [
@@ -278,9 +359,15 @@ describe('CLI - Reporters', () => {
         done(err);
       });
     });
-    after(() => { process.env.APIARY_API_URL = apiaryApiUrl; });
+    after(() => {
+      process.env.APIARY_API_URL = apiaryApiUrl;
+    });
 
     it('ends successfully', () => assert.equal(cliInfo.exitStatus, 0));
-    it('prints error about Apiary API connection issues', () => assert.include(cliInfo.stderr, 'Apiary reporter could not connect to Apiary API'));
+    it('prints error about Apiary API connection issues', () =>
+      assert.include(
+        cliInfo.stderr,
+        'Apiary reporter could not connect to Apiary API',
+      ));
   });
 });

--- a/test/integration/cli/server-process-cli-test.js
+++ b/test/integration/cli/server-process-cli-test.js
@@ -1,6 +1,10 @@
 const { assert } = require('chai');
 const {
-  isProcessRunning, killAll, runCLI, createServer, DEFAULT_SERVER_PORT,
+  isProcessRunning,
+  killAll,
+  runCLI,
+  createServer,
+  DEFAULT_SERVER_PORT,
 } = require('../helpers');
 
 const NON_EXISTENT_PORT = DEFAULT_SERVER_PORT + 1;
@@ -13,9 +17,13 @@ describe('CLI - Server Process', () => {
     before((done) => {
       const app = createServer();
 
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
-      app.get('/machines/willy', (req, res) => res.json({ type: 'bulldozer', name: 'willy' }));
+      app.get('/machines/willy', (req, res) =>
+        res.json({ type: 'bulldozer', name: 'willy' }),
+      );
 
       server = app.listen((err, info) => {
         serverRuntimeInfo = info;
@@ -23,44 +31,58 @@ describe('CLI - Server Process', () => {
       });
     });
 
-    after(done => server.close(done));
-
+    after((done) => server.close(done));
 
     describe('when is running', () => {
       let cliInfo;
-      const args = ['./test/fixtures/single-get.apib', `http://127.0.0.1:${DEFAULT_SERVER_PORT}`];
+      const args = [
+        './test/fixtures/single-get.apib',
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}`,
+      ];
 
-      before(done => runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
-      }));
+      before((done) =>
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        }),
+      );
 
-      it('should request /machines', () => assert.deepEqual(serverRuntimeInfo.requestCounts, { '/machines': 1 }));
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('should request /machines', () =>
+        assert.deepEqual(serverRuntimeInfo.requestCounts, { '/machines': 1 }));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
     });
 
     describe('when is not running', () => {
       let cliInfo;
-      const args = ['./test/fixtures/apiary.apib', `http://127.0.0.1:${NON_EXISTENT_PORT}`];
+      const args = [
+        './test/fixtures/apiary.apib',
+        `http://127.0.0.1:${NON_EXISTENT_PORT}`,
+      ];
 
-      before(done => runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
-      }));
+      before((done) =>
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        }),
+      );
 
-      it('should return understandable message', () => assert.include(cliInfo.stdout, 'Error connecting'));
+      it('should return understandable message', () =>
+        assert.include(cliInfo.stdout, 'Error connecting'));
       it('should report error for all transactions', () => {
-        const occurences = (cliInfo.stdout.match(/Error connecting/g) || []).length;
+        const occurences = (cliInfo.stdout.match(/Error connecting/g) || [])
+          .length;
         assert.equal(occurences, 5);
       });
-      it('should return stats', () => assert.include(cliInfo.stdout, '5 errors'));
-      it('should exit with status 1', () => assert.equal(cliInfo.exitStatus, 1));
+      it('should return stats', () =>
+        assert.include(cliInfo.stdout, '5 errors'));
+      it('should exit with status 1', () =>
+        assert.equal(cliInfo.exitStatus, 1));
     });
   });
 
-
   describe('when specified by -g/--server', () => {
-    afterEach(done => killAll('test/fixtures/scripts/', done));
+    afterEach((done) => killAll('test/fixtures/scripts/', done));
 
     describe('when works as expected', () => {
       let cliInfo;
@@ -72,14 +94,25 @@ describe('CLI - Server Process', () => {
         '--loglevel=debug',
       ];
 
-      before(done => runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
-      }));
+      before((done) =>
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        }),
+      );
 
-      it('should inform about starting server with custom command', () => assert.include(cliInfo.stderr, 'Starting backend server process with command'));
-      it('should redirect server\'s welcome message', () => assert.include(cliInfo.stdout, `Dummy server listening on port ${DEFAULT_SERVER_PORT}`));
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('should inform about starting server with custom command', () =>
+        assert.include(
+          cliInfo.stderr,
+          'Starting backend server process with command',
+        ));
+      it("should redirect server's welcome message", () =>
+        assert.include(
+          cliInfo.stdout,
+          `Dummy server listening on port ${DEFAULT_SERVER_PORT}`,
+        ));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
     });
 
     describe('when it fails to start', () => {
@@ -92,40 +125,52 @@ describe('CLI - Server Process', () => {
         '--loglevel=debug',
       ];
 
-      before(done => runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
-      }));
+      before((done) =>
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        }),
+      );
 
-      it('should inform about starting server with custom command', () => assert.include(cliInfo.stderr, 'Starting backend server process with command'));
-      it('should report problem with server process spawn', () => assert.include(cliInfo.stderr, 'Command to start backend server process failed, exiting Dredd'));
-      it('should exit with status 1', () => assert.equal(cliInfo.exitStatus, 1));
+      it('should inform about starting server with custom command', () =>
+        assert.include(
+          cliInfo.stderr,
+          'Starting backend server process with command',
+        ));
+      it('should report problem with server process spawn', () =>
+        assert.include(
+          cliInfo.stderr,
+          'Command to start backend server process failed, exiting Dredd',
+        ));
+      it('should exit with status 1', () =>
+        assert.equal(cliInfo.exitStatus, 1));
     });
 
-    for (const scenario of [{
-      description: 'when crashes before requests',
-      apiDescriptionDocument: './test/fixtures/single-get.apib',
-      server: 'node test/fixtures/scripts/exit-3.js',
-      expectServerBoot: false,
-    },
-    {
-      description: 'when crashes during requests',
-      apiDescriptionDocument: './test/fixtures/apiary.apib',
-      server: `node test/fixtures/scripts/dummy-server-crash.js ${DEFAULT_SERVER_PORT}`,
-      expectServerBoot: true,
-    },
-    {
-      description: 'when killed before requests',
-      apiDescriptionDocument: './test/fixtures/single-get.apib',
-      server: 'node test/fixtures/scripts/kill-self.js',
-      expectServerBoot: false,
-    },
-    {
-      description: 'when killed during requests',
-      apiDescriptionDocument: './test/fixtures/apiary.apib',
-      server: `node test/fixtures/scripts/dummy-server-kill.js ${DEFAULT_SERVER_PORT}`,
-      expectServerBoot: true,
-    },
+    for (const scenario of [
+      {
+        description: 'when crashes before requests',
+        apiDescriptionDocument: './test/fixtures/single-get.apib',
+        server: 'node test/fixtures/scripts/exit-3.js',
+        expectServerBoot: false,
+      },
+      {
+        description: 'when crashes during requests',
+        apiDescriptionDocument: './test/fixtures/apiary.apib',
+        server: `node test/fixtures/scripts/dummy-server-crash.js ${DEFAULT_SERVER_PORT}`,
+        expectServerBoot: true,
+      },
+      {
+        description: 'when killed before requests',
+        apiDescriptionDocument: './test/fixtures/single-get.apib',
+        server: 'node test/fixtures/scripts/kill-self.js',
+        expectServerBoot: false,
+      },
+      {
+        description: 'when killed during requests',
+        apiDescriptionDocument: './test/fixtures/apiary.apib',
+        server: `node test/fixtures/scripts/dummy-server-kill.js ${DEFAULT_SERVER_PORT}`,
+        expectServerBoot: true,
+      },
     ]) {
       describe(scenario.description, () => {
         let cliInfo;
@@ -137,25 +182,40 @@ describe('CLI - Server Process', () => {
           '--loglevel=debug',
         ];
 
-        before(done => runCLI(args, (err, info) => {
-          cliInfo = info;
-          done(err);
-        }));
+        before((done) =>
+          runCLI(args, (err, info) => {
+            cliInfo = info;
+            done(err);
+          }),
+        );
 
-        it('should inform about starting server with custom command', () => assert.include(cliInfo.stderr, 'Starting backend server process with command'));
+        it('should inform about starting server with custom command', () =>
+          assert.include(
+            cliInfo.stderr,
+            'Starting backend server process with command',
+          ));
         if (scenario.expectServerBoot) {
-          it('should redirect server\'s boot message', () => assert.include(cliInfo.stdout, `Dummy server listening on port ${DEFAULT_SERVER_PORT}`));
+          it("should redirect server's boot message", () =>
+            assert.include(
+              cliInfo.stdout,
+              `Dummy server listening on port ${DEFAULT_SERVER_PORT}`,
+            ));
         }
-        it('the server should not be running', done => isProcessRunning('test/fixtures/scripts/', (err, isRunning) => {
-          if (!err) { assert.isFalse(isRunning); }
-          done(err);
-        }));
-        it('should report problems with connection to server', () => assert.include(cliInfo.stderr, 'Error connecting to server'));
-        it('should exit with status 1', () => assert.equal(cliInfo.exitStatus, 1));
+        it('the server should not be running', (done) =>
+          isProcessRunning('test/fixtures/scripts/', (err, isRunning) => {
+            if (!err) {
+              assert.isFalse(isRunning);
+            }
+            done(err);
+          }));
+        it('should report problems with connection to server', () =>
+          assert.include(cliInfo.stderr, 'Error connecting to server'));
+        it('should exit with status 1', () =>
+          assert.equal(cliInfo.exitStatus, 1));
       });
     }
 
-    describe('when didn\'t terminate and had to be killed by Dredd', () => {
+    describe("when didn't terminate and had to be killed by Dredd", () => {
       let cliInfo;
       const args = [
         './test/fixtures/single-get.apib',
@@ -165,20 +225,36 @@ describe('CLI - Server Process', () => {
         '--loglevel=debug',
       ];
 
-      before(done => runCLI(args, (err, info) => {
-        cliInfo = info;
-        done(err);
-      }));
+      before((done) =>
+        runCLI(args, (err, info) => {
+          cliInfo = info;
+          done(err);
+        }),
+      );
 
-      it('should inform about starting server with custom command', () => assert.include(cliInfo.stderr, 'Starting backend server process with command'));
-      it('should inform about gracefully terminating the server', () => assert.include(cliInfo.stderr, 'Gracefully terminating the backend server process'));
-      it('should redirect server\'s message about ignoring termination', () => assert.include(cliInfo.stdout, 'ignoring termination'));
-      it('should inform about forcefully killing the server', () => assert.include(cliInfo.stderr, 'Killing the backend server process'));
-      it('the server should not be running', done => isProcessRunning('test/fixtures/scripts/', (err, isRunning) => {
-        if (!err) { assert.isFalse(isRunning); }
-        done(err);
-      }));
-      it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0));
+      it('should inform about starting server with custom command', () =>
+        assert.include(
+          cliInfo.stderr,
+          'Starting backend server process with command',
+        ));
+      it('should inform about gracefully terminating the server', () =>
+        assert.include(
+          cliInfo.stderr,
+          'Gracefully terminating the backend server process',
+        ));
+      it("should redirect server's message about ignoring termination", () =>
+        assert.include(cliInfo.stdout, 'ignoring termination'));
+      it('should inform about forcefully killing the server', () =>
+        assert.include(cliInfo.stderr, 'Killing the backend server process'));
+      it('the server should not be running', (done) =>
+        isProcessRunning('test/fixtures/scripts/', (err, isRunning) => {
+          if (!err) {
+            assert.isFalse(isRunning);
+          }
+          done(err);
+        }));
+      it('should exit with status 0', () =>
+        assert.equal(cliInfo.exitStatus, 0));
     });
   });
 });

--- a/test/integration/configuration/resolveConfig-test.js
+++ b/test/integration/configuration/resolveConfig-test.js
@@ -1,6 +1,9 @@
 const { assert } = require('chai');
 const { EventEmitter } = require('events');
-const { DEFAULT_CONFIG, resolveConfig } = require('../../../lib/configuration/applyConfiguration');
+const {
+  DEFAULT_CONFIG,
+  resolveConfig,
+} = require('../../../lib/configuration/applyConfiguration');
 
 describe('resolveConfig()', () => {
   describe('when flattening config', () => {

--- a/test/integration/js-interface-test.js
+++ b/test/integration/js-interface-test.js
@@ -4,7 +4,6 @@ const { assert } = require('chai');
 const Dredd = require('../../lib/Dredd');
 const { createServer, runDredd, runDreddWithServer } = require('./helpers');
 
-
 const EXPECTED_STATS_KEYS = [
   'tests',
   'failures',
@@ -16,16 +15,19 @@ const EXPECTED_STATS_KEYS = [
   'duration',
 ];
 
-
 describe('Running Dredd from JavaScript', () => {
   describe('when the testing is successful', () => {
     let runtimeInfo;
 
     before((done) => {
       const app = createServer();
-      app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
-      const dredd = new Dredd({ options: { path: './test/fixtures/single-get.apib' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/single-get.apib' },
+      });
       runDreddWithServer(dredd, app, (err, info) => {
         runtimeInfo = info;
         done(err);
@@ -74,7 +76,9 @@ describe('Running Dredd from JavaScript', () => {
       const app = createServer();
       app.get('/machines', (req, res) => res.json([{ foo: 'bar' }]));
 
-      const dredd = new Dredd({ options: { path: './test/fixtures/single-get.apib' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/single-get.apib' },
+      });
       runDreddWithServer(dredd, app, (err, info) => {
         runtimeInfo = info;
         done(err);
@@ -120,7 +124,9 @@ describe('Running Dredd from JavaScript', () => {
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = new Dredd({ options: { path: './test/fixtures/single-get.apib' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/single-get.apib' },
+      });
       runDredd(dredd, (err, info) => {
         dreddRuntimeInfo = info;
         done(err);
@@ -207,7 +213,9 @@ describe('Running Dredd from JavaScript', () => {
     const error = new Error('Ouch!');
 
     before((done) => {
-      const dredd = new Dredd({ options: { path: './test/fixtures/single-get.apib' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/single-get.apib' },
+      });
       sinon.stub(dredd.transactionRunner, 'run').callsArgWithAsync(1, error);
 
       runDredd(dredd, (err, info) => {

--- a/test/integration/loading-api-descriptions-test.js
+++ b/test/integration/loading-api-descriptions-test.js
@@ -6,7 +6,6 @@ const { assert } = require('chai');
 const { DEFAULT_SERVER_PORT } = require('./helpers');
 const Dredd = require('../../lib/Dredd');
 
-
 const EXPECTED_API_DESCRIPTION_PROPS = [
   'location',
   'content',
@@ -16,7 +15,6 @@ const EXPECTED_API_DESCRIPTION_PROPS = [
   'annotations',
 ];
 
-
 function createDredd(configuration) {
   const dredd = new Dredd(configuration);
   dredd.transactionRunner = {
@@ -25,7 +23,6 @@ function createDredd(configuration) {
   };
   return dredd;
 }
-
 
 describe('Loading API descriptions', () => {
   describe('when the API description is specified by configuration', () => {
@@ -47,24 +44,45 @@ FORMAT: 1A
       assert.lengthOf(dredd.configuration.apiDescriptions, 1);
     });
     it('the API description has all expected data', () => {
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[0], EXPECTED_API_DESCRIPTION_PROPS);
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[0],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
     });
     it('the location is set to the configuration', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'location', 'configuration.apiDescriptions[0]');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'location',
+        'configuration.apiDescriptions[0]',
+      );
     });
     it('the content is set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'content', content);
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'content',
+        content,
+      );
     });
     it('the media type is set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'mediaType', 'text/vnd.apiblueprint');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
     });
     it('the transactions are set', () => {
       assert.lengthOf(dredd.configuration.apiDescriptions[0].transactions, 1);
-      assert.equal(dredd.configuration.apiDescriptions[0].transactions[0].name, 'Machines API > /machines > GET');
+      assert.equal(
+        dredd.configuration.apiDescriptions[0].transactions[0].name,
+        'Machines API > /machines > GET',
+      );
     });
     it('the transaction runner is called with the transactions', () => {
       assert.lengthOf(dredd.transactionRunner.run.firstCall.args[0], 1);
-      assert.equal(dredd.transactionRunner.run.firstCall.args[0][0].name, 'Machines API > /machines > GET');
+      assert.equal(
+        dredd.transactionRunner.run.firstCall.args[0][0].name,
+        'Machines API > /machines > GET',
+      );
     });
   });
 
@@ -72,7 +90,9 @@ FORMAT: 1A
     let dredd;
 
     before((done) => {
-      dredd = createDredd({ options: { path: './test/fixtures/single-get.apib' } });
+      dredd = createDredd({
+        options: { path: './test/fixtures/single-get.apib' },
+      });
       dredd.run(done);
     });
 
@@ -80,25 +100,46 @@ FORMAT: 1A
       assert.lengthOf(dredd.configuration.apiDescriptions, 1);
     });
     it('the API description has all expected data', () => {
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[0], EXPECTED_API_DESCRIPTION_PROPS);
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[0],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
     });
     it('the location is set to the path', () => {
-      assert.match(dredd.configuration.apiDescriptions[0].location, /single-get\.apib$/);
-      assert.isTrue(path.isAbsolute(dredd.configuration.apiDescriptions[0].location));
+      assert.match(
+        dredd.configuration.apiDescriptions[0].location,
+        /single-get\.apib$/,
+      );
+      assert.isTrue(
+        path.isAbsolute(dredd.configuration.apiDescriptions[0].location),
+      );
     });
     it('the content is set', () => {
-      assert.include(dredd.configuration.apiDescriptions[0].content, '# Machines collection [/machines]');
+      assert.include(
+        dredd.configuration.apiDescriptions[0].content,
+        '# Machines collection [/machines]',
+      );
     });
     it('the media type is set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'mediaType', 'text/vnd.apiblueprint');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
     });
     it('the transactions are set', () => {
       assert.lengthOf(dredd.configuration.apiDescriptions[0].transactions, 1);
-      assert.equal(dredd.configuration.apiDescriptions[0].transactions[0].name, 'Machines API > Machines > Machines collection > Get Machines');
+      assert.equal(
+        dredd.configuration.apiDescriptions[0].transactions[0].name,
+        'Machines API > Machines > Machines collection > Get Machines',
+      );
     });
     it('the transaction runner is called with the transactions', () => {
       assert.lengthOf(dredd.transactionRunner.run.firstCall.args[0], 1);
-      assert.equal(dredd.transactionRunner.run.firstCall.args[0][0].name, 'Machines API > Machines > Machines collection > Get Machines');
+      assert.equal(
+        dredd.transactionRunner.run.firstCall.args[0][0].name,
+        'Machines API > Machines > Machines collection > Get Machines',
+      );
     });
   });
 
@@ -108,14 +149,20 @@ FORMAT: 1A
 
     before((done) => {
       dredd = createDredd({ options: { path: '__non-existing__.apib' } });
-      dredd.run((err) => { error = err; done(); });
+      dredd.run((err) => {
+        error = err;
+        done();
+      });
     });
 
     it('results in an error', () => {
       assert.instanceOf(error, Error);
     });
     it('the error is descriptive', () => {
-      assert.equal(error.message, "Could not find any files on path: '__non-existing__.apib'");
+      assert.equal(
+        error.message,
+        "Could not find any files on path: '__non-existing__.apib'",
+      );
     });
     it('aborts Dredd', () => {
       assert.isFalse(dredd.transactionRunner.run.called);
@@ -126,7 +173,9 @@ FORMAT: 1A
     let dredd;
 
     before((done) => {
-      dredd = createDredd({ options: { path: './test/fixtures/multifile/*.apib' } });
+      dredd = createDredd({
+        options: { path: './test/fixtures/multifile/*.apib' },
+      });
       dredd.run(done);
     });
 
@@ -134,35 +183,89 @@ FORMAT: 1A
       assert.lengthOf(dredd.configuration.apiDescriptions, 3);
     });
     it('the API descriptions have all expected data', () => {
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[0], EXPECTED_API_DESCRIPTION_PROPS);
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[1], EXPECTED_API_DESCRIPTION_PROPS);
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[2], EXPECTED_API_DESCRIPTION_PROPS);
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[0],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[1],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[2],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
     });
     it('the locations are set to the absolute paths', () => {
-      assert.match(dredd.configuration.apiDescriptions[0].location, /greeting\.apib$/);
-      assert.match(dredd.configuration.apiDescriptions[1].location, /message\.apib$/);
-      assert.match(dredd.configuration.apiDescriptions[2].location, /name\.apib$/);
-      assert.isTrue(path.isAbsolute(dredd.configuration.apiDescriptions[0].location));
-      assert.isTrue(path.isAbsolute(dredd.configuration.apiDescriptions[1].location));
-      assert.isTrue(path.isAbsolute(dredd.configuration.apiDescriptions[2].location));
+      assert.match(
+        dredd.configuration.apiDescriptions[0].location,
+        /greeting\.apib$/,
+      );
+      assert.match(
+        dredd.configuration.apiDescriptions[1].location,
+        /message\.apib$/,
+      );
+      assert.match(
+        dredd.configuration.apiDescriptions[2].location,
+        /name\.apib$/,
+      );
+      assert.isTrue(
+        path.isAbsolute(dredd.configuration.apiDescriptions[0].location),
+      );
+      assert.isTrue(
+        path.isAbsolute(dredd.configuration.apiDescriptions[1].location),
+      );
+      assert.isTrue(
+        path.isAbsolute(dredd.configuration.apiDescriptions[2].location),
+      );
     });
     it('the contents are set', () => {
-      assert.include(dredd.configuration.apiDescriptions[0].content, '# Greeting API');
-      assert.include(dredd.configuration.apiDescriptions[1].content, '# Message API');
-      assert.include(dredd.configuration.apiDescriptions[2].content, '# Name API');
+      assert.include(
+        dredd.configuration.apiDescriptions[0].content,
+        '# Greeting API',
+      );
+      assert.include(
+        dredd.configuration.apiDescriptions[1].content,
+        '# Message API',
+      );
+      assert.include(
+        dredd.configuration.apiDescriptions[2].content,
+        '# Name API',
+      );
     });
     it('the media types are set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'mediaType', 'text/vnd.apiblueprint');
-      assert.propertyVal(dredd.configuration.apiDescriptions[1], 'mediaType', 'text/vnd.apiblueprint');
-      assert.propertyVal(dredd.configuration.apiDescriptions[2], 'mediaType', 'text/vnd.apiblueprint');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[1],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[2],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
     });
     it('the transactions are set', () => {
       assert.lengthOf(dredd.configuration.apiDescriptions[0].transactions, 1);
       assert.lengthOf(dredd.configuration.apiDescriptions[1].transactions, 1);
       assert.lengthOf(dredd.configuration.apiDescriptions[2].transactions, 1);
-      assert.equal(dredd.configuration.apiDescriptions[0].transactions[0].name, 'Greeting API > /greeting > GET');
-      assert.equal(dredd.configuration.apiDescriptions[1].transactions[0].name, 'Message API > /message > GET');
-      assert.equal(dredd.configuration.apiDescriptions[2].transactions[0].name, 'Name API > /name > GET');
+      assert.equal(
+        dredd.configuration.apiDescriptions[0].transactions[0].name,
+        'Greeting API > /greeting > GET',
+      );
+      assert.equal(
+        dredd.configuration.apiDescriptions[1].transactions[0].name,
+        'Message API > /message > GET',
+      );
+      assert.equal(
+        dredd.configuration.apiDescriptions[2].transactions[0].name,
+        'Name API > /name > GET',
+      );
     });
     it('the transaction runner is called with the transactions', () => {
       const transactions = dredd.transactionRunner.run.firstCall.args[0];
@@ -178,15 +281,23 @@ FORMAT: 1A
     let dredd;
 
     before((done) => {
-      dredd = createDredd({ options: { path: '__non-existing-*-glob__.apib' } });
-      dredd.run((err) => { error = err; done(); });
+      dredd = createDredd({
+        options: { path: '__non-existing-*-glob__.apib' },
+      });
+      dredd.run((err) => {
+        error = err;
+        done();
+      });
     });
 
     it('results in an error', () => {
       assert.instanceOf(error, Error);
     });
     it('the error is descriptive', () => {
-      assert.equal(error.message, "Could not find any files on path: '__non-existing-*-glob__.apib'");
+      assert.equal(
+        error.message,
+        "Could not find any files on path: '__non-existing-*-glob__.apib'",
+      );
     });
     it('aborts Dredd', () => {
       assert.isFalse(dredd.transactionRunner.run.called);
@@ -210,10 +321,19 @@ FORMAT: 1A
       });
 
       const server = app.listen(DEFAULT_SERVER_PORT, (listenErr) => {
-        if (listenErr) { done(listenErr); return; }
-        dredd = createDredd({ options: { path: `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib` } });
+        if (listenErr) {
+          done(listenErr);
+          return;
+        }
+        dredd = createDredd({
+          options: {
+            path: `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib`,
+          },
+        });
         dredd.run((dreddErr) => {
-          server.close(() => { done(dreddErr); });
+          server.close(() => {
+            done(dreddErr);
+          });
         });
       });
     });
@@ -222,24 +342,40 @@ FORMAT: 1A
       assert.lengthOf(dredd.configuration.apiDescriptions, 1);
     });
     it('the API description has all expected data', () => {
-      assert.hasAllKeys(dredd.configuration.apiDescriptions[0], EXPECTED_API_DESCRIPTION_PROPS);
+      assert.hasAllKeys(
+        dredd.configuration.apiDescriptions[0],
+        EXPECTED_API_DESCRIPTION_PROPS,
+      );
     });
     it('the location is set to the URL', () => {
-      assert.equal(dredd.configuration.apiDescriptions[0].location, `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib`);
+      assert.equal(
+        dredd.configuration.apiDescriptions[0].location,
+        `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib`,
+      );
     });
     it('the content is set', () => {
       assert.equal(dredd.configuration.apiDescriptions[0].content, content);
     });
     it('the media type is set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'mediaType', 'text/vnd.apiblueprint');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
     });
     it('the transactions are set', () => {
       assert.lengthOf(dredd.configuration.apiDescriptions[0].transactions, 1);
-      assert.equal(dredd.configuration.apiDescriptions[0].transactions[0].name, 'Machines API > /machines > GET');
+      assert.equal(
+        dredd.configuration.apiDescriptions[0].transactions[0].name,
+        'Machines API > /machines > GET',
+      );
     });
     it('the transaction runner is called with the transactions', () => {
       assert.lengthOf(dredd.transactionRunner.run.firstCall.args[0], 1);
-      assert.equal(dredd.transactionRunner.run.firstCall.args[0][0].name, 'Machines API > /machines > GET');
+      assert.equal(
+        dredd.transactionRunner.run.firstCall.args[0][0].name,
+        'Machines API > /machines > GET',
+      );
     });
   });
 
@@ -248,15 +384,23 @@ FORMAT: 1A
     let dredd;
 
     before((done) => {
-      dredd = createDredd({ options: { path: 'http://example.example:1234/file.apib' } });
-      dredd.run((err) => { error = err; done(); });
+      dredd = createDredd({
+        options: { path: 'http://example.example:1234/file.apib' },
+      });
+      dredd.run((err) => {
+        error = err;
+        done();
+      });
     });
 
     it('results in an error', () => {
       assert.instanceOf(error, Error);
     });
     it('the error is descriptive', () => {
-      assert.include(error.message, "Unable to load API description document from 'http://example.example:1234/file.apib': ");
+      assert.include(
+        error.message,
+        "Unable to load API description document from 'http://example.example:1234/file.apib': ",
+      );
       assert.include(error.message, 'ENOTFOUND');
     });
     it('aborts Dredd', () => {
@@ -271,8 +415,15 @@ FORMAT: 1A
     before((done) => {
       const app = express();
       const server = app.listen(DEFAULT_SERVER_PORT, (listenErr) => {
-        if (listenErr) { done(listenErr); return; }
-        dredd = createDredd({ options: { path: `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib` } });
+        if (listenErr) {
+          done(listenErr);
+          return;
+        }
+        dredd = createDredd({
+          options: {
+            path: `http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib`,
+          },
+        });
         dredd.run((dreddErr) => {
           error = dreddErr;
           server.close(done);
@@ -284,7 +435,10 @@ FORMAT: 1A
       assert.instanceOf(error, Error);
     });
     it('the error is descriptive', () => {
-      assert.include(error.message, `Unable to load API description document from 'http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib': `);
+      assert.include(
+        error.message,
+        `Unable to load API description document from 'http://127.0.0.1:${DEFAULT_SERVER_PORT}/file.apib': `,
+      );
       assert.include(error.message, 'Dredd got HTTP 404 response');
     });
     it('aborts Dredd', () => {
@@ -323,7 +477,11 @@ FORMAT: 1A
       assert.lengthOf(dredd.configuration.apiDescriptions, 3);
     });
     it('the media type is set', () => {
-      assert.propertyVal(dredd.configuration.apiDescriptions[0], 'mediaType', 'text/vnd.apiblueprint');
+      assert.propertyVal(
+        dredd.configuration.apiDescriptions[0],
+        'mediaType',
+        'text/vnd.apiblueprint',
+      );
     });
     it('the transactions are set', () => {
       assert.lengthOf(dredd.configuration.apiDescriptions[0].transactions, 1);

--- a/test/integration/openapi2-test.js
+++ b/test/integration/openapi2-test.js
@@ -29,11 +29,9 @@ function execCommand(options = {}, cb) {
   });
 }
 
-
 function record(transport, level, message) {
   output += `\n${level}: ${message}`;
 }
-
 
 // These tests were separated out from a larger file. They deserve a rewrite,
 // see https://github.com/apiaryio/dredd/issues/1288
@@ -58,26 +56,38 @@ describe('OpenAPI 2', () => {
     const reTransaction = /(skip|fail): (\w+) \((\d+)\) \/honey/g;
     let actual;
 
-    before(done => execCommand({
-      options: {
-        path: './test/fixtures/multiple-responses.yaml',
-      },
-    },
-    (err) => {
-      let groups;
-      const matches = [];
-      // eslint-disable-next-line
-      while (groups = reTransaction.exec(output)) { matches.push(groups); }
+    before((done) =>
+      execCommand(
+        {
+          options: {
+            path: './test/fixtures/multiple-responses.yaml',
+          },
+        },
+        (err) => {
+          let groups;
+          const matches = [];
+          // eslint-disable-next-line
+          while ((groups = reTransaction.exec(output))) {
+            matches.push(groups);
+          }
 
-      actual = matches.map((match) => {
-        const keyMap = {
-          0: 'name', 1: 'action', 2: 'method', 3: 'statusCode',
-        };
-        return match.reduce((result, element, i) => Object.assign(result, { [keyMap[i]]: element }),
-          {});
-      });
-      done(err);
-    }));
+          actual = matches.map((match) => {
+            const keyMap = {
+              0: 'name',
+              1: 'action',
+              2: 'method',
+              3: 'statusCode',
+            };
+            return match.reduce(
+              (result, element, i) =>
+                Object.assign(result, { [keyMap[i]]: element }),
+              {},
+            );
+          });
+          done(err);
+        },
+      ),
+    );
 
     it('recognizes all 3 transactions', () => assert.equal(actual.length, 3));
 
@@ -85,37 +95,55 @@ describe('OpenAPI 2', () => {
       { action: 'skip', statusCode: '400' },
       { action: 'skip', statusCode: '500' },
       { action: 'fail', statusCode: '200' },
-    ].forEach((expected, i) => context(`the transaction #${i + 1}`, () => {
-      it(`has status code ${expected.statusCode}`, () => assert.equal(expected.statusCode, actual[i].statusCode));
-      it(`is ${expected.action === 'skip' ? '' : 'not '}skipped by default`, () => assert.equal(expected.action, actual[i].action));
-    }));
+    ].forEach((expected, i) =>
+      context(`the transaction #${i + 1}`, () => {
+        it(`has status code ${expected.statusCode}`, () =>
+          assert.equal(expected.statusCode, actual[i].statusCode));
+        it(`is ${
+          expected.action === 'skip' ? '' : 'not '
+        }skipped by default`, () =>
+          assert.equal(expected.action, actual[i].action));
+      }),
+    );
   });
 
   describe('when OpenAPI 2 document has multiple responses and hooks unskip some of them', () => {
     const reTransaction = /(skip|fail): (\w+) \((\d+)\) \/honey/g;
     let actual;
 
-    before(done => execCommand({
-      options: {
-        path: './test/fixtures/multiple-responses.yaml',
-        hookfiles: './test/fixtures/openapi2-multiple-responses.js',
-      },
-    },
-    (err) => {
-      let groups;
-      const matches = [];
-      // eslint-disable-next-line
-      while (groups = reTransaction.exec(output)) { matches.push(groups); }
-      actual = matches.map((match) => {
-        const keyMap = {
-          0: 'name', 1: 'action', 2: 'method', 3: 'statusCode',
-        };
-        return match.reduce((result, element, i) => Object.assign(result, { [keyMap[i]]: element }),
-          {});
-      });
+    before((done) =>
+      execCommand(
+        {
+          options: {
+            path: './test/fixtures/multiple-responses.yaml',
+            hookfiles: './test/fixtures/openapi2-multiple-responses.js',
+          },
+        },
+        (err) => {
+          let groups;
+          const matches = [];
+          // eslint-disable-next-line
+          while ((groups = reTransaction.exec(output))) {
+            matches.push(groups);
+          }
+          actual = matches.map((match) => {
+            const keyMap = {
+              0: 'name',
+              1: 'action',
+              2: 'method',
+              3: 'statusCode',
+            };
+            return match.reduce(
+              (result, element, i) =>
+                Object.assign(result, { [keyMap[i]]: element }),
+              {},
+            );
+          });
 
-      done(err);
-    }));
+          done(err);
+        },
+      ),
+    );
 
     it('recognizes all 3 transactions', () => assert.equal(actual.length, 3));
 
@@ -123,37 +151,51 @@ describe('OpenAPI 2', () => {
       { action: 'skip', statusCode: '400' },
       { action: 'fail', statusCode: '200' },
       { action: 'fail', statusCode: '500' }, // Unskipped in hooks
-    ].forEach((expected, i) => context(`the transaction #${i + 1}`, () => {
-      it(`has status code ${expected.statusCode}`, () => assert.equal(expected.statusCode, actual[i].statusCode));
+    ].forEach((expected, i) =>
+      context(`the transaction #${i + 1}`, () => {
+        it(`has status code ${expected.statusCode}`, () =>
+          assert.equal(expected.statusCode, actual[i].statusCode));
 
-      const defaultMessage = `is ${expected.action === 'skip' ? '' : 'not '}skipped by default`;
-      const unskippedMessage = 'is unskipped in hooks';
-      it(`${expected.statusCode === '500' ? unskippedMessage : defaultMessage}`, () => assert.equal(expected.action, actual[i].action));
-    }));
+        const defaultMessage = `is ${
+          expected.action === 'skip' ? '' : 'not '
+        }skipped by default`;
+        const unskippedMessage = 'is unskipped in hooks';
+        it(`${
+          expected.statusCode === '500' ? unskippedMessage : defaultMessage
+        }`, () => assert.equal(expected.action, actual[i].action));
+      }),
+    );
   });
 
   describe('when using OpenAPI 2 document with hooks', () => {
     const reTransactionName = /hook: (.+)/g;
     let matches;
 
-    before(done => execCommand({
-      options: {
-        path: './test/fixtures/multiple-responses.yaml',
-        hookfiles: './test/fixtures/openapi2-transaction-names.js',
-      },
-    },
-    (err) => {
-      let groups;
-      matches = [];
-      // eslint-disable-next-line
-      while (groups = reTransactionName.exec(output)) { matches.push(groups[1]); }
-      done(err);
-    }));
+    before((done) =>
+      execCommand(
+        {
+          options: {
+            path: './test/fixtures/multiple-responses.yaml',
+            hookfiles: './test/fixtures/openapi2-transaction-names.js',
+          },
+        },
+        (err) => {
+          let groups;
+          matches = [];
+          // eslint-disable-next-line
+          while ((groups = reTransactionName.exec(output))) {
+            matches.push(groups[1]);
+          }
+          done(err);
+        },
+      ),
+    );
 
-    it('transaction names contain status code and content type', () => assert.deepEqual(matches, [
-      '/honey > GET > 200 > application/json',
-      '/honey > GET > 400 > application/json',
-      '/honey > GET > 500 > application/json',
-    ]));
+    it('transaction names contain status code and content type', () =>
+      assert.deepEqual(matches, [
+        '/honey > GET > 200 > application/json',
+        '/honey > GET > 400 > application/json',
+        '/honey > GET > 500 > application/json',
+      ]));
   });
 });

--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -3,7 +3,10 @@ const url = require('url');
 const { assert } = require('chai');
 
 const {
-  runDredd, recordLogging, createServer, DEFAULT_SERVER_PORT,
+  runDredd,
+  recordLogging,
+  createServer,
+  DEFAULT_SERVER_PORT,
 } = require('./helpers');
 const Dredd = require('../../lib/Dredd');
 
@@ -13,30 +16,35 @@ const SERVER_HOST = `127.0.0.1:${DEFAULT_SERVER_PORT}`;
 const DUMMY_URL = 'http://example.com';
 const REGULAR_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
 
-
 function unsetAllProxyEnvVars(env) {
   Object.keys(env)
-    .filter(envName => envName.toLowerCase().includes('proxy'))
-    .forEach(envName => delete env[envName]);
+    .filter((envName) => envName.toLowerCase().includes('proxy'))
+    .forEach((envName) => delete env[envName]);
 }
 
 // Normally, tests create Dredd instance and pass it to the 'runDredd'
 // helper, which captures Dredd's logging while it runs. However, in
 // this case we need to capture logging also during the instantiation.
 function createAndRunDredd(configuration, done) {
-  if (!configuration.options) { configuration.options = {}; }
+  if (!configuration.options) {
+    configuration.options = {};
+  }
   configuration.options.color = false;
   configuration.options.loglevel = 'debug';
 
   let dredd;
-  recordLogging((next) => {
-    dredd = new Dredd(configuration);
-    dredd.configuration.http.strictSSL = false;
-    next();
-  }, (err, args, dreddInitLogging) => runDredd(dredd, (error, info) => {
-    info.logging = `${dreddInitLogging}\n${info.logging}`;
-    done(error, info);
-  }));
+  recordLogging(
+    (next) => {
+      dredd = new Dredd(configuration);
+      dredd.configuration.http.strictSSL = false;
+      next();
+    },
+    (err, args, dreddInitLogging) =>
+      runDredd(dredd, (error, info) => {
+        info.logging = `${dreddInitLogging}\n${info.logging}`;
+        done(error, info);
+      }),
+  );
 }
 
 // Creates dummy proxy server for given protocol. Records details
@@ -125,43 +133,58 @@ function test(scenario) {
     scenario.configureDredd(configuration);
 
     createAndRunDredd(configuration, (err, info) => {
-      if (err) { return done(err); }
+      if (err) {
+        return done(err);
+      }
       dreddLogging = info.logging;
       done();
     });
   });
 
   // Assertions...
-  it('logs the proxy settings', () => assert.include(dreddLogging, scenario.expectedLog));
-  it('recommends user to read the documentation about using HTTP(S) proxies', () => assert.include(dreddLogging, '#using-https-proxy'));
+  it('logs the proxy settings', () =>
+    assert.include(dreddLogging, scenario.expectedLog));
+  it('recommends user to read the documentation about using HTTP(S) proxies', () =>
+    assert.include(dreddLogging, '#using-https-proxy'));
 
   if (scenario.expectedDestination === 'proxy') {
-    it('does not request the server', () => assert.isFalse(serverRuntimeInfo.requested));
-    it('does request the proxy', () => assert.notDeepEqual(proxyRequestInfo, {}));
+    it('does not request the server', () =>
+      assert.isFalse(serverRuntimeInfo.requested));
+    it('does request the proxy', () =>
+      assert.notDeepEqual(proxyRequestInfo, {}));
 
     if (scenario.protocol === 'http') {
-      it('requests the proxy with regular HTTP method', () => assert.oneOf(proxyRequestInfo.method, REGULAR_HTTP_METHODS));
-      it('requests the proxy, using the original URL as a path', () => assert.equal(proxyRequestInfo.url, scenario.expectedUrl));
+      it('requests the proxy with regular HTTP method', () =>
+        assert.oneOf(proxyRequestInfo.method, REGULAR_HTTP_METHODS));
+      it('requests the proxy, using the original URL as a path', () =>
+        assert.equal(proxyRequestInfo.url, scenario.expectedUrl));
       return;
-    } if (scenario.protocol === 'https') {
-      it('requests the proxy with CONNECT', () => assert.equal(proxyRequestInfo.method, 'CONNECT'));
+    }
+    if (scenario.protocol === 'https') {
+      it('requests the proxy with CONNECT', () =>
+        assert.equal(proxyRequestInfo.method, 'CONNECT'));
       it('asks the proxy to tunnel SSL connection to the original hostname', () => {
-        const hostname = `${url.parse(scenario.expectedUrl).hostname}:${DEFAULT_SERVER_PORT}`;
+        const hostname = `${
+          url.parse(scenario.expectedUrl).hostname
+        }:${DEFAULT_SERVER_PORT}`;
         assert.equal(proxyRequestInfo.url, hostname);
       });
       return;
     }
     throw new Error(`Unsupported protocol: ${scenario.protocol}`);
   } else if (scenario.expectedDestination === 'server') {
-    it('does not request the proxy', () => assert.deepEqual(proxyRequestInfo, {}));
-    it('does request the server', () => assert.isTrue(serverRuntimeInfo.requestedOnce));
-    it('requests the server with regular HTTP method', () => assert.oneOf(serverRuntimeInfo.lastRequest.method, REGULAR_HTTP_METHODS));
-    it('requests the server with the original path', () => assert.equal(serverRuntimeInfo.lastRequest.url, scenario.expectedUrl));
+    it('does not request the proxy', () =>
+      assert.deepEqual(proxyRequestInfo, {}));
+    it('does request the server', () =>
+      assert.isTrue(serverRuntimeInfo.requestedOnce));
+    it('requests the server with regular HTTP method', () =>
+      assert.oneOf(serverRuntimeInfo.lastRequest.method, REGULAR_HTTP_METHODS));
+    it('requests the server with the original path', () =>
+      assert.equal(serverRuntimeInfo.lastRequest.url, scenario.expectedUrl));
   } else {
     throw new Error(`Unsupported destination: ${scenario.expectedDestination}`);
   }
 }
-
 
 ['http', 'https'].forEach((protocol) => {
   const serverUrl = `${protocol}://${SERVER_HOST}`;
@@ -178,20 +201,23 @@ ${protocol}_proxy=${PROXY_URL}\
     });
     after(() => unsetAllProxyEnvVars(process.env));
 
-    describe('Requesting Server Under Test', () => test({
-      protocol,
-      configureDredd(configuration) {
-        configuration.loglevel = 'debug';
-        configuration.server = serverUrl;
-        configuration.options.path = './test/fixtures/single-get.apib';
-      },
-      expectedLog,
-      expectedDestination: 'server',
-      expectedUrl: '/machines',
-    }));
+    describe('Requesting Server Under Test', () =>
+      test({
+        protocol,
+        configureDredd(configuration) {
+          configuration.loglevel = 'debug';
+          configuration.server = serverUrl;
+          configuration.options.path = './test/fixtures/single-get.apib';
+        },
+        expectedLog,
+        expectedDestination: 'server',
+        expectedUrl: '/machines',
+      }));
 
     describe('Using Apiary Reporter', () => {
-      before(() => { process.env.APIARY_API_URL = serverUrl; });
+      before(() => {
+        process.env.APIARY_API_URL = serverUrl;
+      });
       after(() => delete process.env.APIARY_API_URL);
 
       test({
@@ -207,19 +233,19 @@ ${protocol}_proxy=${PROXY_URL}\
       });
     });
 
-    describe('Downloading API Description Document', () => test({
-      protocol,
-      configureDredd(configuration) {
-        configuration.server = DUMMY_URL;
-        configuration.options.path = `${serverUrl}/example.apib`;
-      },
-      expectedLog,
-      expectedDestination: 'proxy',
-      expectedUrl: `${serverUrl}/example.apib`,
-    }));
+    describe('Downloading API Description Document', () =>
+      test({
+        protocol,
+        configureDredd(configuration) {
+          configuration.server = DUMMY_URL;
+          configuration.options.path = `${serverUrl}/example.apib`;
+        },
+        expectedLog,
+        expectedDestination: 'proxy',
+        expectedUrl: `${serverUrl}/example.apib`,
+      }));
   });
 });
-
 
 describe('Respecting ‘no_proxy’ Environment Variable', () => {
   const serverUrl = `http://${SERVER_HOST}`;
@@ -235,20 +261,23 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
   });
   after(() => unsetAllProxyEnvVars(process.env));
 
-  describe('Requesting Server Under Test', () => test({
-    protocol: 'http',
-    configureDredd(configuration) {
-      configuration.loglevel = 'debug';
-      configuration.server = serverUrl;
-      configuration.options.path = './test/fixtures/single-get.apib';
-    },
-    expectedLog,
-    expectedDestination: 'server',
-    expectedUrl: '/machines',
-  }));
+  describe('Requesting Server Under Test', () =>
+    test({
+      protocol: 'http',
+      configureDredd(configuration) {
+        configuration.loglevel = 'debug';
+        configuration.server = serverUrl;
+        configuration.options.path = './test/fixtures/single-get.apib';
+      },
+      expectedLog,
+      expectedDestination: 'server',
+      expectedUrl: '/machines',
+    }));
 
   describe('Using Apiary Reporter', () => {
-    before(() => { process.env.APIARY_API_URL = serverUrl; });
+    before(() => {
+      process.env.APIARY_API_URL = serverUrl;
+    });
     after(() => delete process.env.APIARY_API_URL);
 
     test({
@@ -264,14 +293,15 @@ http_proxy=${PROXY_URL}, no_proxy=${SERVER_HOST}\
     });
   });
 
-  describe('Downloading API Description Document', () => test({
-    protocol: 'http',
-    configureDredd(configuration) {
-      configuration.server = DUMMY_URL;
-      configuration.options.path = `${serverUrl}/example.apib`;
-    },
-    expectedLog,
-    expectedDestination: 'server',
-    expectedUrl: '/example.apib',
-  }));
+  describe('Downloading API Description Document', () =>
+    test({
+      protocol: 'http',
+      configureDredd(configuration) {
+        configuration.server = DUMMY_URL;
+        configuration.options.path = `${serverUrl}/example.apib`;
+      },
+      expectedLog,
+      expectedDestination: 'server',
+      expectedUrl: '/example.apib',
+    }));
 });

--- a/test/integration/regressions/regression-152-test.js
+++ b/test/integration/regressions/regression-152-test.js
@@ -3,28 +3,34 @@ const { assert } = require('chai');
 const Dredd = require('../../../lib/Dredd');
 const { runDreddWithServer, createServer } = require('../helpers');
 
-describe('Regression: Issue #152', () => describe('Modify transaction object inside beforeAll combined with beforeEach helper', () => {
-  let runtimeInfo;
+describe('Regression: Issue #152', () =>
+  describe('Modify transaction object inside beforeAll combined with beforeEach helper', () => {
+    let runtimeInfo;
 
-  before((done) => {
-    const app = createServer();
-    app.get('/machines', (req, res) => res.json([{ type: 'bulldozer', name: 'willy' }]));
+    before((done) => {
+      const app = createServer();
+      app.get('/machines', (req, res) =>
+        res.json([{ type: 'bulldozer', name: 'willy' }]),
+      );
 
-    const dredd = new Dredd({
-      options: {
-        path: './test/fixtures/single-get.apib',
-        require: 'coffeescript/register',
-        hookfiles: './test/fixtures/regression-152.coffee',
-      },
-    });
+      const dredd = new Dredd({
+        options: {
+          path: './test/fixtures/single-get.apib',
+          require: 'coffeescript/register',
+          hookfiles: './test/fixtures/regression-152.coffee',
+        },
+      });
 
-    runDreddWithServer(dredd, app, (...args) => {
-      let err;
-      // eslint-disable-next-line
+      runDreddWithServer(dredd, app, (...args) => {
+        let err;
+        // eslint-disable-next-line
         [err, runtimeInfo] = Array.from(args);
-      done(err);
+        done(err);
+      });
     });
-  });
 
-  it('should modify the transaction with hooks', () => assert.deepEqual(Object.keys(runtimeInfo.server.requests), ['/machines?api-key=23456']));
-}));
+    it('should modify the transaction with hooks', () =>
+      assert.deepEqual(Object.keys(runtimeInfo.server.requests), [
+        '/machines?api-key=23456',
+      ]));
+  }));

--- a/test/integration/regressions/regression-319-354-test.js
+++ b/test/integration/regressions/regression-319-354-test.js
@@ -1,20 +1,24 @@
 const clone = require('clone');
 const { assert } = require('chai');
 
-const { runCLIWithServer, createServer, DEFAULT_SERVER_PORT } = require('../helpers');
-
+const {
+  runCLIWithServer,
+  createServer,
+  DEFAULT_SERVER_PORT,
+} = require('../helpers');
 
 // Helper, tries to parse given HTTP body and in case it can be parsed as JSON,
 // it returns the resulting JS object, otherwise it returns whatever came in.
 function parseIfJson(body) {
-  if (!body) { return undefined; }
+  if (!body) {
+    return undefined;
+  }
   try {
     return JSON.parse(body);
   } catch (error) {
     return body;
   }
 }
-
 
 // This can be removed once https://github.com/apiaryio/dredd/issues/341 is done
 function parseDreddStdout(stdout) {
@@ -41,7 +45,7 @@ function parseDreddStdout(stdout) {
   // body: At '/shoeSize' Invalid type: string (expected number)
   entries = entries.filter((item, i) => {
     const previousEntry = entries[i - 1];
-    if ((item.label === 'body') && (previousEntry.label === 'fail')) {
+    if (item.label === 'body' && previousEntry.label === 'fail') {
       previousEntry.body += `\n${item.body}`;
       return false;
     }
@@ -50,15 +54,27 @@ function parseDreddStdout(stdout) {
 
   // Re-arrange data from entries
   const results = {
-    summary: '', failures: [], bodies: [], schemas: [],
+    summary: '',
+    failures: [],
+    bodies: [],
+    schemas: [],
   };
   for (entry of entries) {
     switch (entry.label) {
-      case 'body': results.bodies.push(parseIfJson(entry.body)); break;
-      case 'bodySchema': results.schemas.push(parseIfJson(entry.body)); break;
-      case 'complete': results.summary = entry.body; break;
-      case 'fail': results.failures.push(entry.body); break;
-      default: continue;
+      case 'body':
+        results.bodies.push(parseIfJson(entry.body));
+        break;
+      case 'bodySchema':
+        results.schemas.push(parseIfJson(entry.body));
+        break;
+      case 'complete':
+        results.summary = entry.body;
+        break;
+      case 'fail':
+        results.failures.push(entry.body);
+        break;
+      default:
+        continue;
     }
   }
   return results;
@@ -95,10 +111,7 @@ describe('Regression: Issues #319 and #354', () => {
             type: 'object',
             properties: {
               city: {
-                anyOf: [
-                  { type: 'null' },
-                  { type: 'string' },
-                ],
+                anyOf: [{ type: 'null' }, { type: 'string' }],
               },
               street: { type: 'string' },
             },
@@ -130,10 +143,7 @@ describe('Regression: Issues #319 and #354', () => {
         type: 'object',
         properties: {
           city: {
-            anyOf: [
-              { type: 'null' },
-              { type: 'string' },
-            ],
+            anyOf: [{ type: 'null' }, { type: 'string' }],
           },
           street: { type: 'string' },
         },
@@ -141,9 +151,7 @@ describe('Regression: Issues #319 and #354', () => {
     },
   };
 
-  const userArrayPayload = [
-    userPayload,
-  ];
+  const userArrayPayload = [userPayload];
 
   const userArraySchema = {
     $schema: 'http://json-schema.org/draft-04/schema#',
@@ -169,7 +177,9 @@ describe('Regression: Issues #319 and #354', () => {
         '--no-color',
       ];
       runCLIWithServer(args, app, (err, info) => {
-        if (info) { results = parseDreddStdout(info.dredd.stdout); }
+        if (info) {
+          results = parseDreddStdout(info.dredd.stdout);
+        }
         done(err);
       });
     });
@@ -178,35 +188,51 @@ describe('Regression: Issues #319 and #354', () => {
       // Intentionally not testing just '.length' as this approach will output the difference
       assert.deepEqual(results.failures, []);
     });
-    it('results in exactly four tests', () => assert.include(results.summary, '4 total'));
-    it('results in four passing tests', () => assert.include(results.summary, '4 passing'));
+    it('results in exactly four tests', () =>
+      assert.include(results.summary, '4 total'));
+    it('results in four passing tests', () =>
+      assert.include(results.summary, '4 passing'));
 
     describe('Attributes defined in resource are referenced from payload [GET /bricks/XYZ42]', () => {
       it('has no request body', () => assert.isUndefined(results.bodies[0]));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[1], brickTypePayload));
-      it('has correct ‘actual’ response body', () => assert.deepEqual(results.bodies[2], brickTypePayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[0], brickTypeSchema));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[1], brickTypePayload));
+      it('has correct ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[2], brickTypePayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[0], brickTypeSchema));
     });
 
     describe('Attributes defined in resource are referenced from action [POST /bricks]', () => {
-      it('has correct request body', () => assert.deepEqual(results.bodies[3], brickTypePayload));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[4], brickTypePayload));
-      it('has correct ‘actual’ response body', () => assert.deepEqual(results.bodies[5], brickTypePayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[1], brickTypeSchema));
+      it('has correct request body', () =>
+        assert.deepEqual(results.bodies[3], brickTypePayload));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[4], brickTypePayload));
+      it('has correct ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[5], brickTypePayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[1], brickTypeSchema));
     });
 
     describe('Attributes defined as data structure are referenced from payload [GET /customers]', () => {
       it('has no request body', () => assert.isUndefined(results.bodies[6]));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[7], userArrayPayload));
-      it('has correct ‘actual’ response body', () => assert.deepEqual(results.bodies[8], userArrayPayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[2], userArraySchema));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[7], userArrayPayload));
+      it('has correct ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[8], userArrayPayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[2], userArraySchema));
     });
 
     describe('Attributes defined as data structure are referenced from action [POST /customers]', () => {
-      it('has correct request body', () => assert.deepEqual(results.bodies[9], userPayload));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[10], userPayload));
-      it('has correct ‘actual’ response body', () => assert.deepEqual(results.bodies[11], userPayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[3], userSchema));
+      it('has correct request body', () =>
+        assert.deepEqual(results.bodies[9], userPayload));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[10], userPayload));
+      it('has correct ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[11], userPayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[3], userSchema));
     });
   });
 
@@ -228,7 +254,9 @@ describe('Regression: Issues #319 and #354', () => {
       const app = createServer();
 
       // Attaching endpoint for each testing scenario
-      app.get('/bricks/XYZ42', (req, res) => res.json(incorrectBrickTypePayload));
+      app.get('/bricks/XYZ42', (req, res) =>
+        res.json(incorrectBrickTypePayload),
+      );
       app.post('/bricks', (req, res) => res.json(incorrectBrickTypePayload));
       app.get('/customers', (req, res) => res.json(incorrectUserArrayPayload));
       app.post('/customers', (req, res) => res.json(incorrectUserPayload));
@@ -242,14 +270,18 @@ describe('Regression: Issues #319 and #354', () => {
         '--no-color',
       ];
       runCLIWithServer(args, app, (err, info) => {
-        if (info) { results = parseDreddStdout(info.dredd.stdout); }
+        if (info) {
+          results = parseDreddStdout(info.dredd.stdout);
+        }
         done(err);
       });
     });
 
     it('outputs failures', () => assert.isOk(results.failures.length));
-    it('results in exactly four tests', () => assert.include(results.summary, '4 total'));
-    it('results in four failing tests', () => assert.include(results.summary, '4 failing'));
+    it('results in exactly four tests', () =>
+      assert.include(results.summary, '4 total'));
+    it('results in four failing tests', () =>
+      assert.include(results.summary, '4 failing'));
 
     describe('Attributes defined in resource are referenced from payload [GET /bricks/XYZ42]', () => {
       it('fails on missing required property and invalid type', () => {
@@ -258,9 +290,12 @@ describe('Regression: Issues #319 and #354', () => {
         assert.include(results.failures[1], 'Invalid type: number');
       });
       it('has no request body', () => assert.isUndefined(results.bodies[0]));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[1], brickTypePayload));
-      it('has incorrect ‘actual’ response body', () => assert.deepEqual(results.bodies[2], incorrectBrickTypePayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[0], brickTypeSchema));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[1], brickTypePayload));
+      it('has incorrect ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[2], incorrectBrickTypePayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[0], brickTypeSchema));
     });
 
     describe('Attributes defined in resource are referenced from action [POST /bricks]', () => {
@@ -269,10 +304,14 @@ describe('Regression: Issues #319 and #354', () => {
         assert.include(results.failures[3], 'Missing required property: name');
         assert.include(results.failures[3], 'Invalid type: number');
       });
-      it('has correct request body', () => assert.deepEqual(results.bodies[3], brickTypePayload));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[4], brickTypePayload));
-      it('has incorrect ‘actual’ response body', () => assert.deepEqual(results.bodies[5], incorrectBrickTypePayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[1], brickTypeSchema));
+      it('has correct request body', () =>
+        assert.deepEqual(results.bodies[3], brickTypePayload));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[4], brickTypePayload));
+      it('has incorrect ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[5], incorrectBrickTypePayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[1], brickTypeSchema));
     });
 
     describe('Attributes defined as data structure are referenced from payload [GET /customers]', () => {
@@ -281,9 +320,12 @@ describe('Regression: Issues #319 and #354', () => {
         assert.include(results.failures[5], 'Invalid type: object');
       });
       it('has no request body', () => assert.isUndefined(results.bodies[6]));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[7], userArrayPayload));
-      it('has incorrect ‘actual’ response body', () => assert.deepEqual(results.bodies[8], incorrectUserArrayPayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[2], userArraySchema));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[7], userArrayPayload));
+      it('has incorrect ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[8], incorrectUserArrayPayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[2], userArraySchema));
     });
 
     describe('Attributes defined as data structure are referenced from action [POST /customers]', () => {
@@ -292,10 +334,14 @@ describe('Regression: Issues #319 and #354', () => {
         assert.include(results.failures[7], 'Invalid type: null');
         assert.include(results.failures[7], 'Invalid type: string');
       });
-      it('has correct request body', () => assert.deepEqual(results.bodies[9], userPayload));
-      it('has correct ‘expected’ response body', () => assert.deepEqual(results.bodies[10], userPayload));
-      it('has incorrect ‘actual’ response body', () => assert.deepEqual(results.bodies[11], incorrectUserPayload));
-      it('has correct schema', () => assert.deepEqual(results.schemas[3], userSchema));
+      it('has correct request body', () =>
+        assert.deepEqual(results.bodies[9], userPayload));
+      it('has correct ‘expected’ response body', () =>
+        assert.deepEqual(results.bodies[10], userPayload));
+      it('has incorrect ‘actual’ response body', () =>
+        assert.deepEqual(results.bodies[11], incorrectUserPayload));
+      it('has correct schema', () =>
+        assert.deepEqual(results.schemas[3], userSchema));
     });
   });
 });

--- a/test/integration/regressions/regression-615-test.js
+++ b/test/integration/regressions/regression-615-test.js
@@ -8,9 +8,16 @@ describe('Regression: Issue #615', () => {
 
   before((done) => {
     const app = createServer();
-    app.all('/honey', (req, res) => res.status(200).type('text/plain').send(''));
+    app.all('/honey', (req, res) =>
+      res
+        .status(200)
+        .type('text/plain')
+        .send(''),
+    );
 
-    const dredd = new Dredd({ options: { path: './test/fixtures/regression-615.apib' } });
+    const dredd = new Dredd({
+      options: { path: './test/fixtures/regression-615.apib' },
+    });
     runDreddWithServer(dredd, app, (...args) => {
       let err;
       // eslint-disable-next-line
@@ -19,8 +26,10 @@ describe('Regression: Issue #615', () => {
     });
   });
 
-  it('outputs no failures', () => assert.equal(runtimeInfo.dredd.stats.failures, 0));
-  it('results in exactly three tests', () => assert.equal(runtimeInfo.dredd.stats.tests, 3));
+  it('outputs no failures', () =>
+    assert.equal(runtimeInfo.dredd.stats.failures, 0));
+  it('results in exactly three tests', () =>
+    assert.equal(runtimeInfo.dredd.stats.tests, 3));
   it('results in three passing tests', () => {
     // Ensures just the 200 responses were selected, because the server returns only 200s
     assert.equal(runtimeInfo.dredd.stats.passes, 3);

--- a/test/integration/regressions/regression-893-897-test.js
+++ b/test/integration/regressions/regression-893-897-test.js
@@ -9,9 +9,13 @@ describe('Regression: Issue #893 and #897', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/resource', (req, res) => res.json({ name: 'Honza', color: 'green' }));
+      app.get('/resource', (req, res) =>
+        res.json({ name: 'Honza', color: 'green' }),
+      );
 
-      const dredd = new Dredd({ options: { path: './test/fixtures/regression-893.yaml' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/regression-893.yaml' },
+      });
       runDreddWithServer(dredd, app, (...args) => {
         let err;
         // eslint-disable-next-line
@@ -20,9 +24,15 @@ describe('Regression: Issue #893 and #897', () => {
       });
     });
 
-    it('outputs no failures or errors', () => assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0));
-    it('results in exactly one test', () => assert.equal(runtimeInfo.dredd.stats.tests, 1));
-    it('results in one passing test (HTTP 200 is assumed)', () => assert.equal(runtimeInfo.dredd.stats.passes, 1));
+    it('outputs no failures or errors', () =>
+      assert.equal(
+        runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+        0,
+      ));
+    it('results in exactly one test', () =>
+      assert.equal(runtimeInfo.dredd.stats.tests, 1));
+    it('results in one passing test (HTTP 200 is assumed)', () =>
+      assert.equal(runtimeInfo.dredd.stats.passes, 1));
   });
 
   describe('when the response has no explicit schema and it has empty body', () => {
@@ -30,10 +40,16 @@ describe('Regression: Issue #893 and #897', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/resource', (req, res) => res.json({ name: 'Honza', color: 'green' }));
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send('name,color\nHonza,green\n'));
+      app.get('/resource', (req, res) =>
+        res.json({ name: 'Honza', color: 'green' }),
+      );
+      app.get('/resource.csv', (req, res) =>
+        res.type('text/csv').send('name,color\nHonza,green\n'),
+      );
 
-      const dredd = new Dredd({ options: { path: './test/fixtures/regression-897-body.yaml' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/regression-897-body.yaml' },
+      });
       runDreddWithServer(dredd, app, (...args) => {
         let err;
         // eslint-disable-next-line
@@ -42,9 +58,15 @@ describe('Regression: Issue #893 and #897', () => {
       });
     });
 
-    it('outputs no failures or errors', () => assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0));
-    it('results in exactly two tests', () => assert.equal(runtimeInfo.dredd.stats.tests, 2));
-    it('results in two passing tests (body is not validated)', () => assert.equal(runtimeInfo.dredd.stats.passes, 2));
+    it('outputs no failures or errors', () =>
+      assert.equal(
+        runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+        0,
+      ));
+    it('results in exactly two tests', () =>
+      assert.equal(runtimeInfo.dredd.stats.tests, 2));
+    it('results in two passing tests (body is not validated)', () =>
+      assert.equal(runtimeInfo.dredd.stats.passes, 2));
   });
 
   describe('when the response has no explicit schema', () => {
@@ -52,10 +74,16 @@ describe('Regression: Issue #893 and #897', () => {
 
     before((done) => {
       const app = createServer();
-      app.get('/resource', (req, res) => res.json({ name: 'Honza', color: 'green' }));
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send('name,color\nHonza,green\n'));
+      app.get('/resource', (req, res) =>
+        res.json({ name: 'Honza', color: 'green' }),
+      );
+      app.get('/resource.csv', (req, res) =>
+        res.type('text/csv').send('name,color\nHonza,green\n'),
+      );
 
-      const dredd = new Dredd({ options: { path: './test/fixtures/regression-897-schema.yaml' } });
+      const dredd = new Dredd({
+        options: { path: './test/fixtures/regression-897-schema.yaml' },
+      });
       runDreddWithServer(dredd, app, (...args) => {
         let err;
         // eslint-disable-next-line
@@ -64,8 +92,14 @@ describe('Regression: Issue #893 and #897', () => {
       });
     });
 
-    it('outputs no failures or errors', () => assert.equal(runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors, 0));
-    it('results in exactly two tests', () => assert.equal(runtimeInfo.dredd.stats.tests, 2));
-    it('results in two passing tests', () => assert.equal(runtimeInfo.dredd.stats.passes, 2));
+    it('outputs no failures or errors', () =>
+      assert.equal(
+        runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+        0,
+      ));
+    it('results in exactly two tests', () =>
+      assert.equal(runtimeInfo.dredd.stats.tests, 2));
+    it('results in two passing tests', () =>
+      assert.equal(runtimeInfo.dredd.stats.passes, 2));
   });
 });

--- a/test/integration/request-test.js
+++ b/test/integration/request-test.js
@@ -6,15 +6,19 @@ const path = require('path');
 const { runDreddWithServer, createServer } = require('./helpers');
 const Dredd = require('../../lib/Dredd');
 
-describe('Sending \'application/json\' request', () => {
+describe("Sending 'application/json' request", () => {
   let runtimeInfo;
   const contentType = 'application/json';
 
   before((done) => {
-    const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+    const app = createServer({
+      bodyParser: bodyParser.text({ type: contentType }),
+    });
     app.post('/data', (req, res) => res.json({ test: 'OK' }));
 
-    const dredd = new Dredd({ options: { path: './test/fixtures/request/application-json.apib' } });
+    const dredd = new Dredd({
+      options: { path: './test/fixtures/request/application-json.apib' },
+    });
 
     runDreddWithServer(dredd, app, (err, info) => {
       runtimeInfo = info;
@@ -22,8 +26,13 @@ describe('Sending \'application/json\' request', () => {
     });
   });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType));
+  it('results in one request being delivered to the server', () =>
+    assert.isTrue(runtimeInfo.server.requestedOnce));
+  it('the request has the expected Content-Type', () =>
+    assert.equal(
+      runtimeInfo.server.lastRequest.headers['content-type'],
+      contentType,
+    ));
   it('the request has the expected format', () => {
     const { body } = runtimeInfo.server.lastRequest;
     assert.deepEqual(JSON.parse(body), { test: 42 });
@@ -39,9 +48,13 @@ describe("Sending 'multipart/form-data' request described in API Blueprint", () 
   const contentType = 'multipart/form-data';
 
   before((done) => {
-    const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+    const app = createServer({
+      bodyParser: bodyParser.text({ type: contentType }),
+    });
     app.post('/data', (req, res) => res.json({ test: 'OK' }));
-    const dredd = new Dredd({ options: { path: './test/fixtures/request/multipart-form-data.apib' } });
+    const dredd = new Dredd({
+      options: { path: './test/fixtures/request/multipart-form-data.apib' },
+    });
 
     runDreddWithServer(dredd, app, (err, info) => {
       runtimeInfo = info;
@@ -49,8 +62,13 @@ describe("Sending 'multipart/form-data' request described in API Blueprint", () 
     });
   });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data'));
+  it('results in one request being delivered to the server', () =>
+    assert.isTrue(runtimeInfo.server.requestedOnce));
+  it('the request has the expected Content-Type', () =>
+    assert.include(
+      runtimeInfo.server.lastRequest.headers['content-type'],
+      'multipart/form-data',
+    ));
   it('the request has the expected format', () => {
     const lines = [
       '--CUSTOM-BOUNDARY',
@@ -80,9 +98,13 @@ describe("Sending 'multipart/form-data' request described in OpenAPI 2", () => {
   const contentType = 'multipart/form-data';
 
   before((done) => {
-    const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+    const app = createServer({
+      bodyParser: bodyParser.text({ type: contentType }),
+    });
     app.post('/data', (req, res) => res.json({ test: 'OK' }));
-    const dredd = new Dredd({ options: { path: './test/fixtures/request/multipart-form-data.yaml' } });
+    const dredd = new Dredd({
+      options: { path: './test/fixtures/request/multipart-form-data.yaml' },
+    });
 
     runDreddWithServer(dredd, app, (err, info) => {
       runtimeInfo = info;
@@ -90,8 +112,13 @@ describe("Sending 'multipart/form-data' request described in OpenAPI 2", () => {
     });
   });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data'));
+  it('results in one request being delivered to the server', () =>
+    assert.isTrue(runtimeInfo.server.requestedOnce));
+  it('the request has the expected Content-Type', () =>
+    assert.include(
+      runtimeInfo.server.lastRequest.headers['content-type'],
+      'multipart/form-data',
+    ));
   it('the request has the expected format', () => {
     const lines = [
       '--CUSTOM-BOUNDARY',
@@ -119,9 +146,15 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
   const contentType = 'multipart/form-data';
 
   before((done) => {
-    const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+    const app = createServer({
+      bodyParser: bodyParser.text({ type: contentType }),
+    });
     app.post('/data', (req, res) => res.json({ test: 'OK' }));
-    const dredd = new Dredd({ options: { path: './test/fixtures/request/multipart-form-data-file.yaml' } });
+    const dredd = new Dredd({
+      options: {
+        path: './test/fixtures/request/multipart-form-data-file.yaml',
+      },
+    });
 
     runDreddWithServer(dredd, app, (err, info) => {
       runtimeInfo = info;
@@ -129,8 +162,13 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
     });
   });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.include(runtimeInfo.server.lastRequest.headers['content-type'], 'multipart/form-data'));
+  it('results in one request being delivered to the server', () =>
+    assert.isTrue(runtimeInfo.server.requestedOnce));
+  it('the request has the expected Content-Type', () =>
+    assert.include(
+      runtimeInfo.server.lastRequest.headers['content-type'],
+      'multipart/form-data',
+    ));
   it('the request has the expected format', () => {
     const lines = [
       '--BOUNDARY',
@@ -153,21 +191,24 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
   });
 });
 
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/request/application-x-www-form-urlencoded.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/request/application-x-www-form-urlencoded.yaml',
-},
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/request/application-x-www-form-urlencoded.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/request/application-x-www-form-urlencoded.yaml',
+  },
 ].forEach((apiDescription) => {
   describe(`Sending 'application/x-www-form-urlencoded' request described in ${apiDescription.name}`, () => {
     let runtimeInfo;
     const contentType = 'application/x-www-form-urlencoded';
 
     before((done) => {
-      const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+      const app = createServer({
+        bodyParser: bodyParser.text({ type: contentType }),
+      });
       app.post('/data', (req, res) => res.json({ test: 'OK' }));
       const dredd = new Dredd({ options: { path: apiDescription.path } });
 
@@ -181,7 +222,10 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
       assert.isTrue(runtimeInfo.server.requestedOnce);
     });
     it('the request has the expected Content-Type', () => {
-      assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType);
+      assert.equal(
+        runtimeInfo.server.lastRequest.headers['content-type'],
+        contentType,
+      );
     });
     it('the request has the expected format', () => {
       // API Blueprint adds extra \n at the end: https://github.com/apiaryio/dredd/issues/67
@@ -194,14 +238,18 @@ describe("Sending 'multipart/form-data' request described as 'file' in OpenAPI 2
   });
 });
 
-describe('Sending \'text/plain\' request', () => {
+describe("Sending 'text/plain' request", () => {
   let runtimeInfo;
   const contentType = 'text/plain';
 
   before((done) => {
-    const app = createServer({ bodyParser: bodyParser.text({ type: contentType }) });
+    const app = createServer({
+      bodyParser: bodyParser.text({ type: contentType }),
+    });
     app.post('/data', (req, res) => res.json({ test: 'OK' }));
-    const dredd = new Dredd({ options: { path: './test/fixtures/request/text-plain.apib' } });
+    const dredd = new Dredd({
+      options: { path: './test/fixtures/request/text-plain.apib' },
+    });
 
     runDreddWithServer(dredd, app, (err, info) => {
       runtimeInfo = info;
@@ -213,7 +261,10 @@ describe('Sending \'text/plain\' request', () => {
     assert.isTrue(runtimeInfo.server.requestedOnce);
   });
   it('the request has the expected Content-Type', () => {
-    assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType);
+    assert.equal(
+      runtimeInfo.server.lastRequest.headers['content-type'],
+      contentType,
+    );
   });
   it('the request has the expected format', () => {
     assert.equal(runtimeInfo.server.lastRequest.body, 'test equals to 42\n');
@@ -233,37 +284,48 @@ describe('Sending \'text/plain\' request', () => {
     name: 'OpenAPI 2',
     path: './test/fixtures/request/application-octet-stream.yaml',
   },
-].forEach(apiDescription => describe(`Sending 'application/octet-stream' request described in ${apiDescription.name}`, () => {
-  let runtimeInfo;
-  const contentType = 'application/octet-stream';
+].forEach((apiDescription) =>
+  describe(`Sending 'application/octet-stream' request described in ${apiDescription.name}`, () => {
+    let runtimeInfo;
+    const contentType = 'application/octet-stream';
 
-  before((done) => {
-    const app = createServer({ bodyParser: bodyParser.raw({ type: contentType }) });
-    app.post('/binary', (req, res) => res.json({ test: 'OK' }));
+    before((done) => {
+      const app = createServer({
+        bodyParser: bodyParser.raw({ type: contentType }),
+      });
+      app.post('/binary', (req, res) => res.json({ test: 'OK' }));
 
-    const dredd = new Dredd({
-      options: {
-        path: apiDescription.path,
-        hookfiles: './test/fixtures/request/application-octet-stream-hooks.js',
-      },
+      const dredd = new Dredd({
+        options: {
+          path: apiDescription.path,
+          hookfiles:
+            './test/fixtures/request/application-octet-stream-hooks.js',
+        },
+      });
+      runDreddWithServer(dredd, app, (err, info) => {
+        runtimeInfo = info;
+        done(err);
+      });
     });
-    runDreddWithServer(dredd, app, (err, info) => {
-      runtimeInfo = info;
-      done(err);
-    });
-  });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType));
-  it('the request has the expected format', () => assert.equal(
-    runtimeInfo.server.lastRequest.body.toString('base64'),
-    Buffer.from([0xFF, 0xEF, 0xBF, 0xBE]).toString('base64')
-  ));
-  it('results in one passing test', () => {
-    assert.equal(runtimeInfo.dredd.stats.tests, 1);
-    assert.equal(runtimeInfo.dredd.stats.passes, 1);
-  });
-}));
+    it('results in one request being delivered to the server', () =>
+      assert.isTrue(runtimeInfo.server.requestedOnce));
+    it('the request has the expected Content-Type', () =>
+      assert.equal(
+        runtimeInfo.server.lastRequest.headers['content-type'],
+        contentType,
+      ));
+    it('the request has the expected format', () =>
+      assert.equal(
+        runtimeInfo.server.lastRequest.body.toString('base64'),
+        Buffer.from([0xff, 0xef, 0xbf, 0xbe]).toString('base64'),
+      ));
+    it('results in one passing test', () => {
+      assert.equal(runtimeInfo.dredd.stats.tests, 1);
+      assert.equal(runtimeInfo.dredd.stats.passes, 1);
+    });
+  }),
+);
 
 [
   {
@@ -274,34 +336,46 @@ describe('Sending \'text/plain\' request', () => {
     name: 'OpenAPI 2',
     path: './test/fixtures/request/image-png.yaml',
   },
-].forEach(apiDescription => describe(`Sending 'image/png' request described in ${apiDescription.name}`, () => {
-  let runtimeInfo;
-  const contentType = 'image/png';
+].forEach((apiDescription) =>
+  describe(`Sending 'image/png' request described in ${apiDescription.name}`, () => {
+    let runtimeInfo;
+    const contentType = 'image/png';
 
-  before((done) => {
-    const app = createServer({ bodyParser: bodyParser.raw({ type: contentType }) });
-    app.put('/image.png', (req, res) => res.json({ test: 'OK' }));
+    before((done) => {
+      const app = createServer({
+        bodyParser: bodyParser.raw({ type: contentType }),
+      });
+      app.put('/image.png', (req, res) => res.json({ test: 'OK' }));
 
-    const dredd = new Dredd({
-      options: {
-        path: apiDescription.path,
-        hookfiles: './test/fixtures/request/image-png-hooks.js',
-      },
+      const dredd = new Dredd({
+        options: {
+          path: apiDescription.path,
+          hookfiles: './test/fixtures/request/image-png-hooks.js',
+        },
+      });
+      runDreddWithServer(dredd, app, (err, info) => {
+        runtimeInfo = info;
+        done(err);
+      });
     });
-    runDreddWithServer(dredd, app, (err, info) => {
-      runtimeInfo = info;
-      done(err);
-    });
-  });
 
-  it('results in one request being delivered to the server', () => assert.isTrue(runtimeInfo.server.requestedOnce));
-  it('the request has the expected Content-Type', () => assert.equal(runtimeInfo.server.lastRequest.headers['content-type'], contentType));
-  it('the request has the expected format', () => assert.equal(
-    runtimeInfo.server.lastRequest.body.toString('base64'),
-    fs.readFileSync(path.join(__dirname, '../fixtures/image.png')).toString('base64')
-  ));
-  it('results in one passing test', () => {
-    assert.equal(runtimeInfo.dredd.stats.tests, 1);
-    assert.equal(runtimeInfo.dredd.stats.passes, 1);
-  });
-}));
+    it('results in one request being delivered to the server', () =>
+      assert.isTrue(runtimeInfo.server.requestedOnce));
+    it('the request has the expected Content-Type', () =>
+      assert.equal(
+        runtimeInfo.server.lastRequest.headers['content-type'],
+        contentType,
+      ));
+    it('the request has the expected format', () =>
+      assert.equal(
+        runtimeInfo.server.lastRequest.body.toString('base64'),
+        fs
+          .readFileSync(path.join(__dirname, '../fixtures/image.png'))
+          .toString('base64'),
+      ));
+    it('results in one passing test', () => {
+      assert.equal(runtimeInfo.dredd.stats.tests, 1);
+      assert.equal(runtimeInfo.dredd.stats.passes, 1);
+    });
+  }),
+);

--- a/test/integration/require-test.js
+++ b/test/integration/require-test.js
@@ -3,7 +3,6 @@ const { assert } = require('chai');
 const Dredd = require('../../lib/Dredd');
 const { runDredd } = require('./helpers');
 
-
 describe('Requiring user-provided modules (e.g. language compilers)', () => {
   describe('when provided with a local module', () => {
     let dreddRuntimeInfo;
@@ -79,7 +78,10 @@ describe('Requiring user-provided modules (e.g. language compilers)', () => {
       assert.equal(dreddRuntimeInfo.err.code, 'MODULE_NOT_FOUND');
     });
     it('the error message is descriptive', () => {
-      assert.include(dreddRuntimeInfo.err.message, 'Cannot find module \'no-such-module\'');
+      assert.include(
+        dreddRuntimeInfo.err.message,
+        "Cannot find module 'no-such-module'",
+      );
     });
   });
 });

--- a/test/integration/response-test.js
+++ b/test/integration/response-test.js
@@ -4,271 +4,335 @@ const path = require('path');
 const { runDreddWithServer, createServer } = require('./helpers');
 const Dredd = require('../../lib/Dredd');
 
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml',
-},
-].forEach(apiDescription => describe(`Specifying neither response body nor schema in the ${apiDescription.name}`, () => {
-  describe('when the server returns non-empty responses', () => {
-    let runtimeInfo;
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/response/empty-body-empty-schema.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/response/empty-body-empty-schema.yaml',
+  },
+].forEach((apiDescription) =>
+  describe(`Specifying neither response body nor schema in the ${apiDescription.name}`, () => {
+    describe('when the server returns non-empty responses', () => {
+      let runtimeInfo;
 
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send('test,OK\n'));
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
+        app.get('/resource.csv', (req, res) =>
+          res.type('text/csv').send('test,OK\n'),
+        );
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
+
+      it('evaluates the responses as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
     });
 
-    it('evaluates the responses as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
-  });
+    describe('when the server returns empty responses', () => {
+      let runtimeInfo;
 
-  describe('when the server returns empty responses', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.type('json').send());
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send());
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.type('json').send());
+        app.get('/resource.csv', (req, res) => res.type('text/csv').send());
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
+
+      it('evaluates the responses as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
+    });
+  }),
+);
+
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/response/empty-body.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/response/empty-body.yaml',
+  },
+].forEach((apiDescription) =>
+  describe(`Specifying no response body in the ${apiDescription.name}, but specifying a schema`, () => {
+    describe('when the server returns a response not valid according to the schema', () => {
+      let runtimeInfo;
+
+      before((done) => {
+        const app = createServer();
+        app.get('/resource', (req, res) => res.json({ name: 123 }));
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
+      });
+
+      it('evaluates the response as invalid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, failures: 1 }));
+      it('prints JSON Schema validation error', () =>
+        assert.include(
+          runtimeInfo.dredd.logging,
+          "At '/name' Invalid type: number (expected string)",
+        ));
     });
 
-    it('evaluates the responses as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
-  });
-}));
+    describe('when the server returns a response valid according to the schema', () => {
+      let runtimeInfo;
 
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body.yaml',
-},
-].forEach(apiDescription => describe(`Specifying no response body in the ${apiDescription.name}, but specifying a schema`, () => {
-  describe('when the server returns a response not valid according to the schema', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      const app = createServer();
-      app.get('/resource', (req, res) => res.json({ name: 123 }));
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
+      before((done) => {
+        const app = createServer();
+        app.get('/resource', (req, res) => res.json({ name: 'test' }));
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
+
+      it('evaluates the response as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
+    });
+  }),
+);
+
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/response/empty-body-empty-schema.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/response/empty-body-empty-schema.yaml',
+  },
+].forEach((apiDescription) =>
+  describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
+    describe('when the server returns a non-empty responses', () => {
+      let runtimeInfo;
+
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
+        app.get('/resource.csv', (req, res) =>
+          res.type('text/csv').send('test,OK\n'),
+        );
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
+      });
+
+      it('evaluates the responses as invalid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, failures: 2 }));
+      it('prints the error message from hooks', () =>
+        assert.include(
+          runtimeInfo.dredd.logging,
+          'The response body must be empty',
+        ));
     });
 
-    it('evaluates the response as invalid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, failures: 1 }));
-    it('prints JSON Schema validation error', () => assert.include(runtimeInfo.dredd.logging, 'At \'/name\' Invalid type: number (expected string)'));
-  });
+    describe('when the server returns an empty responses', () => {
+      let runtimeInfo;
 
-  describe('when the server returns a response valid according to the schema', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      const app = createServer();
-      app.get('/resource', (req, res) => res.json({ name: 'test' }));
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.send());
+        app.get('/resource.csv', (req, res) => res.type('text/csv').send());
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
+
+      it('evaluates the responses as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
+    });
+  }),
+);
+
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/response/empty-body-empty-schema.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/response/empty-body-empty-schema.yaml',
+  },
+].forEach((apiDescription) =>
+  describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
+    describe('when the server returns non-empty responses', () => {
+      let runtimeInfo;
+
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
+        app.get('/resource.csv', (req, res) =>
+          res.type('text/csv').send('test,OK\n'),
+        );
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
+      });
+
+      it('evaluates the responses as invalid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, failures: 2 }));
+      it('prints the error message from hooks', () =>
+        assert.include(
+          runtimeInfo.dredd.logging,
+          'The response body must be empty',
+        ));
     });
 
-    it('evaluates the response as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
-  });
-}));
+    describe('when the server returns empty responses', () => {
+      let runtimeInfo;
 
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml',
-},
-].forEach(apiDescription => describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
-  describe('when the server returns a non-empty responses', () => {
-    let runtimeInfo;
+      before((done) => {
+        const app = createServer();
+        app.get('/resource.json', (req, res) => res.send());
+        app.get('/resource.csv', (req, res) => res.type('text/csv').send());
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/empty-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
+      });
 
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send('test,OK\n'));
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/empty-body-hooks.js',
-        },
+      it('evaluates the responses as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
+    });
+  }),
+);
+
+[
+  {
+    name: 'API Blueprint',
+    path: './test/fixtures/response/204-205-body.apib',
+  },
+  {
+    name: 'OpenAPI 2',
+    path: './test/fixtures/response/204-205-body.yaml',
+  },
+].forEach((apiDescription) =>
+  describe(`Working with HTTP 204 and 205 responses in the ${apiDescription.name}`, () => {
+    describe('when the actual response is non-empty', () => {
+      let runtimeInfo;
+
+      before((done) => {
+        // It's not trivial to create an actual server sending HTTP 204 or 205
+        // with non-empty body, because it's against specs. That's why we're
+        // returning HTTP 200 here and in the assertions we're making sure
+        // the failures are there only because of non-matching status codes.
+        const app = createServer();
+        app.get('*', (req, res) => res.type('text/plain').send('test\n'));
+
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
+
+      it('evaluates all the responses as invalid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 4, failures: 4 }));
+      it('prints four warnings for each of the responses', () =>
+        assert.equal(
+          runtimeInfo.dredd.logging.match(
+            /HTTP 204 and 205 responses must not include a message body/g,
+          ).length,
+          4,
+        ));
+      it('prints four failures for each non-matching status code', () =>
+        assert.equal(
+          runtimeInfo.dredd.logging.match(
+            /fail: statusCode: Expected status code '\d+', but got '200'./g,
+          ).length,
+          4,
+        ));
+      it('does not print any failures regarding response bodies', () =>
+        assert.isNull(runtimeInfo.dredd.logging.match(/fail: body:/g)));
     });
 
-    it('evaluates the responses as invalid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, failures: 2 }));
-    it('prints the error message from hooks', () => assert.include(runtimeInfo.dredd.logging, 'The response body must be empty'));
-  });
+    describe('when the actual response is empty', () => {
+      let runtimeInfo;
 
-  describe('when the server returns an empty responses', () => {
-    let runtimeInfo;
+      before((done) => {
+        // It's not trivial to create an actual server sending HTTP 204 or 205
+        // sending a Content-Type header, because it's against specs. That's
+        // why we're returning HTTP 200 here and in the assertions we're making
+        // sure the extra failures are there only because of non-matching status
+        // codes.
+        const app = createServer();
+        app.get('*', (req, res) => res.type('text/plain').send());
 
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.send());
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send());
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/empty-body-hooks.js',
-        },
+        const dredd = new Dredd({ options: { path: apiDescription.path } });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
+
+      it('evaluates all the responses as invalid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 4, failures: 4 }));
+      it('prints two warnings for each of the non-empty expectations', () =>
+        assert.equal(
+          runtimeInfo.dredd.logging.match(
+            /HTTP 204 and 205 responses must not include a message body/g,
+          ).length,
+          2,
+        ));
+      it('prints two failures for each non-matching body (and status code)', () =>
+        assert.equal(
+          runtimeInfo.dredd.logging.match(
+            /fail: body: Actual and expected data do not match.\nstatusCode: Expected status code '\d+', but got '200'./g,
+          ).length,
+          2,
+        ));
+      it('prints two failures for each non-matching status code', () =>
+        assert.equal(
+          runtimeInfo.dredd.logging.match(
+            /fail: statusCode: Expected status code '\d+', but got '200'./g,
+          ).length,
+          2,
+        ));
     });
-
-    it('evaluates the responses as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
-  });
-}));
-
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/response/empty-body-empty-schema.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/response/empty-body-empty-schema.yaml',
-},
-].forEach(apiDescription => describe(`Specifying no response body in the ${apiDescription.name} and having hooks ensuring empty response`, () => {
-  describe('when the server returns non-empty responses', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.json({ test: 'OK' }));
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send('test,OK\n'));
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/empty-body-hooks.js',
-        },
-      });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
-    });
-
-    it('evaluates the responses as invalid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, failures: 2 }));
-    it('prints the error message from hooks', () => assert.include(runtimeInfo.dredd.logging, 'The response body must be empty'));
-  });
-
-  describe('when the server returns empty responses', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      const app = createServer();
-      app.get('/resource.json', (req, res) => res.send());
-      app.get('/resource.csv', (req, res) => res.type('text/csv').send());
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/empty-body-hooks.js',
-        },
-      });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
-    });
-
-    it('evaluates the responses as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 2, passes: 2 }));
-  });
-}));
-
-[{
-  name: 'API Blueprint',
-  path: './test/fixtures/response/204-205-body.apib',
-},
-{
-  name: 'OpenAPI 2',
-  path: './test/fixtures/response/204-205-body.yaml',
-},
-].forEach(apiDescription => describe(`Working with HTTP 204 and 205 responses in the ${apiDescription.name}`, () => {
-  describe('when the actual response is non-empty', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      // It's not trivial to create an actual server sending HTTP 204 or 205
-      // with non-empty body, because it's against specs. That's why we're
-      // returning HTTP 200 here and in the assertions we're making sure
-      // the failures are there only because of non-matching status codes.
-      const app = createServer();
-      app.get('*', (req, res) => res.type('text/plain').send('test\n'));
-
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
-    });
-
-    it('evaluates all the responses as invalid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 4, failures: 4 }));
-    it('prints four warnings for each of the responses', () => assert.equal(runtimeInfo.dredd.logging.match(
-      /HTTP 204 and 205 responses must not include a message body/g
-    ).length, 4));
-    it('prints four failures for each non-matching status code', () => assert.equal(runtimeInfo.dredd.logging.match(
-      /fail: statusCode: Expected status code '\d+', but got '200'./g
-    ).length, 4));
-    it('does not print any failures regarding response bodies', () => assert.isNull(runtimeInfo.dredd.logging.match(/fail: body:/g)));
-  });
-
-  describe('when the actual response is empty', () => {
-    let runtimeInfo;
-
-    before((done) => {
-      // It's not trivial to create an actual server sending HTTP 204 or 205
-      // sending a Content-Type header, because it's against specs. That's
-      // why we're returning HTTP 200 here and in the assertions we're making
-      // sure the extra failures are there only because of non-matching status
-      // codes.
-      const app = createServer();
-      app.get('*', (req, res) => res.type('text/plain').send());
-
-      const dredd = new Dredd({ options: { path: apiDescription.path } });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
-    });
-
-    it('evaluates all the responses as invalid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 4, failures: 4 }));
-    it('prints two warnings for each of the non-empty expectations', () => assert.equal(runtimeInfo.dredd.logging.match(
-      /HTTP 204 and 205 responses must not include a message body/g
-    ).length, 2));
-    it('prints two failures for each non-matching body (and status code)', () => assert.equal(runtimeInfo.dredd.logging.match(
-      /fail: body: Actual and expected data do not match.\nstatusCode: Expected status code '\d+', but got '200'./g
-    ).length, 2));
-    it('prints two failures for each non-matching status code', () => assert.equal(runtimeInfo.dredd.logging.match(
-      /fail: statusCode: Expected status code '\d+', but got '200'./g
-    ).length, 2));
-  });
-}));
+  }),
+);
 
 [
   {
@@ -279,46 +343,52 @@ const Dredd = require('../../lib/Dredd');
     name: 'OpenAPI 2',
     path: './test/fixtures/response/binary.yaml',
   },
-].forEach(apiDescription => describe(`Working with binary responses in the ${apiDescription.name}`, () => {
-  const imagePath = path.join(__dirname, '../fixtures/image.png');
-  const app = createServer();
-  app.get('/image.png', (req, res) => res.type('image/png').sendFile(imagePath));
+].forEach((apiDescription) =>
+  describe(`Working with binary responses in the ${apiDescription.name}`, () => {
+    const imagePath = path.join(__dirname, '../fixtures/image.png');
+    const app = createServer();
+    app.get('/image.png', (req, res) =>
+      res.type('image/png').sendFile(imagePath),
+    );
 
-  describe('when the body is described as empty and there are hooks to remove the real body', () => {
-    let runtimeInfo;
+    describe('when the body is described as empty and there are hooks to remove the real body', () => {
+      let runtimeInfo;
 
-    before((done) => {
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/binary-ignore-body-hooks.js',
-        },
+      before((done) => {
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/binary-ignore-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
       });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
+
+      it('evaluates the response as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
     });
 
-    it('evaluates the response as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
-  });
+    describe('when the body is described as empty and there are hooks to assert the real body', () => {
+      let runtimeInfo;
 
-  describe('when the body is described as empty and there are hooks to assert the real body', () => {
-    let runtimeInfo;
+      before((done) => {
+        const dredd = new Dredd({
+          options: {
+            path: apiDescription.path,
+            hookfiles: './test/fixtures/response/binary-assert-body-hooks.js',
+          },
+        });
+        runDreddWithServer(dredd, app, (err, info) => {
+          runtimeInfo = info;
+          done(err);
+        });
+      });
 
-    before((done) => {
-      const dredd = new Dredd({
-        options: {
-          path: apiDescription.path,
-          hookfiles: './test/fixtures/response/binary-assert-body-hooks.js',
-        },
-      });
-      runDreddWithServer(dredd, app, (err, info) => {
-        runtimeInfo = info;
-        done(err);
-      });
+      it('evaluates the response as valid', () =>
+        assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
     });
-
-    it('evaluates the response as valid', () => assert.deepInclude(runtimeInfo.dredd.stats, { tests: 1, passes: 1 }));
-  });
-}));
+  }),
+);

--- a/test/integration/sanitation-test.js
+++ b/test/integration/sanitation-test.js
@@ -20,16 +20,32 @@ describe('Sanitation of Reported Data', () => {
     // the emitted events. We're using 'clone' to prevent propagation of subsequent
     // modifications of the 'test' object (Dredd can change the data after they're
     // reported and by reference they would change also here in the 'events' array).
-    emitter.on('test start', test => events.push({ name: 'test start', test: clone(test) }));
-    emitter.on('test pass', test => events.push({ name: 'test pass', test: clone(test) }));
-    emitter.on('test skip', test => events.push({ name: 'test skip', test: clone(test) }));
-    emitter.on('test fail', test => events.push({ name: 'test fail', test: clone(test) }));
-    emitter.on('test error', (err, test) => events.push({ name: 'test error', test: clone(test), err }));
+    emitter.on('test start', (test) =>
+      events.push({ name: 'test start', test: clone(test) }),
+    );
+    emitter.on('test pass', (test) =>
+      events.push({ name: 'test pass', test: clone(test) }),
+    );
+    emitter.on('test skip', (test) =>
+      events.push({ name: 'test skip', test: clone(test) }),
+    );
+    emitter.on('test fail', (test) =>
+      events.push({ name: 'test fail', test: clone(test) }),
+    );
+    emitter.on('test error', (err, test) =>
+      events.push({ name: 'test error', test: clone(test), err }),
+    );
 
     // 'start' and 'end' events are asynchronous and they do not carry any data
     // significant for following scenarios
-    emitter.on('start', (apiDescriptions, cb) => { events.push({ name: 'start' }); return cb(); });
-    emitter.on('end', (cb) => { events.push({ name: 'end' }); return cb(); });
+    emitter.on('start', (apiDescriptions, cb) => {
+      events.push({ name: 'start' });
+      return cb();
+    });
+    emitter.on('end', (cb) => {
+      events.push({ name: 'end' });
+      return cb();
+    });
 
     return emitter;
   }
@@ -61,7 +77,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -71,10 +89,15 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
-    it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
+    it('emitted test data does not contain request body', () =>
+      assert.equal(events[2].test.request.body, ''));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -95,7 +118,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ token: 123 }); // 'token' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -105,9 +130,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does not contain response body', () => {
       assert.equal(events[2].test.actual.body, '');
       assert.equal(events[2].test.expected.body, '');
@@ -132,7 +161,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -142,9 +173,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does not contain confidential body attribute', () => {
       const attrs = Object.keys(JSON.parse(events[2].test.request.body));
       assert.deepEqual(attrs, ['name']);
@@ -169,7 +204,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ token: 123, name: 'Bob' }); // 'token' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -179,9 +216,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does not contain confidential body attribute', () => {
       let attrs = Object.keys(JSON.parse(events[2].test.actual.body));
       assert.deepEqual(attrs, ['name']);
@@ -206,10 +247,14 @@ describe('Sanitation of Reported Data', () => {
 
     before((done) => {
       const dredd = createDreddFromFixture(events, 'plain-text-response-body');
-      const app = createServerFromResponse(`${sensitiveKey}=42${sensitiveValue}`); // should be without '42' → failing test
+      const app = createServerFromResponse(
+        `${sensitiveKey}=42${sensitiveValue}`,
+      ); // should be without '42' → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -219,15 +264,21 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does contain the sensitive data censored', () => {
       assert.include(events[2].test.actual.body, '--- CENSORED ---');
       assert.include(events[2].test.expected.body, '--- CENSORED ---');
     });
-    it('sensitive data cannot be found anywhere in the emitted test data', () => assert.notInclude(JSON.stringify(events), sensitiveValue));
-    it('sensitive data cannot be found anywhere in Dredd output', () => assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
+    it('sensitive data cannot be found anywhere in the emitted test data', () =>
+      assert.notInclude(JSON.stringify(events), sensitiveValue));
+    it('sensitive data cannot be found anywhere in Dredd output', () =>
+      assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
   });
 
   describe('Sanitation of Request Headers', () => {
@@ -239,7 +290,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -249,11 +302,17 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does not contain confidential header', () => {
-      const names = Object.keys(events[2].test.request.headers).map(name => name.toLowerCase());
+      const names = Object.keys(events[2].test.request.headers).map((name) =>
+        name.toLowerCase(),
+      );
       assert.notInclude(names, sensitiveHeaderName);
     });
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
@@ -277,7 +336,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 'Bob' }); // Authorization header is missing → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -287,14 +348,22 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test data does not contain confidential header', () => {
-      let names = Object.keys(events[2].test.actual.headers).map(name => name.toLowerCase());
+      let names = Object.keys(events[2].test.actual.headers).map((name) =>
+        name.toLowerCase(),
+      );
       assert.notInclude(names, sensitiveHeaderName);
 
-      names = Object.keys(events[2].test.expected.headers).map(name => name.toLowerCase());
+      names = Object.keys(events[2].test.expected.headers).map((name) =>
+        name.toLowerCase(),
+      );
       assert.notInclude(names, sensitiveHeaderName);
     });
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
@@ -318,7 +387,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -328,12 +399,19 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
-    it('emitted test data does contain the sensitive data censored', () => assert.include(events[2].test.request.uri, 'CENSORED'));
-    it('sensitive data cannot be found anywhere in the emitted test data', () => assert.notInclude(JSON.stringify(events), sensitiveValue));
-    it('sensitive data cannot be found anywhere in Dredd output', () => assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
+    it('emitted test data does contain the sensitive data censored', () =>
+      assert.include(events[2].test.request.uri, 'CENSORED'));
+    it('sensitive data cannot be found anywhere in the emitted test data', () =>
+      assert.notInclude(JSON.stringify(events), sensitiveValue));
+    it('sensitive data cannot be found anywhere in Dredd output', () =>
+      assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
   });
 
   // This fails because it's not possible to do 'transaction.test = myOwnTestObject;'
@@ -343,11 +421,16 @@ describe('Sanitation of Reported Data', () => {
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'any-content-pattern-matching');
+      const dredd = createDreddFromFixture(
+        events,
+        'any-content-pattern-matching',
+      );
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -357,24 +440,36 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
-    it('emitted test data does contain the sensitive data censored', () => assert.include(JSON.stringify(events), 'CENSORED'));
-    it('sensitive data cannot be found anywhere in the emitted test data', () => assert.notInclude(JSON.stringify(events), sensitiveValue));
-    it('sensitive data cannot be found anywhere in Dredd output', () => assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
+    it('emitted test data does contain the sensitive data censored', () =>
+      assert.include(JSON.stringify(events), 'CENSORED'));
+    it('sensitive data cannot be found anywhere in the emitted test data', () =>
+      assert.notInclude(JSON.stringify(events), sensitiveValue));
+    it('sensitive data cannot be found anywhere in Dredd output', () =>
+      assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
   });
 
-  describe('Ultimate \'afterEach\' Guard Using Pattern Matching', () => {
+  describe("Ultimate 'afterEach' Guard Using Pattern Matching", () => {
     const events = [];
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'any-content-guard-pattern-matching');
+      const dredd = createDreddFromFixture(
+        events,
+        'any-content-guard-pattern-matching',
+      );
       const app = createServerFromResponse({ name: 123 }); // 'name' should be string → failing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -384,15 +479,24 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveValue);
     });
-    it('sensitive data cannot be found anywhere in Dredd output', () => assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
-    it('custom error message is printed', () => assert.include(dreddRuntimeInfo.logging, 'Sensitive data would be sent to Dredd reporter'));
+    it('sensitive data cannot be found anywhere in Dredd output', () =>
+      assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue));
+    it('custom error message is printed', () =>
+      assert.include(
+        dreddRuntimeInfo.logging,
+        'Sensitive data would be sent to Dredd reporter',
+      ));
   });
 
   describe('Sanitation of Test Data of Passing Transaction', () => {
@@ -404,7 +508,9 @@ describe('Sanitation of Reported Data', () => {
       const app = createServerFromResponse({ name: 'Bob' }); // Passing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -414,10 +520,15 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.passes, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test pass', 'end',
-    ]));
-    it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test pass',
+        'end',
+      ]));
+    it('emitted test data does not contain request body', () =>
+      assert.equal(events[2].test.request.body, ''));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -429,12 +540,15 @@ describe('Sanitation of Reported Data', () => {
     });
   });
 
-  describe('Sanitation of Test Data When Transaction Is Marked as Failed in \'before\' Hook', () => {
+  describe("Sanitation of Test Data When Transaction Is Marked as Failed in 'before' Hook", () => {
     const events = [];
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'transaction-marked-failed-before');
+      const dredd = createDreddFromFixture(
+        events,
+        'transaction-marked-failed-before',
+      );
 
       runDredd(dredd, (...args) => {
         let err;
@@ -448,14 +562,19 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('emitted test is failed', () => {
       assert.equal(events[2].test.status, 'fail');
       assert.include(events[2].test.errors[0].message.toLowerCase(), 'fail');
     });
-    it('emitted test data results contain just \'errors\' section', () => assert.containsAllKeys(events[2].test, ['errors']));
+    it("emitted test data results contain just 'errors' section", () =>
+      assert.containsAllKeys(events[2].test, ['errors']));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -467,16 +586,21 @@ describe('Sanitation of Reported Data', () => {
     });
   });
 
-  describe('Sanitation of Test Data When Transaction Is Marked as Failed in \'after\' Hook', () => {
+  describe("Sanitation of Test Data When Transaction Is Marked as Failed in 'after' Hook", () => {
     const events = [];
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'transaction-marked-failed-after');
+      const dredd = createDreddFromFixture(
+        events,
+        'transaction-marked-failed-after',
+      );
       const app = createServerFromResponse({ name: 'Bob' }); // Passing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -486,10 +610,15 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
-    it('emitted test data does not contain request body', () => assert.equal(events[2].test.request.body, ''));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
+    it('emitted test data does not contain request body', () =>
+      assert.equal(events[2].test.request.body, ''));
     it('emitted test is failed', () => {
       assert.equal(events[2].test.status, 'fail');
       assert.include(events[2].test.errors[0].message.toLowerCase(), 'fail');
@@ -497,7 +626,11 @@ describe('Sanitation of Reported Data', () => {
     it('emitted test data results contain all regular sections', () => {
       assert.containsAllKeys(events[2].test, ['errors']);
       assert.hasAllKeys(events[2].test.results, ['valid', 'fields']);
-      assert.hasAllKeys(events[2].test.results.fields, ['statusCode', 'headers', 'body']);
+      assert.hasAllKeys(events[2].test.results.fields, [
+        'statusCode',
+        'headers',
+        'body',
+      ]);
     });
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
@@ -515,7 +648,10 @@ describe('Sanitation of Reported Data', () => {
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'transaction-marked-skipped');
+      const dredd = createDreddFromFixture(
+        events,
+        'transaction-marked-skipped',
+      );
 
       runDredd(dredd, (...args) => {
         let err;
@@ -529,9 +665,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.skipped, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test skip', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test skip',
+        'end',
+      ]));
     it('emitted test is skipped', () => {
       assert.equal(events[2].test.status, 'skip');
       assert.containsAllKeys(events[2].test, ['errors']);
@@ -553,11 +693,16 @@ describe('Sanitation of Reported Data', () => {
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'transaction-erroring-hooks');
+      const dredd = createDreddFromFixture(
+        events,
+        'transaction-erroring-hooks',
+      );
       const app = createServerFromResponse({ name: 'Bob' }); // passing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -567,9 +712,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.errors, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test error', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test error',
+        'end',
+      ]));
     it('sensitive data leak to emitted test data', () => {
       const test = JSON.stringify(events);
       assert.include(test, sensitiveKey);
@@ -586,11 +735,16 @@ describe('Sanitation of Reported Data', () => {
     let dreddRuntimeInfo;
 
     before((done) => {
-      const dredd = createDreddFromFixture(events, 'transaction-secured-erroring-hooks');
+      const dredd = createDreddFromFixture(
+        events,
+        'transaction-secured-erroring-hooks',
+      );
       const app = createServerFromResponse({ name: 'Bob' }); // passing test
 
       runDreddWithServer(dredd, app, (err, runtimeInfo) => {
-        if (err) { return done(err); }
+        if (err) {
+          return done(err);
+        }
         dreddRuntimeInfo = runtimeInfo.dredd;
         done();
       });
@@ -600,9 +754,13 @@ describe('Sanitation of Reported Data', () => {
       assert.equal(dreddRuntimeInfo.stats.failures, 1);
       assert.equal(dreddRuntimeInfo.stats.tests, 1);
     });
-    it('emits expected events in expected order', () => assert.deepEqual((Array.from(events).map(event => event.name)), [
-      'start', 'test start', 'test fail', 'end',
-    ]));
+    it('emits expected events in expected order', () =>
+      assert.deepEqual(Array.from(events).map((event) => event.name), [
+        'start',
+        'test start',
+        'test fail',
+        'end',
+      ]));
     it('sensitive data cannot be found anywhere in the emitted test data', () => {
       const test = JSON.stringify(events);
       assert.notInclude(test, sensitiveKey);
@@ -612,6 +770,10 @@ describe('Sanitation of Reported Data', () => {
       assert.notInclude(dreddRuntimeInfo.logging, sensitiveKey);
       assert.notInclude(dreddRuntimeInfo.logging, sensitiveValue);
     });
-    it('custom error message is printed', () => assert.include(dreddRuntimeInfo.logging, 'Unexpected exception in hooks'));
+    it('custom error message is printed', () =>
+      assert.include(
+        dreddRuntimeInfo.logging,
+        'Unexpected exception in hooks',
+      ));
   });
 });

--- a/test/unit/Hooks-test.js
+++ b/test/unit/Hooks-test.js
@@ -66,7 +66,8 @@ describe('Hooks', () => {
       hooks.before('beforeHook', () => '');
     });
 
-    it('should add to hook collection', () => assert.property(hooks.beforeHooks, 'beforeHook'));
+    it('should add to hook collection', () =>
+      assert.property(hooks.beforeHooks, 'beforeHook'));
   });
 
   describe('#beforeValidation', () => {
@@ -77,7 +78,8 @@ describe('Hooks', () => {
       hooks.beforeValidation('beforeValidationHook', () => '');
     });
 
-    it('should add to hook collection', () => assert.property(hooks.beforeValidationHooks, 'beforeValidationHook'));
+    it('should add to hook collection', () =>
+      assert.property(hooks.beforeValidationHooks, 'beforeValidationHook'));
   });
 
   describe('#after', () => {
@@ -88,7 +90,8 @@ describe('Hooks', () => {
       hooks.after('afterHook', () => '');
     });
 
-    it('should add to hook collection', () => assert.property(hooks.afterHooks, 'afterHook'));
+    it('should add to hook collection', () =>
+      assert.property(hooks.afterHooks, 'afterHook'));
   });
 
   describe('#beforeAll', () => {
@@ -99,7 +102,8 @@ describe('Hooks', () => {
       hooks.beforeAll(() => '');
     });
 
-    it('should add to hook collection', () => assert.lengthOf(hooks.beforeAllHooks, 1));
+    it('should add to hook collection', () =>
+      assert.lengthOf(hooks.beforeAllHooks, 1));
   });
 
   describe('#afterAll', () => {
@@ -110,7 +114,8 @@ describe('Hooks', () => {
       hooks.afterAll(() => '');
     });
 
-    it('should add to hook collection', () => assert.lengthOf(hooks.afterAllHooks, 1));
+    it('should add to hook collection', () =>
+      assert.lengthOf(hooks.afterAllHooks, 1));
   });
 
   describe('#beforeEach', () => {
@@ -121,7 +126,8 @@ describe('Hooks', () => {
       hooks.beforeEach(() => '');
     });
 
-    it('should add to hook collection', () => assert.lengthOf(hooks.beforeEachHooks, 1));
+    it('should add to hook collection', () =>
+      assert.lengthOf(hooks.beforeEachHooks, 1));
   });
 
   describe('#beforeEachValidation', () => {
@@ -132,9 +138,9 @@ describe('Hooks', () => {
       hooks.beforeEachValidation(() => '');
     });
 
-    it('should add to hook collection', () => assert.lengthOf(hooks.beforeEachValidationHooks, 1));
+    it('should add to hook collection', () =>
+      assert.lengthOf(hooks.beforeEachValidationHooks, 1));
   });
-
 
   describe('#afterEach', () => {
     let hooks;
@@ -144,6 +150,7 @@ describe('Hooks', () => {
       hooks.afterEach(() => '');
     });
 
-    it('should add to hook collection', () => assert.lengthOf(hooks.afterEachHooks, 1));
+    it('should add to hook collection', () =>
+      assert.lengthOf(hooks.afterEachHooks, 1));
   });
 });

--- a/test/unit/HooksWorkerClient-test.js
+++ b/test/unit/HooksWorkerClient-test.js
@@ -17,11 +17,15 @@ function measureExecutionDurationMs(fn) {
   const time = process.hrtime();
   fn();
   const timeDiff = process.hrtime(time); // timeDiff = [seconds, nanoseconds]
-  return ((timeDiff[0] * 1000) + (timeDiff[1] * 1e-6));
+  return timeDiff[0] * 1000 + timeDiff[1] * 1e-6;
 }
 
 const COFFEE_BIN = 'node_modules/.bin/coffee';
-const MIN_COMMAND_EXECUTION_DURATION_MS = 2 * measureExecutionDurationMs(() => crossSpawnStub.sync(COFFEE_BIN, ['test/fixtures/scripts/exit-0.coffee']));
+const MIN_COMMAND_EXECUTION_DURATION_MS =
+  2 *
+  measureExecutionDurationMs(() =>
+    crossSpawnStub.sync(COFFEE_BIN, ['test/fixtures/scripts/exit-0.coffee']),
+  );
 const PORT = 61321;
 
 let runner;
@@ -39,7 +43,7 @@ let hooksWorkerClient;
 
 function loadWorkerClient(callback) {
   hooksWorkerClient = new HooksWorkerClient(runner);
-  hooksWorkerClient.start(error => callback(error));
+  hooksWorkerClient.start((error) => callback(error));
 }
 
 describe('Hooks worker client', () => {
@@ -51,24 +55,32 @@ describe('Hooks worker client', () => {
     runner.hooks = new Hooks({ logs: [], logger: console });
     runner.hooks.configuration = {};
 
-    Array.from(logLevels).forEach(level => sinon.stub(loggerStub, level).callsFake((msg1, msg2) => {
-      let text = msg1;
-      if (msg2) { text += ` ${msg2}`; }
+    Array.from(logLevels).forEach((level) =>
+      sinon.stub(loggerStub, level).callsFake((msg1, msg2) => {
+        let text = msg1;
+        if (msg2) {
+          text += ` ${msg2}`;
+        }
 
-      // Uncomment to enable logging for debug
-      // console.log text
-      logs.push(text);
-    }));
+        // Uncomment to enable logging for debug
+        // console.log text
+        logs.push(text);
+      }),
+    );
   });
 
   afterEach(() => {
-    Array.from(logLevels).forEach(level => loggerStub[level].restore());
+    Array.from(logLevels).forEach((level) => loggerStub[level].restore());
   });
 
   describe('when methods dealing with connection to the handler are stubbed', () => {
     beforeEach(() => {
-      sinon.stub(HooksWorkerClient.prototype, 'disconnectFromHandler').callsFake(() => { });
-      sinon.stub(HooksWorkerClient.prototype, 'connectToHandler').callsFake(cb => cb());
+      sinon
+        .stub(HooksWorkerClient.prototype, 'disconnectFromHandler')
+        .callsFake(() => {});
+      sinon
+        .stub(HooksWorkerClient.prototype, 'connectToHandler')
+        .callsFake((cb) => cb());
     });
 
     afterEach(() => {
@@ -79,7 +91,9 @@ describe('Hooks worker client', () => {
     it('should pipe spawned process stdout to the Dredd process stdout', (done) => {
       runner.hooks.configuration.language = `${COFFEE_BIN} test/fixtures/scripts/stdout.coffee`;
       loadWorkerClient((workerError) => {
-        if (workerError) { return done(workerError); }
+        if (workerError) {
+          return done(workerError);
+        }
 
         // The handler sometimes doesn't write to stdout or stderr until it
         // finishes, so we need to manually stop it. However, it could happen
@@ -89,8 +103,13 @@ describe('Hooks worker client', () => {
           if (data.toString() !== 'exiting\n') {
             process.nextTick(() => {
               hooksWorkerClient.stop((stopError) => {
-                if (stopError) { return done(stopError); }
-                assert.include(logs, 'Hooks handler stdout: standard output text\n');
+                if (stopError) {
+                  return done(stopError);
+                }
+                assert.include(
+                  logs,
+                  'Hooks handler stdout: standard output text\n',
+                );
                 done();
               });
             });
@@ -102,7 +121,9 @@ describe('Hooks worker client', () => {
     it('should pipe spawned process stderr to the Dredd process stderr', (done) => {
       runner.hooks.configuration.language = `${COFFEE_BIN} test/fixtures/scripts/stderr.coffee`;
       loadWorkerClient((workerError) => {
-        if (workerError) { return done(workerError); }
+        if (workerError) {
+          return done(workerError);
+        }
 
         // The handler sometimes doesn't write to stdout or stderr until it
         // finishes, so we need to manually stop it. However, it could happen
@@ -112,8 +133,13 @@ describe('Hooks worker client', () => {
           if (data.toString() !== 'exiting\n') {
             process.nextTick(() => {
               hooksWorkerClient.stop((stopError) => {
-                if (stopError) { return done(stopError); }
-                assert.include(logs, 'Hooks handler stderr: error output text\n');
+                if (stopError) {
+                  return done(stopError);
+                }
+                assert.include(
+                  logs,
+                  'Hooks handler stderr: error output text\n',
+                );
                 done();
               });
             });
@@ -122,41 +148,59 @@ describe('Hooks worker client', () => {
       });
     });
 
-    it('should not set the error on worker if process gets intentionally killed by Dredd '
-    + 'because it can be killed after all hooks execution if SIGTERM isn\'t handled', (done) => {
-      runner.hooks.configuration.language = `${COFFEE_BIN} test/fixtures/scripts/endless-ignore-term.coffee`;
-      loadWorkerClient((workerError) => {
-        if (workerError) { return done(workerError); }
+    it(
+      'should not set the error on worker if process gets intentionally killed by Dredd ' +
+        "because it can be killed after all hooks execution if SIGTERM isn't handled",
+      (done) => {
+        runner.hooks.configuration.language = `${COFFEE_BIN} test/fixtures/scripts/endless-ignore-term.coffee`;
+        loadWorkerClient((workerError) => {
+          if (workerError) {
+            return done(workerError);
+          }
 
-        // The handler sometimes doesn't write to stdout or stderr until it
-        // finishes, so we need to manually stop it. However, it could happen
-        // we'll stop it before it actually manages to do what we test here, so
-        // we add some timeout here.
-        setTimeout(() => hooksWorkerClient.stop((stopError) => {
-          if (stopError) { return done(stopError); }
-          assert.isNull(runner.hookHandlerError);
-          done();
-        }),
-        MIN_COMMAND_EXECUTION_DURATION_MS);
-      });
-    });
+          // The handler sometimes doesn't write to stdout or stderr until it
+          // finishes, so we need to manually stop it. However, it could happen
+          // we'll stop it before it actually manages to do what we test here, so
+          // we add some timeout here.
+          setTimeout(
+            () =>
+              hooksWorkerClient.stop((stopError) => {
+                if (stopError) {
+                  return done(stopError);
+                }
+                assert.isNull(runner.hookHandlerError);
+                done();
+              }),
+            MIN_COMMAND_EXECUTION_DURATION_MS,
+          );
+        });
+      },
+    );
 
     it('should include the status in the error if spawned process ends with non-zero exit status', (done) => {
-      runner.hooks.configuration.language = 'node test/fixtures/scripts/exit-3.js';
+      runner.hooks.configuration.language =
+        'node test/fixtures/scripts/exit-3.js';
       loadWorkerClient((workerError) => {
-        if (workerError) { return done(workerError); }
+        if (workerError) {
+          return done(workerError);
+        }
 
         // The handler sometimes doesn't write to stdout or stderr until it
         // finishes, so we need to manually stop it. However, it could happen
         // we'll stop it before it actually manages to do what we test here, so
         // we add some timeout here.
-        setTimeout(() => hooksWorkerClient.stop((stopError) => {
-          if (stopError) { return done(stopError); }
-          assert.isOk(runner.hookHandlerError);
-          assert.include(runner.hookHandlerError.message, '3');
-          done();
-        }),
-        MIN_COMMAND_EXECUTION_DURATION_MS);
+        setTimeout(
+          () =>
+            hooksWorkerClient.stop((stopError) => {
+              if (stopError) {
+                return done(stopError);
+              }
+              assert.isOk(runner.hookHandlerError);
+              assert.include(runner.hookHandlerError.message, '3');
+              done();
+            }),
+          MIN_COMMAND_EXECUTION_DURATION_MS,
+        );
       });
     });
 
@@ -167,11 +211,12 @@ describe('Hooks worker client', () => {
         };
       });
 
-      it('should write a hint that native hooks should be used', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'native Node.js hooks instead');
-        done();
-      }));
+      it('should write a hint that native hooks should be used', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(err.message, 'native Node.js hooks instead');
+          done();
+        }));
     });
 
     describe('when --language=ruby option is given and the worker is installed', () => {
@@ -189,7 +234,9 @@ describe('Hooks worker client', () => {
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -201,26 +248,34 @@ describe('Hooks worker client', () => {
         HooksWorkerClient.prototype.terminateHandler.restore();
       });
 
-      it('should spawn the server process with command "dredd-hooks-ruby"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "dredd-hooks-ruby"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-ruby');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              'dredd-hooks-ruby',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.rb');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'somefile.rb',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=ruby option is given and the worker is not installed', () => {
@@ -235,12 +290,12 @@ describe('Hooks worker client', () => {
 
       afterEach(() => whichStub.which.restore());
 
-
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'gem install dredd_hooks');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(err.message, 'gem install dredd_hooks');
+          done();
+        }));
     });
 
     describe('when --language=python option is given and the worker is installed', () => {
@@ -258,7 +313,9 @@ describe('Hooks worker client', () => {
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -270,26 +327,34 @@ describe('Hooks worker client', () => {
         HooksWorkerClient.prototype.terminateHandler.restore();
       });
 
-      it('should spawn the server process with command "dredd-hooks-python"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "dredd-hooks-python"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-python');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              'dredd-hooks-python',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'somefile.py',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=python option is given and the worker is not installed', () => {
@@ -304,11 +369,12 @@ describe('Hooks worker client', () => {
 
       afterEach(() => whichStub.which.restore());
 
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'pip install dredd_hooks');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(err.message, 'pip install dredd_hooks');
+          done();
+        }));
     });
 
     describe('when --language=php option is given and the worker is installed', () => {
@@ -326,7 +392,9 @@ describe('Hooks worker client', () => {
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -338,26 +406,34 @@ describe('Hooks worker client', () => {
         HooksWorkerClient.prototype.terminateHandler.restore();
       });
 
-      it('should spawn the server process with command "dredd-hooks-php"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "dredd-hooks-php"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-php');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              'dredd-hooks-php',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'somefile.py',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=php option is given and the worker is not installed', () => {
@@ -372,11 +448,15 @@ describe('Hooks worker client', () => {
 
       afterEach(() => whichStub.which.restore());
 
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'composer require ddelnano/dredd-hooks-php --dev');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(
+            err.message,
+            'composer require ddelnano/dredd-hooks-php --dev',
+          );
+          done();
+        }));
     });
 
     describe('when --language=go option is given and the worker is not installed', () => {
@@ -401,11 +481,15 @@ describe('Hooks worker client', () => {
         process.env.GOPATH = goPath;
       });
 
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'go get github.com/snikch/goodman/cmd/goodman');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(
+            err.message,
+            'go get github.com/snikch/goodman/cmd/goodman',
+          );
+          done();
+        }));
     });
 
     describe('when --language=go option is given and the worker is installed', () => {
@@ -432,7 +516,9 @@ describe('Hooks worker client', () => {
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
 
-        return sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        return sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -446,26 +532,34 @@ describe('Hooks worker client', () => {
         process.env.GOPATH = goPath;
       });
 
-      it('should spawn the server process with command "$GOBIN/goodman"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "$GOBIN/goodman"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], path.join(dummyPath, 'goodman'));
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              path.join(dummyPath, 'goodman'),
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'gobinary');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'gobinary',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=rust option is given and the worker is not installed', () => {
@@ -479,11 +573,12 @@ describe('Hooks worker client', () => {
       });
       afterEach(() => whichStub.which.restore());
 
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'cargo install dredd-hooks');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(err.message, 'cargo install dredd-hooks');
+          done();
+        }));
     });
 
     describe('when --language=rust option is given and the worker is installed', () => {
@@ -501,7 +596,9 @@ describe('Hooks worker client', () => {
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -513,26 +610,34 @@ describe('Hooks worker client', () => {
         HooksWorkerClient.prototype.terminateHandler.restore();
       });
 
-      it('should spawn the server process with command "dredd-hooks-rust"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "dredd-hooks-rust"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-rust');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              'dredd-hooks-rust',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'rustbinary');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'rustbinary',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=perl option is given and the worker is installed', () => {
@@ -550,7 +655,9 @@ describe('Hooks worker client', () => {
         };
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
       });
 
       afterEach(() => {
@@ -562,26 +669,34 @@ describe('Hooks worker client', () => {
         HooksWorkerClient.prototype.terminateHandler.restore();
       });
 
-      it('should spawn the server process with command "dredd-hooks-perl"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "dredd-hooks-perl"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], 'dredd-hooks-perl');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              'dredd-hooks-perl',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'somefile.py');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'somefile.py',
+            );
+            done();
+          });
+        }));
     });
 
     describe('when --language=perl option is given and the worker is not installed', () => {
@@ -596,11 +711,12 @@ describe('Hooks worker client', () => {
 
       afterEach(() => whichStub.which.restore());
 
-      it('should write a hint how to install', done => loadWorkerClient((err) => {
-        assert.isOk(err);
-        assert.include(err.message, 'cpanm Dredd::Hooks');
-        done();
-      }));
+      it('should write a hint how to install', (done) =>
+        loadWorkerClient((err) => {
+          assert.isOk(err);
+          assert.include(err.message, 'cpanm Dredd::Hooks');
+          done();
+        }));
     });
 
     describe('when --language=./any/other-command is given', () => {
@@ -617,7 +733,9 @@ describe('Hooks worker client', () => {
           hookfiles: 'someotherfile',
         };
 
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
         sinon.stub(whichStub, 'which').callsFake(() => true);
       });
 
@@ -630,26 +748,34 @@ describe('Hooks worker client', () => {
         whichStub.which.restore();
       });
 
-      it('should spawn the server process with command "./my-fancy-command"', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should spawn the server process with command "./my-fancy-command"', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.isTrue(crossSpawnStub.spawn.called);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[0], './my-fancy-command');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.isTrue(crossSpawnStub.spawn.called);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[0],
+              './my-fancy-command',
+            );
+            done();
+          });
+        }));
 
-      it('should pass --hookfiles option as an array of arguments', done => loadWorkerClient((err) => {
-        assert.isUndefined(err);
+      it('should pass --hookfiles option as an array of arguments', (done) =>
+        loadWorkerClient((err) => {
+          assert.isUndefined(err);
 
-        hooksWorkerClient.stop((error) => {
-          assert.isUndefined(error);
-          assert.equal(crossSpawnStub.spawn.getCall(0).args[1][0], 'someotherfile');
-          done();
-        });
-      }));
+          hooksWorkerClient.stop((error) => {
+            assert.isUndefined(error);
+            assert.equal(
+              crossSpawnStub.spawn.getCall(0).args[1][0],
+              'someotherfile',
+            );
+            done();
+          });
+        }));
     });
 
     describe('after loading', () => {
@@ -659,12 +785,15 @@ describe('Hooks worker client', () => {
           hookfiles: 'somefile.rb',
         };
 
-        sinon.stub(HooksWorkerClient.prototype, 'spawnHandler').callsFake(callback => callback());
+        sinon
+          .stub(HooksWorkerClient.prototype, 'spawnHandler')
+          .callsFake((callback) => callback());
 
         sinon.stub(whichStub, 'which').callsFake(() => true);
 
-        sinon.stub(HooksWorkerClient.prototype, 'terminateHandler').callsFake(callback => callback());
-
+        sinon
+          .stub(HooksWorkerClient.prototype, 'terminateHandler')
+          .callsFake((callback) => callback());
 
         loadWorkerClient((err) => {
           assert.isUndefined(err);
@@ -675,7 +804,6 @@ describe('Hooks worker client', () => {
           });
         });
       });
-
 
       afterEach(() => {
         runner.hooks.configuration = undefined;
@@ -734,7 +862,6 @@ describe('Hooks worker client', () => {
 
     afterEach(() => server.close());
 
-
     it('should connect to the server', (done) => {
       runner.hooks.configuration.language = `${COFFEE_BIN} test/fixtures/scripts/exit-0.coffee`;
 
@@ -781,7 +908,7 @@ describe('Hooks worker client', () => {
           });
         }
 
-        afterEach(done => hooksWorkerClient.stop(done));
+        afterEach((done) => hooksWorkerClient.stop(done));
 
         it('should send JSON to the socket ending with delimiter character', (done) => {
           assert.include(receivedData, '\n');
@@ -789,23 +916,23 @@ describe('Hooks worker client', () => {
           done();
         });
 
-
         describe('sent object', () => {
           let receivedObject;
 
-          beforeEach(() => { receivedObject = JSON.parse(receivedData.replace('\n', '')); });
-
-          const keys = [
-            'data',
-            'event',
-            'uuid',
-          ];
-
-          Array.from(keys).forEach((key) => {
-            it(`should contain key ${key}`, () => { assert.property(receivedObject, key); });
+          beforeEach(() => {
+            receivedObject = JSON.parse(receivedData.replace('\n', ''));
           });
 
-          it(`key event should have value ${eventType}`, () => assert.equal(receivedObject.event, eventType));
+          const keys = ['data', 'event', 'uuid'];
+
+          Array.from(keys).forEach((key) => {
+            it(`should contain key ${key}`, () => {
+              assert.property(receivedObject, key);
+            });
+          });
+
+          it(`key event should have value ${eventType}`, () =>
+            assert.equal(receivedObject.event, eventType));
 
           if (eventType.indexOf('All') > -1) {
             it('key data should contain array of transaction objects', () => {
@@ -827,7 +954,10 @@ describe('Hooks worker client', () => {
     let transaction = {
       name: 'API > Hello > World',
       request: {
-        method: 'POST', uri: '/message', headers: {}, body: 'Hello World!',
+        method: 'POST',
+        uri: '/message',
+        headers: {},
+        body: 'Hello World!',
       },
     };
 
@@ -845,12 +975,12 @@ describe('Hooks worker client', () => {
         // as a parameter
         transactionData = clone([transaction]);
         // eslint-disable-next-line
-        getFirstTransaction = transactionData => transactionData[0];
+        getFirstTransaction = (transactionData) => transactionData[0];
       } else {
         // all the other hooks recieve a single transaction as a parameter
         transactionData = clone(transaction);
         // eslint-disable-next-line
-        getFirstTransaction = transactionData => transactionData;
+        getFirstTransaction = (transactionData) => transactionData;
       }
 
       describe(`when '${eventName}' function is triggered and the hooks handler replies`, () => {
@@ -899,7 +1029,9 @@ describe('Hooks worker client', () => {
           // -- 2 --, runs hooks worker client, starts to send transaction(s),
           // thus triggers the 'connection' event above
           loadWorkerClient((err) => {
-            if (err) { return done(err); }
+            if (err) {
+              return done(err);
+            }
             runner.hooks[`${eventName}Hooks`][0](transactionData, () => {});
           });
         });
@@ -917,38 +1049,39 @@ describe('Hooks worker client', () => {
   });
 
   describe("'hooks-worker-*' configuration options", () => {
-    const scenarios = [{
-      property: 'timeout',
-      option: 'hooks-worker-timeout',
-    },
-    {
-      property: 'connectTimeout',
-      option: 'hooks-worker-connect-timeout',
-    },
-    {
-      property: 'connectRetry',
-      option: 'hooks-worker-connect-retry',
-    },
-    {
-      property: 'afterConnectWait',
-      option: 'hooks-worker-after-connect-wait',
-    },
-    {
-      property: 'termTimeout',
-      option: 'hooks-worker-term-timeout',
-    },
-    {
-      property: 'termRetry',
-      option: 'hooks-worker-term-retry',
-    },
-    {
-      property: 'handlerHost',
-      option: 'hooks-worker-handler-host',
-    },
-    {
-      property: 'handlerPort',
-      option: 'hooks-worker-handler-port',
-    },
+    const scenarios = [
+      {
+        property: 'timeout',
+        option: 'hooks-worker-timeout',
+      },
+      {
+        property: 'connectTimeout',
+        option: 'hooks-worker-connect-timeout',
+      },
+      {
+        property: 'connectRetry',
+        option: 'hooks-worker-connect-retry',
+      },
+      {
+        property: 'afterConnectWait',
+        option: 'hooks-worker-after-connect-wait',
+      },
+      {
+        property: 'termTimeout',
+        option: 'hooks-worker-term-timeout',
+      },
+      {
+        property: 'termRetry',
+        option: 'hooks-worker-term-retry',
+      },
+      {
+        property: 'handlerHost',
+        option: 'hooks-worker-handler-host',
+      },
+      {
+        property: 'handlerPort',
+        option: 'hooks-worker-handler-port',
+      },
     ];
 
     Array.from(scenarios).forEach((scenario) => {

--- a/test/unit/addHooks-test.js
+++ b/test/unit/addHooks-test.js
@@ -4,9 +4,7 @@ const { assert } = require('chai');
 const Hooks = require('../../lib/Hooks');
 const addHooks = require('../../lib/addHooks');
 
-
 const WORKING_DIRECTORY = path.join(__dirname, '..', 'fixtures');
-
 
 function createTransactionRunner() {
   return {
@@ -15,7 +13,6 @@ function createTransactionRunner() {
     },
   };
 }
-
 
 describe('addHooks()', () => {
   it('sets transactionRunner.hooks', (done) => {
@@ -74,14 +71,12 @@ describe('addHooks()', () => {
 
   it('sets transactionRunner.hooks.configuation', (done) => {
     const transactionRunner = createTransactionRunner();
-    transactionRunner.configuration.hookfiles = [
-      './hooks.js',
-    ];
+    transactionRunner.configuration.hookfiles = ['./hooks.js'];
 
     addHooks(transactionRunner, [], (err) => {
       assert.deepEqual(
         transactionRunner.hooks.configuration,
-        transactionRunner.configuration
+        transactionRunner.configuration,
       );
       done(err);
     });

--- a/test/unit/annotationToLoggerInfo-test.js
+++ b/test/unit/annotationToLoggerInfo-test.js
@@ -2,7 +2,6 @@ const { assert } = require('chai');
 
 const annotationToLoggerInfo = require('../../lib/annotationToLoggerInfo');
 
-
 const PARSE_ANNOTATION_FIXTURE = {
   type: 'error',
   message: 'Ouch!',
@@ -14,9 +13,12 @@ const COMPILE_ANNOTATION_FIXTURE = {
   type: 'error',
   message: 'Ouch!',
   component: 'uriTemplateExpansion',
-  origin: { apiName: 'Broken API', resourceName: 'Things', actionName: 'Retrieve Things' },
+  origin: {
+    apiName: 'Broken API',
+    resourceName: 'Things',
+    actionName: 'Retrieve Things',
+  },
 };
-
 
 describe('annotationToLoggerInfo()', () => {
   describe('annotation.type', () => {
@@ -35,10 +37,14 @@ describe('annotationToLoggerInfo()', () => {
       assert.equal(loggerInfo.level, 'warn');
     });
     it('throws for invalid annotation type', () => {
-      assert.throws(() => annotationToLoggerInfo('apiary.apib', {
-        ...PARSE_ANNOTATION_FIXTURE,
-        type: 'gargamel',
-      }), 'gargamel');
+      assert.throws(
+        () =>
+          annotationToLoggerInfo('apiary.apib', {
+            ...PARSE_ANNOTATION_FIXTURE,
+            type: 'gargamel',
+          }),
+        'gargamel',
+      );
     });
     it('propagates the type to the message for parse annotation', () => {
       const loggerInfo = annotationToLoggerInfo('apiary.apib', {
@@ -69,14 +75,20 @@ describe('annotationToLoggerInfo()', () => {
         ...COMPILE_ANNOTATION_FIXTURE,
         component: 'parametersValidation',
       });
-      assert.match(loggerInfo.message, /^API description URI parameters validation error/);
+      assert.match(
+        loggerInfo.message,
+        /^API description URI parameters validation error/,
+      );
     });
     it('formats uriTemplateExpansion', () => {
       const loggerInfo = annotationToLoggerInfo('apiary.apib', {
         ...COMPILE_ANNOTATION_FIXTURE,
         component: 'uriTemplateExpansion',
       });
-      assert.match(loggerInfo.message, /^API description URI template expansion error/);
+      assert.match(
+        loggerInfo.message,
+        /^API description URI template expansion error/,
+      );
     });
     it('formats unexpected component with a generic name', () => {
       const loggerInfo = annotationToLoggerInfo('apiary.apib', {
@@ -95,7 +107,7 @@ describe('annotationToLoggerInfo()', () => {
       });
       assert.include(
         loggerInfo.message,
-        'error in apiary.apib (Broken API > Things > Retrieve Things): Ouch!'
+        'error in apiary.apib (Broken API > Things > Retrieve Things): Ouch!',
       );
     });
   });
@@ -108,7 +120,7 @@ describe('annotationToLoggerInfo()', () => {
       });
       assert.include(
         loggerInfo.message,
-        'error in apiary.apib:1 (from line 1 column 2 to line 3 column 4): Ouch!'
+        'error in apiary.apib:1 (from line 1 column 2 to line 3 column 4): Ouch!',
       );
     });
     it('formats location without end line if it is the same as the start line', () => {
@@ -118,7 +130,7 @@ describe('annotationToLoggerInfo()', () => {
       });
       assert.include(
         loggerInfo.message,
-        'error in apiary.apib:1 (from line 1 column 2 to column 4): Ouch!'
+        'error in apiary.apib:1 (from line 1 column 2 to column 4): Ouch!',
       );
     });
     it('formats location without range if the start and the end are the same', () => {
@@ -128,7 +140,7 @@ describe('annotationToLoggerInfo()', () => {
       });
       assert.include(
         loggerInfo.message,
-        'error in apiary.apib:1 (line 1 column 2): Ouch!'
+        'error in apiary.apib:1 (line 1 column 2): Ouch!',
       );
     });
     it('formats missing location', () => {
@@ -136,10 +148,7 @@ describe('annotationToLoggerInfo()', () => {
         ...PARSE_ANNOTATION_FIXTURE,
         location: null,
       });
-      assert.include(
-        loggerInfo.message,
-        'error in apiary.apib: Ouch!'
-      );
+      assert.include(loggerInfo.message, 'error in apiary.apib: Ouch!');
     });
   });
 });

--- a/test/unit/configUtils-test.js
+++ b/test/unit/configUtils-test.js
@@ -58,7 +58,9 @@ const argvData = {
 
 describe('configUtils', () => {
   let argv = null;
-  beforeEach(() => { argv = clone(argvData); });
+  beforeEach(() => {
+    argv = clone(argvData);
+  });
 
   it('it should export an object', () => assert.isObject(configUtils));
 
@@ -73,7 +75,8 @@ describe('configUtils', () => {
       yamlStub.dump.restore();
     });
 
-    it('should be a defined function', () => assert.isFunction(configUtils.save));
+    it('should be a defined function', () =>
+      assert.isFunction(configUtils.save));
 
     it('should add endpoint key', () => {
       configUtils.save(argv);
@@ -123,20 +126,22 @@ describe('configUtils', () => {
       assert.isOk(yamlStub.dump.called);
     });
 
-    describe('when path is not given', () => it('should save to ./dredd.yml', () => {
-      configUtils.save(argv);
-      const call = fsStub.writeFileSync.getCall(0);
-      const { args } = call;
-      assert.include(args[0], 'dredd.yml');
-    }));
+    describe('when path is not given', () =>
+      it('should save to ./dredd.yml', () => {
+        configUtils.save(argv);
+        const call = fsStub.writeFileSync.getCall(0);
+        const { args } = call;
+        assert.include(args[0], 'dredd.yml');
+      }));
 
-    describe('when path is given', () => it('should save to that path', () => {
-      const path = 'some-other-location.yml ';
-      configUtils.save(argv, path);
-      const call = fsStub.writeFileSync.getCall(0);
-      const { args } = call;
-      assert.include(args[0], path);
-    }));
+    describe('when path is given', () =>
+      it('should save to that path', () => {
+        const path = 'some-other-location.yml ';
+        configUtils.save(argv, path);
+        const call = fsStub.writeFileSync.getCall(0);
+        const { args } = call;
+        assert.include(args[0], path);
+      }));
   });
 
   describe('load(path)', () => {
@@ -165,26 +170,31 @@ blueprint: blueprint
 endpoint: endpoint\
 `;
 
-    beforeEach(() => sinon.stub(fsStub, 'readFileSync').callsFake(() => yamlData));
+    beforeEach(() =>
+      sinon.stub(fsStub, 'readFileSync').callsFake(() => yamlData),
+    );
 
     afterEach(() => fsStub.readFileSync.restore());
 
-    it('should be a defined function', () => assert.isFunction(configUtils.load));
+    it('should be a defined function', () =>
+      assert.isFunction(configUtils.load));
 
-    describe('if no path is given', () => it('should load from ./dredd.yml', () => {
-      configUtils.load();
-      const call = fsStub.readFileSync.getCall(0);
-      const { args } = call;
-      assert.include(args[0], 'dredd.yml');
-    }));
+    describe('if no path is given', () =>
+      it('should load from ./dredd.yml', () => {
+        configUtils.load();
+        const call = fsStub.readFileSync.getCall(0);
+        const { args } = call;
+        assert.include(args[0], 'dredd.yml');
+      }));
 
-    describe('when path is given', () => it('should load from that path', () => {
-      const path = 'some-other-location.yml ';
-      configUtils.load(path);
-      const call = fsStub.readFileSync.getCall(0);
-      const { args } = call;
-      assert.include(args[0], path);
-    }));
+    describe('when path is given', () =>
+      it('should load from that path', () => {
+        const path = 'some-other-location.yml ';
+        configUtils.load(path);
+        const call = fsStub.readFileSync.getCall(0);
+        const { args } = call;
+        assert.include(args[0], path);
+      }));
 
     it('should move blueprint and enpoint to an array under _ key', () => {
       const output = configUtils.load();

--- a/test/unit/configuration-test.js
+++ b/test/unit/configuration-test.js
@@ -8,7 +8,9 @@ const logger = require('../../lib/logger');
 const reporterOutputLogger = require('../../lib/reporters/reporterOutputLogger');
 
 const defaultLoggerConsole = clone(logger.transports.console);
-const defaultReporterOutputLoggerConsole = clone(reporterOutputLogger.transports.console);
+const defaultReporterOutputLoggerConsole = clone(
+  reporterOutputLogger.transports.console,
+);
 
 function resetLoggerConsoles() {
   logger.transports.console = defaultLoggerConsole;
@@ -167,7 +169,6 @@ describe('configuration.applyLoggingOptions()', () => {
     });
   });
 });
-
 
 describe('configuration', () => {
   describe("with -c set to string 'true'", () => {
@@ -452,10 +453,12 @@ describe('configuration', () => {
   describe('with both data and apiDescriptions set', () => {
     const config = {
       data: { 'filename.api': 'FORMAT: 1A\n# Sample API v1\n' },
-      apiDescriptions: [{
-        location: 'configuration.apiDescriptions[0]',
-        content: 'FORMAT: 1A\n# Sample API v2\n',
-      }],
+      apiDescriptions: [
+        {
+          location: 'configuration.apiDescriptions[0]',
+          content: 'FORMAT: 1A\n# Sample API v2\n',
+        },
+      ],
     };
     const { warnings, errors } = validateConfig(config);
 

--- a/test/unit/configuration/normalizeConfig-test.js
+++ b/test/unit/configuration/normalizeConfig-test.js
@@ -23,7 +23,15 @@ describe('normalizeConfig()', () => {
         sandbox: true,
       });
 
-      ['q', 'silent', 't', 'timestamp', 'blueprintPath', 'b', 'sandbox'].forEach((optionName) => {
+      [
+        'q',
+        'silent',
+        't',
+        'timestamp',
+        'blueprintPath',
+        'b',
+        'sandbox',
+      ].forEach((optionName) => {
         it(`removes "${optionName}"`, () => {
           assert.notProperty(result, optionName);
         });
@@ -126,37 +134,77 @@ describe('normalizeConfig()', () => {
     describe('level', () => {
       describe('coerces to "debug"', () => {
         it('when given "silly"', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'silly' }), 'loglevel', 'debug');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'silly' }),
+            'loglevel',
+            'debug',
+          );
         });
 
         it('when given "verbose"', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'verbose' }), 'loglevel', 'debug');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'verbose' }),
+            'loglevel',
+            'debug',
+          );
         });
 
         it('when given "debug"', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'debug' }), 'loglevel', 'debug');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'debug' }),
+            'loglevel',
+            'debug',
+          );
         });
       });
 
       describe('coerces to "error"', () => {
         it('when given "error"', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'error' }), 'loglevel', 'error');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'error' }),
+            'loglevel',
+            'error',
+          );
         });
       });
 
       describe('coerces to "silent"', () => {
         it('when given "silent"', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'silent' }), 'loglevel', 'silent');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'silent' }),
+            'loglevel',
+            'silent',
+          );
         });
       });
 
       describe('coerces to "warn"', () => {
         it('when given falsy value', () => {
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'warn' }), 'loglevel', 'warn');
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: 'foobar' }), 'loglevel', 'warn');
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: false }), 'loglevel', 'warn');
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: undefined }), 'loglevel', 'warn');
-          assert.propertyVal(coerceDeprecatedLevelOption({ l: null }), 'loglevel', 'warn');
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'warn' }),
+            'loglevel',
+            'warn',
+          );
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: 'foobar' }),
+            'loglevel',
+            'warn',
+          );
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: false }),
+            'loglevel',
+            'warn',
+          );
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: undefined }),
+            'loglevel',
+            'warn',
+          );
+          assert.propertyVal(
+            coerceDeprecatedLevelOption({ l: null }),
+            'loglevel',
+            'warn',
+          );
         });
       });
     });

--- a/test/unit/configureReporters-test.js
+++ b/test/unit/configureReporters-test.js
@@ -11,13 +11,21 @@ const proxyquire = require('proxyquire').noCallThru();
 
 const loggerStub = require('../../lib/logger');
 const BaseReporterStub = sinon.spy(require('../../lib/reporters/BaseReporter'));
-const XUnitReporterStub = sinon.spy(require('../../lib/reporters/XUnitReporter'));
+const XUnitReporterStub = sinon.spy(
+  require('../../lib/reporters/XUnitReporter'),
+);
 const CliReporterStub = sinon.spy(require('../../lib/reporters/CLIReporter'));
 const DotReporterStub = sinon.spy(require('../../lib/reporters/DotReporter'));
-const NyanCatReporterStub = sinon.spy(require('../../lib/reporters/NyanReporter'));
+const NyanCatReporterStub = sinon.spy(
+  require('../../lib/reporters/NyanReporter'),
+);
 const HtmlReporterStub = sinon.spy(require('../../lib/reporters/HTMLReporter'));
-const MarkdownReporterStub = sinon.spy(require('../../lib/reporters/MarkdownReporter'));
-const ApiaryReporterStub = sinon.spy(require('../../lib/reporters/ApiaryReporter'));
+const MarkdownReporterStub = sinon.spy(
+  require('../../lib/reporters/MarkdownReporter'),
+);
+const ApiaryReporterStub = sinon.spy(
+  require('../../lib/reporters/ApiaryReporter'),
+);
 
 const emitterStub = new EventEmitter();
 
@@ -45,7 +53,6 @@ function resetStubs() {
   return ApiaryReporterStub.resetHistory();
 }
 
-
 describe('configureReporters()', () => {
   const configuration = {
     emitter: emitterStub,
@@ -54,9 +61,9 @@ describe('configureReporters()', () => {
     'inline-errors': false,
   };
 
-  before(() => loggerStub.transports.console.silent = true);
+  before(() => (loggerStub.transports.console.silent = true));
 
-  after(() => loggerStub.transports.console.silent = false);
+  after(() => (loggerStub.transports.console.silent = false));
 
   describe('when there are no reporters', () => {
     beforeEach(() => resetStubs());
@@ -68,9 +75,9 @@ describe('configureReporters()', () => {
     });
 
     describe('when silent', () => {
-      before(() => configuration.loglevel = 'silent');
+      before(() => (configuration.loglevel = 'silent'));
 
-      after(() => configuration.loglevel = 'silent');
+      after(() => (configuration.loglevel = 'silent'));
 
       beforeEach(() => resetStubs());
 
@@ -83,9 +90,9 @@ describe('configureReporters()', () => {
   });
 
   describe('when there are only cli-based reporters', () => {
-    before(() => configuration.reporter = ['dot', 'nyan']);
+    before(() => (configuration.reporter = ['dot', 'nyan']));
 
-    after(() => configuration.reporter = []);
+    after(() => (configuration.reporter = []));
 
     beforeEach(() => resetStubs());
 
@@ -102,11 +109,10 @@ describe('configureReporters()', () => {
     });
   });
 
-
   describe('when there are only file-based reporters', () => {
-    before(() => configuration.reporter = ['xunit', 'markdown']);
+    before(() => (configuration.reporter = ['xunit', 'markdown']));
 
-    after(() => configuration.reporter = []);
+    after(() => (configuration.reporter = []));
 
     beforeEach(() => resetStubs());
 
@@ -117,40 +123,64 @@ describe('configureReporters()', () => {
     });
 
     describe('when the number of outputs is greater than or equals the number of reporters', () => {
-      before(() => configuration.output = ['file1', 'file2', 'file3']);
+      before(() => (configuration.output = ['file1', 'file2', 'file3']));
 
-      after(() => configuration.output = []);
+      after(() => (configuration.output = []));
 
       beforeEach(() => resetStubs());
 
       it('should use the output paths in the order provided', (done) => {
         configureReporters(configuration, {}, () => {});
-        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file2'));
+        assert.isOk(
+          XUnitReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file1',
+          ),
+        );
+        assert.isOk(
+          MarkdownReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file2',
+          ),
+        );
         return done();
       });
     });
 
     describe('when the number of outputs is less than the number of reporters', () => {
-      before(() => configuration.output = ['file1']);
+      before(() => (configuration.output = ['file1']));
 
-      after(() => configuration.output = []);
+      after(() => (configuration.output = []));
 
       beforeEach(() => resetStubs());
 
       it('should use the default output paths for the additional reporters', (done) => {
         configureReporters(configuration, {}, () => {});
-        assert.isOk(XUnitReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, undefined));
+        assert.isOk(
+          XUnitReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file1',
+          ),
+        );
+        assert.isOk(
+          MarkdownReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            undefined,
+          ),
+        );
         return done();
       });
     });
   });
 
   describe('when there are both cli-based and file-based reporters', () => {
-    before(() => configuration.reporter = ['nyan', 'markdown', 'html']);
+    before(() => (configuration.reporter = ['nyan', 'markdown', 'html']));
 
-    after(() => configuration.reporter = []);
+    after(() => (configuration.reporter = []));
 
     beforeEach(() => resetStubs());
 
@@ -168,31 +198,55 @@ describe('configureReporters()', () => {
     });
 
     describe('when the number of outputs is greather than or equals the number of file-based reporters', () => {
-      before(() => configuration.output = ['file1', 'file2']);
+      before(() => (configuration.output = ['file1', 'file2']));
 
-      after(() => configuration.output = []);
+      after(() => (configuration.output = []));
 
       beforeEach(() => resetStubs());
 
       it('should use the output paths in the order provided', (done) => {
         configureReporters(configuration, {}, () => {});
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
-        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file2'));
+        assert.isOk(
+          MarkdownReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file1',
+          ),
+        );
+        assert.isOk(
+          HtmlReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file2',
+          ),
+        );
         return done();
       });
     });
 
     describe('when the number of outputs is less than the number of file-based reporters', () => {
-      before(() => configuration.output = ['file1']);
+      before(() => (configuration.output = ['file1']));
 
-      after(() => configuration.output = []);
+      after(() => (configuration.output = []));
 
       beforeEach(() => resetStubs());
 
       it('should use the default output paths for the additional reporters', (done) => {
         configureReporters(configuration, {}, () => {});
-        assert.isOk(MarkdownReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, 'file1'));
-        assert.isOk(HtmlReporterStub.calledWith(emitterStub, { fileBasedReporters: 2 }, undefined));
+        assert.isOk(
+          MarkdownReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            'file1',
+          ),
+        );
+        assert.isOk(
+          HtmlReporterStub.calledWith(
+            emitterStub,
+            { fileBasedReporters: 2 },
+            undefined,
+          ),
+        );
         return done();
       });
     });

--- a/test/unit/getGoBinary-test.js
+++ b/test/unit/getGoBinary-test.js
@@ -32,7 +32,11 @@ describe('getGoBinary()', () => {
       });
     });
 
-    it('resolves as $GOBIN', () => assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gobin', 'path')]));
+    it('resolves as $GOBIN', () =>
+      assert.deepEqual(callbackArgs, [
+        null,
+        path.join('dummy', 'gobin', 'path'),
+      ]));
   });
 
   describe('when $GOPATH is set', () => {
@@ -46,7 +50,11 @@ describe('getGoBinary()', () => {
       });
     });
 
-    it('resolves as $GOPATH + /bin', () => assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gopath', 'path', 'bin')]));
+    it('resolves as $GOPATH + /bin', () =>
+      assert.deepEqual(callbackArgs, [
+        null,
+        path.join('dummy', 'gopath', 'path', 'bin'),
+      ]));
   });
 
   describe('when both $GOBIN and $GOPATH are set', () => {
@@ -61,14 +69,22 @@ describe('getGoBinary()', () => {
       });
     });
 
-    it('resolves as $GOBIN', () => assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gobin', 'path')]));
+    it('resolves as $GOBIN', () =>
+      assert.deepEqual(callbackArgs, [
+        null,
+        path.join('dummy', 'gobin', 'path'),
+      ]));
   });
 
   describe('when neither $GOBIN nor $GOPATH are set', () => {
     let callbackArgs;
 
     beforeEach((done) => {
-      sinon.stub(childProcess, 'exec').callsFake((command, callback) => callback(null, path.join('dummy', 'gopath', 'path')));
+      sinon
+        .stub(childProcess, 'exec')
+        .callsFake((command, callback) =>
+          callback(null, path.join('dummy', 'gopath', 'path')),
+        );
       getGoBinary((...args) => {
         callbackArgs = args;
         done();
@@ -76,15 +92,21 @@ describe('getGoBinary()', () => {
     });
     after(() => childProcess.exec.restore());
 
-    it('calls \'go env GOPATH\' + /bin', () => assert.deepEqual(callbackArgs, [null, path.join('dummy', 'gopath', 'path', 'bin')]));
+    it("calls 'go env GOPATH' + /bin", () =>
+      assert.deepEqual(callbackArgs, [
+        null,
+        path.join('dummy', 'gopath', 'path', 'bin'),
+      ]));
   });
 
-  describe('when \'go env GOPATH\' fails', () => {
+  describe("when 'go env GOPATH' fails", () => {
     const error = new Error('Ouch!');
     let callbackArgs;
 
     beforeEach((done) => {
-      sinon.stub(childProcess, 'exec').callsFake((command, callback) => callback(error));
+      sinon
+        .stub(childProcess, 'exec')
+        .callsFake((command, callback) => callback(error));
       getGoBinary((...args) => {
         callbackArgs = args;
         done();

--- a/test/unit/getProxySettings-test.js
+++ b/test/unit/getProxySettings-test.js
@@ -2,58 +2,61 @@ const { assert } = require('chai');
 
 const getProxySettings = require('../../lib/getProxySettings');
 
-
 describe('getProxySettings()', () => {
   it('detects HTTP_PROXY', () => {
-    assert.deepEqual(getProxySettings({
-      SHELL: '/bin/bash',
-      USER: 'honza',
-      HTTP_PROXY: 'http://proxy.example.com:8080',
-    }), [
-      'HTTP_PROXY=http://proxy.example.com:8080',
-    ]);
+    assert.deepEqual(
+      getProxySettings({
+        SHELL: '/bin/bash',
+        USER: 'honza',
+        HTTP_PROXY: 'http://proxy.example.com:8080',
+      }),
+      ['HTTP_PROXY=http://proxy.example.com:8080'],
+    );
   });
 
   it('detects HTTPS_PROXY', () => {
-    assert.deepEqual(getProxySettings({
-      SHELL: '/bin/bash',
-      USER: 'honza',
-      HTTPS_PROXY: 'https://proxy.example.com:8080',
-    }), [
-      'HTTPS_PROXY=https://proxy.example.com:8080',
-    ]);
+    assert.deepEqual(
+      getProxySettings({
+        SHELL: '/bin/bash',
+        USER: 'honza',
+        HTTPS_PROXY: 'https://proxy.example.com:8080',
+      }),
+      ['HTTPS_PROXY=https://proxy.example.com:8080'],
+    );
   });
 
   it('detects NO_PROXY', () => {
-    assert.deepEqual(getProxySettings({
-      SHELL: '/bin/bash',
-      USER: 'honza',
-      NO_PROXY: '*',
-    }), [
-      'NO_PROXY=*',
-    ]);
+    assert.deepEqual(
+      getProxySettings({
+        SHELL: '/bin/bash',
+        USER: 'honza',
+        NO_PROXY: '*',
+      }),
+      ['NO_PROXY=*'],
+    );
   });
 
   it('detects both lower and upper case', () => {
-    assert.deepEqual(getProxySettings({
-      SHELL: '/bin/bash',
-      USER: 'honza',
-      http_proxy: 'http://proxy.example.com:8080',
-      NO_PROXY: '*',
-    }), [
-      'http_proxy=http://proxy.example.com:8080',
-      'NO_PROXY=*',
-    ]);
+    assert.deepEqual(
+      getProxySettings({
+        SHELL: '/bin/bash',
+        USER: 'honza',
+        http_proxy: 'http://proxy.example.com:8080',
+        NO_PROXY: '*',
+      }),
+      ['http_proxy=http://proxy.example.com:8080', 'NO_PROXY=*'],
+    );
   });
 
   it('skips environment variables set to empty strings', () => {
-    assert.deepEqual(getProxySettings({
-      SHELL: '/bin/bash',
-      USER: 'honza',
-      http_proxy: 'http://proxy.example.com:8080',
-      NO_PROXY: '',
-    }), [
-      'http_proxy=http://proxy.example.com:8080',
-    ]);
+    assert.deepEqual(
+      getProxySettings({
+        SHELL: '/bin/bash',
+        USER: 'honza',
+        http_proxy: 'http://proxy.example.com:8080',
+        NO_PROXY: '',
+      }),
+      ['http_proxy=http://proxy.example.com:8080'],
+    );
   });
 });

--- a/test/unit/hooksLog-test.js
+++ b/test/unit/hooksLog-test.js
@@ -8,12 +8,10 @@ const hooksLog = require('../../lib/hooksLog');
 const reporterOutputLoggerStub = require('../../lib/reporters/reporterOutputLogger');
 
 describe('hooksLog()', () => {
-  const exampleLogs = [
-    { content: 'some text' },
-  ];
+  const exampleLogs = [{ content: 'some text' }];
 
   before(() => {
-    sinon.stub(reporterOutputLoggerStub, 'hook').callsFake(() => { });
+    sinon.stub(reporterOutputLoggerStub, 'hook').callsFake(() => {});
   });
 
   after(() => {
@@ -21,9 +19,13 @@ describe('hooksLog()', () => {
   });
 
   it('should print using util.format only when content is an object type', () => {
-    const data = hooksLog(clone(exampleLogs), reporterOutputLoggerStub, { hello: 'object world' });
+    const data = hooksLog(clone(exampleLogs), reporterOutputLoggerStub, {
+      hello: 'object world',
+    });
     assert.equal(reporterOutputLoggerStub.hook.callCount, 1);
-    assert.deepEqual(reporterOutputLoggerStub.hook.getCall(0).args[0], { hello: 'object world' });
+    assert.deepEqual(reporterOutputLoggerStub.hook.getCall(0).args[0], {
+      hello: 'object world',
+    });
     assert.lengthOf(data, 2);
     assert.isObject(data[1]);
     assert.property(data[1], 'content');
@@ -39,7 +41,11 @@ describe('hooksLog()', () => {
 
     it('should push message to the passed array and return the new array', () => {
       const originLogs = [];
-      const data = hooksLog(originLogs, reporterOutputLoggerStub, 'one message');
+      const data = hooksLog(
+        originLogs,
+        reporterOutputLoggerStub,
+        'one message',
+      );
       assert.isArray(data);
       assert.lengthOf(data, 1);
       assert.strictEqual(data, originLogs);
@@ -49,7 +55,11 @@ describe('hooksLog()', () => {
 
     it('should push message to undefined logs and return new array instead', () => {
       const originLogs = undefined;
-      const data = hooksLog(originLogs, reporterOutputLoggerStub, 'another message');
+      const data = hooksLog(
+        originLogs,
+        reporterOutputLoggerStub,
+        'another message',
+      );
       assert.isArray(data);
       assert.lengthOf(data, 1);
       assert.isUndefined(originLogs);
@@ -59,7 +69,11 @@ describe('hooksLog()', () => {
 
     it('should append message to an existing logs array', () => {
       const originLogs = clone(exampleLogs);
-      const data = hooksLog(originLogs, reporterOutputLoggerStub, 'some other idea');
+      const data = hooksLog(
+        originLogs,
+        reporterOutputLoggerStub,
+        'some other idea',
+      );
       assert.isArray(data);
       assert.lengthOf(data, 2);
       assert.deepEqual(data, originLogs);
@@ -73,7 +87,10 @@ describe('hooksLog()', () => {
       assert.isTrue(reporterOutputLoggerStub.hook.called);
       assert.equal(reporterOutputLoggerStub.hook.callCount, 1);
 
-      assert.equal(reporterOutputLoggerStub.hook.getCall(0).args[0], 'there is a log');
+      assert.equal(
+        reporterOutputLoggerStub.hook.getCall(0).args[0],
+        'there is a log',
+      );
     });
   });
 });

--- a/test/unit/init/applyAnswers-test.js
+++ b/test/unit/init/applyAnswers-test.js
@@ -3,11 +3,9 @@ const sinon = require('sinon');
 
 const { _applyAnswers: applyAnswers } = require('../../../lib/init');
 
-
 function createConfig() {
   return { _: [], custom: {} };
 }
-
 
 describe('init._applyAnswers()', () => {
   const ci = {
@@ -17,7 +15,7 @@ describe('init._applyAnswers()', () => {
     wercker: sinon.spy(),
   };
 
-  beforeEach(() => Object.keys(ci).forEach(name => ci[name].resetHistory()));
+  beforeEach(() => Object.keys(ci).forEach((name) => ci[name].resetHistory()));
 
   it('applies the API description and the API host as positional CLI arguments', () => {
     const config = applyAnswers(createConfig(), {
@@ -46,7 +44,7 @@ describe('init._applyAnswers()', () => {
     const config = applyAnswers(createConfig(), {});
     assert.isUndefined(config.reporter);
   });
-  it('sets the reporter to \'apiary\' if asked', () => {
+  it("sets the reporter to 'apiary' if asked", () => {
     const config = applyAnswers(createConfig(), { apiary: true });
     assert.equal(config.reporter, 'apiary');
   });
@@ -65,27 +63,37 @@ describe('init._applyAnswers()', () => {
   it('creates selected CI configuration if asked', () => {
     applyAnswers(createConfig(), { createCI: 'wercker' }, { ci });
     assert.isTrue(ci.wercker.calledOnce);
-    assert.isFalse(ci.appveyor.called || ci.circleci.called || ci.travisci.called);
+    assert.isFalse(
+      ci.appveyor.called || ci.circleci.called || ci.travisci.called,
+    );
   });
   it('updates AppVeyor if asked', () => {
     applyAnswers(createConfig(), { appveyor: true }, { ci });
     assert.isTrue(ci.appveyor.calledOnce);
-    assert.isFalse(ci.circleci.called || ci.travisci.called || ci.wercker.called);
+    assert.isFalse(
+      ci.circleci.called || ci.travisci.called || ci.wercker.called,
+    );
   });
   it('updates CircleCI if asked', () => {
     applyAnswers(createConfig(), { circleci: true }, { ci });
     assert.isTrue(ci.circleci.calledOnce);
-    assert.isFalse(ci.appveyor.called || ci.travisci.called || ci.wercker.called);
+    assert.isFalse(
+      ci.appveyor.called || ci.travisci.called || ci.wercker.called,
+    );
   });
   it('updates Travis CI if asked', () => {
     applyAnswers(createConfig(), { travisci: true }, { ci });
     assert.isTrue(ci.travisci.calledOnce);
-    assert.isFalse(ci.appveyor.called || ci.circleci.called || ci.wercker.called);
+    assert.isFalse(
+      ci.appveyor.called || ci.circleci.called || ci.wercker.called,
+    );
   });
   it('updates Wercker if asked', () => {
     applyAnswers(createConfig(), { wercker: true }, { ci });
     assert.isTrue(ci.wercker.calledOnce);
-    assert.isFalse(ci.appveyor.called || ci.circleci.called || ci.travisci.called);
+    assert.isFalse(
+      ci.appveyor.called || ci.circleci.called || ci.travisci.called,
+    );
   });
   it('updates multiple CIs if asked', () => {
     applyAnswers(createConfig(), { wercker: true, circleci: true }, { ci });

--- a/test/unit/init/detectApiDescription-test.js
+++ b/test/unit/init/detectApiDescription-test.js
@@ -1,45 +1,55 @@
 const { assert } = require('chai');
 
-const { _detectApiDescription: detectApiDescription } = require('../../../lib/init');
-
+const {
+  _detectApiDescription: detectApiDescription,
+} = require('../../../lib/init');
 
 describe('init._detectApiDescription()', () => {
-  it('defaults to API Blueprint on empty array', () => assert.equal(detectApiDescription([]), 'apiary.apib'));
+  it('defaults to API Blueprint on empty array', () =>
+    assert.equal(detectApiDescription([]), 'apiary.apib'));
 
-  it('defaults to API Blueprint on arbitrary files', () => assert.equal(detectApiDescription(['foo', 'bar']), 'apiary.apib'));
+  it('defaults to API Blueprint on arbitrary files', () =>
+    assert.equal(detectApiDescription(['foo', 'bar']), 'apiary.apib'));
 
-  it('detects the first API Blueprint file', () => assert.equal(
-    detectApiDescription(['foo', 'boo.apib', 'bar', 'moo.apib']),
-    'boo.apib'
-  ));
+  it('detects the first API Blueprint file', () =>
+    assert.equal(
+      detectApiDescription(['foo', 'boo.apib', 'bar', 'moo.apib']),
+      'boo.apib',
+    ));
 
-  it('detects the first .yml file containing \'swagger\' as OpenAPI 2', () => assert.equal(
-    detectApiDescription(['foo', 'this-is-swagger.yml', 'bar']),
-    'this-is-swagger.yml'
-  ));
+  it("detects the first .yml file containing 'swagger' as OpenAPI 2", () =>
+    assert.equal(
+      detectApiDescription(['foo', 'this-is-swagger.yml', 'bar']),
+      'this-is-swagger.yml',
+    ));
 
-  it('detects the first .yaml file containing \'swagger\' as OpenAPI 2', () => assert.equal(
-    detectApiDescription(['foo', 'this-is-swagger.yaml', 'bar']),
-    'this-is-swagger.yaml'
-  ));
+  it("detects the first .yaml file containing 'swagger' as OpenAPI 2", () =>
+    assert.equal(
+      detectApiDescription(['foo', 'this-is-swagger.yaml', 'bar']),
+      'this-is-swagger.yaml',
+    ));
 
-  it('detects the first .yml file containing \'api\' as OpenAPI 2', () => assert.equal(
-    detectApiDescription(['foo', 'openapi.yml', 'bar']),
-    'openapi.yml'
-  ));
+  it("detects the first .yml file containing 'api' as OpenAPI 2", () =>
+    assert.equal(
+      detectApiDescription(['foo', 'openapi.yml', 'bar']),
+      'openapi.yml',
+    ));
 
-  it('detects the first .yaml file containing \'api\' as OpenAPI 2', () => assert.equal(
-    detectApiDescription(['foo', 'openapi.yaml', 'bar']),
-    'openapi.yaml'
-  ));
+  it("detects the first .yaml file containing 'api' as OpenAPI 2", () =>
+    assert.equal(
+      detectApiDescription(['foo', 'openapi.yaml', 'bar']),
+      'openapi.yaml',
+    ));
 
-  it('prefers API Blueprint over OpenAPI 2', () => assert.equal(
-    detectApiDescription(['swagger.yml', 'boo.apib']),
-    'boo.apib'
-  ));
+  it('prefers API Blueprint over OpenAPI 2', () =>
+    assert.equal(
+      detectApiDescription(['swagger.yml', 'boo.apib']),
+      'boo.apib',
+    ));
 
-  it('prefers \'swagger\' over \'api\'', () => assert.equal(
-    detectApiDescription(['api.yml', 'swagger.yml']),
-    'swagger.yml'
-  ));
+  it("prefers 'swagger' over 'api'", () =>
+    assert.equal(
+      detectApiDescription(['api.yml', 'swagger.yml']),
+      'swagger.yml',
+    ));
 });

--- a/test/unit/init/detectCI-test.js
+++ b/test/unit/init/detectCI-test.js
@@ -2,20 +2,24 @@ const { assert } = require('chai');
 
 const { _detectCI: detectCI } = require('../../../lib/init');
 
-
 describe('init._detectCI()', () => {
   it('detects no CI on empty array', () => assert.deepEqual(detectCI([]), []));
 
-  it('detects AppVeyor', () => assert.deepEqual(detectCI(['README', 'appveyor.yml']), ['appveyor']));
+  it('detects AppVeyor', () =>
+    assert.deepEqual(detectCI(['README', 'appveyor.yml']), ['appveyor']));
 
-  it('detects CircleCI', () => assert.deepEqual(detectCI(['README', '.circleci']), ['circleci']));
+  it('detects CircleCI', () =>
+    assert.deepEqual(detectCI(['README', '.circleci']), ['circleci']));
 
-  it('detects Travis CI', () => assert.deepEqual(detectCI(['README', '.travis.yml']), ['travisci']));
+  it('detects Travis CI', () =>
+    assert.deepEqual(detectCI(['README', '.travis.yml']), ['travisci']));
 
-  it('detects Wercker', () => assert.deepEqual(detectCI(['README', 'wercker.yml']), ['wercker']));
+  it('detects Wercker', () =>
+    assert.deepEqual(detectCI(['README', 'wercker.yml']), ['wercker']));
 
-  it('detects multiple CIs', () => assert.deepEqual(
-    detectCI(['README', 'wercker.yml', '.circleci']),
-    ['wercker', 'circleci']
-  ));
+  it('detects multiple CIs', () =>
+    assert.deepEqual(detectCI(['README', 'wercker.yml', '.circleci']), [
+      'wercker',
+      'circleci',
+    ]));
 });

--- a/test/unit/init/detectLanguage-test.js
+++ b/test/unit/init/detectLanguage-test.js
@@ -2,19 +2,23 @@ const { assert } = require('chai');
 
 const { _detectLanguage: detectLanguage } = require('../../../lib/init');
 
-
 describe('init._detectLanguage()', () => {
-  it('defaults to JavaScript', () => assert.equal(detectLanguage([]), 'nodejs'));
+  it('defaults to JavaScript', () =>
+    assert.equal(detectLanguage([]), 'nodejs'));
 
   [
     { name: 'Rust', value: 'rust', file: 'Cargo.toml' },
     { name: 'Go', value: 'go', file: 'foo.go' },
     { name: 'PHP', value: 'php', file: 'composer.json' },
   ].forEach(({ name, value, file }) => {
-    it(`prioritizes ${name} over Python`, () => assert.equal(detectLanguage(['README', 'Pipfile', file]), value));
-    it(`prioritizes ${name} over Ruby`, () => assert.equal(detectLanguage(['README', 'Gemfile', file]), value));
+    it(`prioritizes ${name} over Python`, () =>
+      assert.equal(detectLanguage(['README', 'Pipfile', file]), value));
+    it(`prioritizes ${name} over Ruby`, () =>
+      assert.equal(detectLanguage(['README', 'Gemfile', file]), value));
   });
 
-  it('detects Python', () => assert.equal(detectLanguage(['README', 'Pipfile']), 'python'));
-  it('detects Ruby', () => assert.equal(detectLanguage(['README', 'Gemfile']), 'ruby'));
+  it('detects Python', () =>
+    assert.equal(detectLanguage(['README', 'Pipfile']), 'python'));
+  it('detects Ruby', () =>
+    assert.equal(detectLanguage(['README', 'Gemfile']), 'ruby'));
 });

--- a/test/unit/init/detectServer-test.js
+++ b/test/unit/init/detectServer-test.js
@@ -2,17 +2,19 @@ const { assert } = require('chai');
 
 const { _detectServer: detectServer } = require('../../../lib/init');
 
-
 describe('init._detectServer()', () => {
-  it('defaults to \'npm start\' script', () => assert.equal(detectServer([]), 'npm start'));
+  it("defaults to 'npm start' script", () =>
+    assert.equal(detectServer([]), 'npm start'));
 
-  it('assumes Python project means Django application', () => assert.equal(
-    detectServer(['README', 'Pipfile']),
-    'python manage.py runserver'
-  ));
+  it('assumes Python project means Django application', () =>
+    assert.equal(
+      detectServer(['README', 'Pipfile']),
+      'python manage.py runserver',
+    ));
 
-  it('assumes Ruby project means RoR application', () => assert.equal(
-    detectServer(['README', 'Gemfile']),
-    'bundle exec rails server'
-  ));
+  it('assumes Ruby project means RoR application', () =>
+    assert.equal(
+      detectServer(['README', 'Gemfile']),
+      'bundle exec rails server',
+    ));
 });

--- a/test/unit/init/printClosingMessage-test.js
+++ b/test/unit/init/printClosingMessage-test.js
@@ -4,14 +4,14 @@ const {
   _printClosingMessage: printClosingMessage,
 } = require('../../../lib/init');
 
-
 function print(s) {
   print.output += `${s}\n`;
 }
 
-
 describe('init._printClosingMessage()', () => {
-  beforeEach(() => { print.output = ''; });
+  beforeEach(() => {
+    print.output = '';
+  });
 
   it('mentions the config has been saved to dredd.yml', () => {
     printClosingMessage({ language: 'nodejs' }, print);

--- a/test/unit/init/updateAppVeyor-test.js
+++ b/test/unit/init/updateAppVeyor-test.js
@@ -2,11 +2,9 @@ const { assert } = require('chai');
 
 const { _updateAppVeyor: updateAppVeyor } = require('../../../lib/init');
 
-
 function createOptions(contents) {
   return { editYaml: (file, update) => update(contents) };
 }
-
 
 describe('init._updateAppVeyor()', () => {
   it('is able to create a new config file', () => {

--- a/test/unit/init/updateCircleCI-test.js
+++ b/test/unit/init/updateCircleCI-test.js
@@ -2,11 +2,9 @@ const { assert } = require('chai');
 
 const { _updateCircleCI: updateCircleCI } = require('../../../lib/init');
 
-
 function createOptions(contents) {
   return { editYaml: (file, update) => update(contents) };
 }
-
 
 describe('init._updateCircleCI()', () => {
   it('is able to create a new config file', () => {
@@ -16,7 +14,7 @@ describe('init._updateCircleCI()', () => {
     assert.include(JSON.stringify(contents), 'dredd');
   });
 
-  it('sets a \'dredd\' job', () => {
+  it("sets a 'dredd' job", () => {
     const contents = {};
     updateCircleCI(createOptions(contents));
 

--- a/test/unit/init/updateTravisCI-test.js
+++ b/test/unit/init/updateTravisCI-test.js
@@ -2,11 +2,9 @@ const { assert } = require('chai');
 
 const { _updateTravisCI: updateTravisCI } = require('../../../lib/init');
 
-
 function createOptions(contents) {
   return { editYaml: (file, update) => update(contents) };
 }
-
 
 describe('init._updateTravisCI()', () => {
   it('is able to create a new config file', () => {

--- a/test/unit/init/updateWercker-test.js
+++ b/test/unit/init/updateWercker-test.js
@@ -2,11 +2,9 @@ const { assert } = require('chai');
 
 const { _updateWercker: updateWercker } = require('../../../lib/init');
 
-
 function createOptions(contents) {
   return { editYaml: (file, update) => update(contents) };
 }
-
 
 describe('init._updateWercker()', () => {
   it('is able to create a new config file', () => {
@@ -19,9 +17,7 @@ describe('init._updateWercker()', () => {
   it('adds commands to install and run Dredd', () => {
     const contents = {
       build: {
-        steps: [
-          { script: { name: 'pipenv-install', code: 'pipenv install' } },
-        ],
+        steps: [{ script: { name: 'pipenv-install', code: 'pipenv install' } }],
       },
     };
     updateWercker(createOptions(contents));

--- a/test/unit/isURL-test.js
+++ b/test/unit/isURL-test.js
@@ -2,7 +2,6 @@ const { assert } = require('chai');
 
 const isURL = require('../../lib/isURL');
 
-
 describe('isURL()', () => {
   it('recognizes HTTP URL', () => {
     assert.isTrue(isURL('http://example.com'));

--- a/test/unit/performRequest/createTransactionResponse-test.js
+++ b/test/unit/performRequest/createTransactionResponse-test.js
@@ -4,14 +4,14 @@ const {
   _createTransactionResponse: createTransactionResponse,
 } = require('../../../lib/performRequest');
 
-
 describe('performRequest._createTransactionResponse()', () => {
   const res = { statusCode: 200, headers: {} };
 
-  it('sets the status code', () => assert.deepEqual(
-    createTransactionResponse(res),
-    { statusCode: 200, headers: {} }
-  ));
+  it('sets the status code', () =>
+    assert.deepEqual(createTransactionResponse(res), {
+      statusCode: 200,
+      headers: {},
+    }));
   it('copies the headers', () => {
     const headers = { 'Content-Type': 'application/json' };
     const transactionRes = createTransactionResponse({
@@ -20,28 +20,31 @@ describe('performRequest._createTransactionResponse()', () => {
     });
     headers['X-Header'] = 'abcd';
 
-    assert.deepEqual(
-      transactionRes,
-      { statusCode: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    assert.deepEqual(transactionRes, {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   });
-  it('does not set empty body', () => assert.deepEqual(
-    createTransactionResponse(res, Buffer.from([])),
-    { statusCode: 200, headers: {} }
-  ));
-  it('sets textual body as a string with UTF-8 encoding', () => assert.deepEqual(
-    createTransactionResponse(res, Buffer.from('řeřicha')),
-    {
-      statusCode: 200, headers: {}, body: 'řeřicha', bodyEncoding: 'utf-8',
-    }
-  ));
-  it('sets binary body as a string with Base64 encoding', () => assert.deepEqual(
-    createTransactionResponse(res, Buffer.from([0xFF, 0xBE])),
-    {
+  it('does not set empty body', () =>
+    assert.deepEqual(createTransactionResponse(res, Buffer.from([])), {
       statusCode: 200,
       headers: {},
-      body: Buffer.from([0xFF, 0xBE]).toString('base64'),
-      bodyEncoding: 'base64',
-    }
-  ));
+    }));
+  it('sets textual body as a string with UTF-8 encoding', () =>
+    assert.deepEqual(createTransactionResponse(res, Buffer.from('řeřicha')), {
+      statusCode: 200,
+      headers: {},
+      body: 'řeřicha',
+      bodyEncoding: 'utf-8',
+    }));
+  it('sets binary body as a string with Base64 encoding', () =>
+    assert.deepEqual(
+      createTransactionResponse(res, Buffer.from([0xff, 0xbe])),
+      {
+        statusCode: 200,
+        headers: {},
+        body: Buffer.from([0xff, 0xbe]).toString('base64'),
+        bodyEncoding: 'base64',
+      },
+    ));
 });

--- a/test/unit/performRequest/detectBodyEncoding-test.js
+++ b/test/unit/performRequest/detectBodyEncoding-test.js
@@ -4,18 +4,14 @@ const {
   _detectBodyEncoding: detectBodyEncoding,
 } = require('../../../lib/performRequest');
 
-
 describe('performRequest._detectBodyEncoding()', () => {
-  it('detects binary content as Base64', () => assert.equal(
-    detectBodyEncoding(Buffer.from([0xFF, 0xEF, 0xBF, 0xBE])),
-    'base64'
-  ));
-  it('detects textual content as UTF-8', () => assert.equal(
-    detectBodyEncoding(Buffer.from('řeřicha')),
-    'utf-8'
-  ));
-  it('detects no content as UTF-8', () => assert.equal(
-    detectBodyEncoding(Buffer.from([])),
-    'utf-8'
-  ));
+  it('detects binary content as Base64', () =>
+    assert.equal(
+      detectBodyEncoding(Buffer.from([0xff, 0xef, 0xbf, 0xbe])),
+      'base64',
+    ));
+  it('detects textual content as UTF-8', () =>
+    assert.equal(detectBodyEncoding(Buffer.from('řeřicha')), 'utf-8'));
+  it('detects no content as UTF-8', () =>
+    assert.equal(detectBodyEncoding(Buffer.from([])), 'utf-8'));
 });

--- a/test/unit/performRequest/getBodyAsBuffer-test.js
+++ b/test/unit/performRequest/getBodyAsBuffer-test.js
@@ -4,24 +4,26 @@ const {
   _getBodyAsBuffer: getBodyAsBuffer,
 } = require('../../../lib/performRequest');
 
-
 describe('performRequest._getBodyAsBuffer()', () => {
   describe('when the body is a Buffer', () => {
     it('returns the body unmodified', () => {
-      const body = Buffer.from([0xFF, 0xEF, 0xBF, 0xBE]);
+      const body = Buffer.from([0xff, 0xef, 0xbf, 0xbe]);
       assert.equal(getBodyAsBuffer(body), body);
     });
     it('ignores encoding', () => {
-      const body = Buffer.from([0xFF, 0xEF, 0xBF, 0xBE]);
+      const body = Buffer.from([0xff, 0xef, 0xbf, 0xbe]);
       assert.equal(getBodyAsBuffer(body, 'utf-8'), body);
     });
   });
 
   [undefined, null, ''].forEach((body) => {
     describe(`when the body is ${JSON.stringify(body)}`, () => {
-      it('returns empty Buffer without encoding', () => assert.deepEqual(getBodyAsBuffer(body), Buffer.from([])));
-      it('returns empty Buffer with encoding set to UTF-8', () => assert.deepEqual(getBodyAsBuffer(body, 'utf-8'), Buffer.from([])));
-      it('returns empty Buffer with encoding set to Base64', () => assert.deepEqual(getBodyAsBuffer(body, 'base64'), Buffer.from([])));
+      it('returns empty Buffer without encoding', () =>
+        assert.deepEqual(getBodyAsBuffer(body), Buffer.from([])));
+      it('returns empty Buffer with encoding set to UTF-8', () =>
+        assert.deepEqual(getBodyAsBuffer(body, 'utf-8'), Buffer.from([])));
+      it('returns empty Buffer with encoding set to Base64', () =>
+        assert.deepEqual(getBodyAsBuffer(body, 'base64'), Buffer.from([])));
     });
   });
 
@@ -33,8 +35,10 @@ describe('performRequest._getBodyAsBuffer()', () => {
   });
 
   describe('when the body is a string', () => {
-    it('assumes UTF-8 without encoding', () => assert.deepEqual(getBodyAsBuffer('abc'), Buffer.from('abc')));
-    it('respects encoding set to UTF-8', () => assert.deepEqual(getBodyAsBuffer('abc', 'utf-8'), Buffer.from('abc')));
+    it('assumes UTF-8 without encoding', () =>
+      assert.deepEqual(getBodyAsBuffer('abc'), Buffer.from('abc')));
+    it('respects encoding set to UTF-8', () =>
+      assert.deepEqual(getBodyAsBuffer('abc', 'utf-8'), Buffer.from('abc')));
     it('respects encoding set to Base64', () => {
       const body = Buffer.from('abc').toString('base64');
       assert.deepEqual(getBodyAsBuffer(body, 'base64'), Buffer.from('abc'));

--- a/test/unit/performRequest/normalizeBodyEncoding-test.js
+++ b/test/unit/performRequest/normalizeBodyEncoding-test.js
@@ -4,12 +4,21 @@ const {
   _normalizeBodyEncoding: normalizeBodyEncoding,
 } = require('../../../lib/performRequest');
 
-
 describe('performRequest._normalizeBodyEncoding()', () => {
-  ['utf-8', 'utf8', 'UTF-8', 'UTF8'].forEach(value => it(`normalizes ${JSON.stringify(value)} to utf-8`, () => assert.equal(normalizeBodyEncoding(value), 'utf-8')));
-  ['base64', 'Base64'].forEach(value => it(`normalizes ${JSON.stringify(value)} to base64`, () => assert.equal(normalizeBodyEncoding(value), 'base64')));
-  [undefined, null, '', false].forEach(value => it(`defaults ${JSON.stringify(value)} to utf-8`, () => assert.equal(normalizeBodyEncoding(value), 'utf-8')));
-  it('throws an error on "latin2"', () => assert.throws(() => {
-    normalizeBodyEncoding('latin2');
-  }, /^unsupported encoding/i));
+  ['utf-8', 'utf8', 'UTF-8', 'UTF8'].forEach((value) =>
+    it(`normalizes ${JSON.stringify(value)} to utf-8`, () =>
+      assert.equal(normalizeBodyEncoding(value), 'utf-8')),
+  );
+  ['base64', 'Base64'].forEach((value) =>
+    it(`normalizes ${JSON.stringify(value)} to base64`, () =>
+      assert.equal(normalizeBodyEncoding(value), 'base64')),
+  );
+  [undefined, null, '', false].forEach((value) =>
+    it(`defaults ${JSON.stringify(value)} to utf-8`, () =>
+      assert.equal(normalizeBodyEncoding(value), 'utf-8')),
+  );
+  it('throws an error on "latin2"', () =>
+    assert.throws(() => {
+      normalizeBodyEncoding('latin2');
+    }, /^unsupported encoding/i));
 });

--- a/test/unit/performRequest/normalizeContentLengthHeader-test.js
+++ b/test/unit/performRequest/normalizeContentLengthHeader-test.js
@@ -5,7 +5,6 @@ const {
   _normalizeContentLengthHeader: normalizeContentLengthHeader,
 } = require('../../../lib/performRequest');
 
-
 describe('performRequest._normalizeContentLengthHeader()', () => {
   let headers;
 
@@ -18,77 +17,118 @@ describe('performRequest._normalizeContentLengthHeader()', () => {
     });
 
     it('does not warn', () => assert.isFalse(logger.warn.called));
-    it('has the Content-Length header set to 0', () => assert.deepPropertyVal(headers, 'Content-Length', '0'));
+    it('has the Content-Length header set to 0', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '0'));
   });
 
   describe('when there is no body and the Content-Length is set to 0', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({
-        'Content-Length': '0',
-      }, Buffer.from(''), { logger });
+      headers = normalizeContentLengthHeader(
+        {
+          'Content-Length': '0',
+        },
+        Buffer.from(''),
+        { logger },
+      );
     });
 
     it('does not warn', () => assert.isFalse(logger.warn.called));
-    it('has the Content-Length header set to 0', () => assert.deepPropertyVal(headers, 'Content-Length', '0'));
+    it('has the Content-Length header set to 0', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '0'));
   });
 
   describe('when there is body and the Content-Length is not set', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({}, Buffer.from('abcd'), { logger });
+      headers = normalizeContentLengthHeader({}, Buffer.from('abcd'), {
+        logger,
+      });
     });
 
     it('does not warn', () => assert.isFalse(logger.warn.called));
-    it('has the Content-Length header set to 4', () => assert.deepPropertyVal(headers, 'Content-Length', '4'));
+    it('has the Content-Length header set to 4', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '4'));
   });
 
   describe('when there is body and the Content-Length is correct', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({
-        'Content-Length': '4',
-      }, Buffer.from('abcd'), { logger });
+      headers = normalizeContentLengthHeader(
+        {
+          'Content-Length': '4',
+        },
+        Buffer.from('abcd'),
+        { logger },
+      );
     });
 
     it('does not warn', () => assert.isFalse(logger.warn.called));
-    it('has the Content-Length header set to 4', () => assert.deepPropertyVal(headers, 'Content-Length', '4'));
+    it('has the Content-Length header set to 4', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '4'));
   });
 
   describe('when there is no body and the Content-Length is wrong', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({
-        'Content-Length': '42',
-      }, Buffer.from(''), { logger });
+      headers = normalizeContentLengthHeader(
+        {
+          'Content-Length': '42',
+        },
+        Buffer.from(''),
+        { logger },
+      );
     });
 
-    it('warns about the discrepancy', () => assert.match(logger.warn.lastCall.args[0], /but the real body length is/));
-    it('has the Content-Length header set to 0', () => assert.deepPropertyVal(headers, 'Content-Length', '0'));
+    it('warns about the discrepancy', () =>
+      assert.match(
+        logger.warn.lastCall.args[0],
+        /but the real body length is/,
+      ));
+    it('has the Content-Length header set to 0', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '0'));
   });
 
   describe('when there is body and the Content-Length is wrong', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({
-        'Content-Length': '42',
-      }, Buffer.from('abcd'), { logger });
+      headers = normalizeContentLengthHeader(
+        {
+          'Content-Length': '42',
+        },
+        Buffer.from('abcd'),
+        { logger },
+      );
     });
 
-    it('warns about the discrepancy', () => assert.match(logger.warn.lastCall.args[0], /but the real body length is/));
-    it('has the Content-Length header set to 4', () => assert.deepPropertyVal(headers, 'Content-Length', '4'));
+    it('warns about the discrepancy', () =>
+      assert.match(
+        logger.warn.lastCall.args[0],
+        /but the real body length is/,
+      ));
+    it('has the Content-Length header set to 4', () =>
+      assert.deepPropertyVal(headers, 'Content-Length', '4'));
   });
 
   describe('when the existing header name has unusual casing', () => {
     beforeEach(() => {
-      headers = normalizeContentLengthHeader({
-        'CoNtEnT-lEnGtH': '4',
-      }, Buffer.from('abcd'), { logger });
+      headers = normalizeContentLengthHeader(
+        {
+          'CoNtEnT-lEnGtH': '4',
+        },
+        Buffer.from('abcd'),
+        { logger },
+      );
     });
 
-    it('has the CoNtEnT-lEnGtH header set to 4', () => assert.deepEqual(headers, { 'CoNtEnT-lEnGtH': '4' }));
+    it('has the CoNtEnT-lEnGtH header set to 4', () =>
+      assert.deepEqual(headers, { 'CoNtEnT-lEnGtH': '4' }));
   });
 
   describe('when there are modifications to the headers', () => {
     const originalHeaders = {};
 
     beforeEach(() => {
-      headers = normalizeContentLengthHeader(originalHeaders, Buffer.from('abcd'), { logger });
+      headers = normalizeContentLengthHeader(
+        originalHeaders,
+        Buffer.from('abcd'),
+        { logger },
+      );
     });
 
     it('does not modify the original headers object', () => {

--- a/test/unit/performRequest/performRequest-test.js
+++ b/test/unit/performRequest/performRequest-test.js
@@ -3,7 +3,6 @@ const { assert } = require('chai');
 
 const performRequest = require('../../../lib/performRequest');
 
-
 describe('performRequest()', () => {
   const uri = 'http://example.com/42';
   const uriS = 'https://example.com/42';
@@ -13,10 +12,14 @@ describe('performRequest()', () => {
     body: 'Hello',
   };
   const res = { statusCode: 200, headers: { 'Content-Type': 'text/plain' } };
-  const request = sinon.stub().callsArgWithAsync(1, null, res, Buffer.from('Bye'));
+  const request = sinon
+    .stub()
+    .callsArgWithAsync(1, null, res, Buffer.from('Bye'));
   const logger = { debug: sinon.spy() };
 
-  beforeEach(() => { logger.debug.resetHistory(); });
+  beforeEach(() => {
+    logger.debug.resetHistory();
+  });
 
   it('does not modify the original HTTP options object', (done) => {
     const httpOptions = { json: true };
@@ -26,10 +29,15 @@ describe('performRequest()', () => {
     });
   });
   it('does not allow to override the hardcoded HTTP options', (done) => {
-    performRequest(uri, transactionReq, { http: { proxy: true }, request }, () => {
-      assert.isFalse(request.firstCall.args[0].proxy);
-      done();
-    });
+    performRequest(
+      uri,
+      transactionReq,
+      { http: { proxy: true }, request },
+      () => {
+        assert.isFalse(request.firstCall.args[0].proxy);
+        done();
+      },
+    );
   });
   it('forbids the HTTP client library to respect proxy settings', (done) => {
     performRequest(uri, transactionReq, { request }, () => {
@@ -64,7 +72,7 @@ describe('performRequest()', () => {
   it('handles exceptions when preparing the HTTP request body', (done) => {
     const invalidTransactionReq = Object.assign(
       { bodyEncoding: 'latin2' },
-      transactionReq
+      transactionReq,
     );
     performRequest(uri, invalidTransactionReq, { request }, (err) => {
       assert.instanceOf(err, Error);
@@ -75,7 +83,7 @@ describe('performRequest()', () => {
     performRequest(uri, transactionReq, { request, logger }, () => {
       assert.equal(
         logger.debug.firstCall.args[0],
-        `Performing HTTP request to the server under test: POST ${uri}`
+        `Performing HTTP request to the server under test: POST ${uri}`,
       );
       done();
     });
@@ -84,7 +92,7 @@ describe('performRequest()', () => {
     performRequest(uriS, transactionReq, { request, logger }, () => {
       assert.equal(
         logger.debug.firstCall.args[0],
-        `Performing HTTPS request to the server under test: POST ${uriS}`
+        `Performing HTTPS request to the server under test: POST ${uriS}`,
       );
       done();
     });
@@ -93,7 +101,7 @@ describe('performRequest()', () => {
     performRequest(uri, transactionReq, { request, logger }, () => {
       assert.equal(
         logger.debug.lastCall.args[0],
-        'Handling HTTP response from the server under test'
+        'Handling HTTP response from the server under test',
       );
       done();
     });
@@ -102,7 +110,7 @@ describe('performRequest()', () => {
     performRequest(uriS, transactionReq, { request, logger }, () => {
       assert.equal(
         logger.debug.lastCall.args[0],
-        'Handling HTTPS response from the server under test'
+        'Handling HTTPS response from the server under test',
       );
       done();
     });

--- a/test/unit/prettifyResponse-test.js
+++ b/test/unit/prettifyResponse-test.js
@@ -11,8 +11,7 @@ describe('prettifyResponse(response)', () => {
         headers: {
           'content-type': 'application/json',
         },
-        body:
-          { a: 'b' },
+        body: { a: 'b' },
       });
 
       const expectedOutput = `\
@@ -24,13 +23,13 @@ body: \n{
       assert.equal(output, expectedOutput);
     });
 
-
     it('should print indented XML when content-type is text/html', () => {
       const output = prettifyResponse({
         headers: {
           'content-type': 'text/html',
         },
-        body: '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>',
+        body:
+          '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>',
       });
 
       const expectedOutput = `\
@@ -60,12 +59,15 @@ body: \n<div>before paragraph
 
     after(() => sinon.stub(loggerStub.debug.restore()));
 
-    it('should\'ve printed into debug', () => {
+    it("should've printed into debug", () => {
       assert.isOk(loggerStub.debug.called);
       assert.isObject(loggerStub.debug.firstCall);
       assert.isArray(loggerStub.debug.firstCall.args);
       assert.lengthOf(loggerStub.debug.firstCall.args, 1);
-      assert.equal(loggerStub.debug.firstCall.args[0], 'Could not stringify: [object Object]');
+      assert.equal(
+        loggerStub.debug.firstCall.args[0],
+        'Could not stringify: [object Object]',
+      );
     });
   });
 });

--- a/test/unit/reporters/ApiaryReporter-test.js
+++ b/test/unit/reporters/ApiaryReporter-test.js
@@ -47,9 +47,10 @@ describe('ApiaryReporter', () => {
       test = {
         status: 'fail',
         title: 'POST /machines',
-        message: "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
+        message:
+          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
 
-        startedAt: (1234567890 * 1000), // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
+        startedAt: 1234567890 * 1000, // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
 
         origin: {
           filename: './test/fixtures/multifile/greeting.apib',
@@ -74,7 +75,8 @@ describe('ApiaryReporter', () => {
             'content-type': 'application/json',
           },
 
-          body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+          body:
+            '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           status: '202',
         },
 
@@ -92,11 +94,13 @@ describe('ApiaryReporter', () => {
 
         results: {
           headers: {
-            results: [{
-              pointer: '/content-type',
-              severity: 'error',
-              message: 'Value of the ‘content-type’ must be application/json.',
-            },
+            results: [
+              {
+                pointer: '/content-type',
+                severity: 'error',
+                message:
+                  'Value of the ‘content-type’ must be application/json.',
+              },
             ],
             realType: 'application/vnd.apiary.http-headers+json',
             expectedType: 'application/vnd.apiary.http-headers+json',
@@ -107,7 +111,8 @@ describe('ApiaryReporter', () => {
                 propertyValue: 'text/plain',
                 attributeName: 'enum',
                 attributeValue: ['application/json'],
-                message: 'Value of the ‘content-type’ must be application/json.',
+                message:
+                  'Value of the ‘content-type’ must be application/json.',
                 validator: 'enum',
                 validatorName: 'enum',
                 validatorValue: ['application/json'],
@@ -118,10 +123,12 @@ describe('ApiaryReporter', () => {
           },
 
           body: {
-            results: [{
-              message: "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
-              severity: 'error',
-            },
+            results: [
+              {
+                message:
+                  "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
+                severity: 'error',
+              },
             ],
             realType: 'text/plain',
             expectedType: 'application/json',
@@ -134,10 +141,11 @@ describe('ApiaryReporter', () => {
             expectedType: 'text/vnd.apiary.status-code',
             validator: 'TextDiff',
             rawData: '@@ -1,3 +1,9 @@\n-400\n+undefined\n',
-            results: [{
-              severity: 'error',
-              message: 'Real and expected data does not match.',
-            },
+            results: [
+              {
+                severity: 'error',
+                message: 'Real and expected data does not match.',
+              },
             ],
           },
         },
@@ -166,7 +174,7 @@ describe('ApiaryReporter', () => {
           const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           assert.equal(
             apiaryReporter.configuration.apiUrl,
-            'https://api.example.com:1234'
+            'https://api.example.com:1234',
           );
         });
       });
@@ -182,7 +190,7 @@ describe('ApiaryReporter', () => {
           const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           assert.equal(
             apiaryReporter.configuration.apiUrl,
-            'https://api.example.com:1234'
+            'https://api.example.com:1234',
           );
         });
       });
@@ -199,7 +207,11 @@ describe('ApiaryReporter', () => {
           emitter = new EventEmitter();
           const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
           apiaryReporter._performRequestAsync('/', 'POST', '', () => {
-            assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/ (without body)'));
+            assert.isOk(
+              loggerStub.debug.calledWithMatch(
+                'POST https://api.example.com:1234/ (without body)',
+              ),
+            );
             done();
           });
         });
@@ -211,23 +223,38 @@ describe('ApiaryReporter', () => {
           apiaryApiUrl: 'https://api.example.com:1234/',
         };
 
-        describe('when provided with root path', () => it('should use API URL without double slashes', (done) => {
-          emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
-          apiaryReporter._performRequestAsync('/', 'POST', '', () => {
-            assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/ (without body)'));
-            done();
-          });
-        }));
+        describe('when provided with root path', () =>
+          it('should use API URL without double slashes', (done) => {
+            emitter = new EventEmitter();
+            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
+            apiaryReporter._performRequestAsync('/', 'POST', '', () => {
+              assert.isOk(
+                loggerStub.debug.calledWithMatch(
+                  'POST https://api.example.com:1234/ (without body)',
+                ),
+              );
+              done();
+            });
+          }));
 
-        describe('when provided with non-root path', () => it('should use API URL without double slashes', (done) => {
-          emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
-          apiaryReporter._performRequestAsync('/hello?q=1', 'POST', '', () => {
-            assert.isOk(loggerStub.debug.calledWithMatch('POST https://api.example.com:1234/hello?q=1 (without body)'));
-            done();
-          });
-        }));
+        describe('when provided with non-root path', () =>
+          it('should use API URL without double slashes', (done) => {
+            emitter = new EventEmitter();
+            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom });
+            apiaryReporter._performRequestAsync(
+              '/hello?q=1',
+              'POST',
+              '',
+              () => {
+                assert.isOk(
+                  loggerStub.debug.calledWithMatch(
+                    'POST https://api.example.com:1234/hello?q=1 (without body)',
+                  ),
+                );
+                done();
+              },
+            );
+          }));
       });
 
       describe('when server is not available', () => {
@@ -238,7 +265,11 @@ describe('ApiaryReporter', () => {
 
         it('should log human readable message', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
           apiaryReporter._performRequestAsync('/', 'POST', '', (error) => {
             assert.isNotNull(error);
             done();
@@ -247,7 +278,11 @@ describe('ApiaryReporter', () => {
 
         it('should set server error to true', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
           apiaryReporter._performRequestAsync('/', 'POST', '', () => {
             assert.isTrue(apiaryReporter.serverError);
             done();
@@ -263,7 +298,8 @@ describe('ApiaryReporter', () => {
       beforeEach(() => {
         requestBody = null;
         const uri = '/apis/public/tests/runs';
-        const reportUrl = 'https://absolutely.fancy.url/wich-can-change/some/id';
+        const reportUrl =
+          'https://absolutely.fancy.url/wich-can-change/some/id';
 
         // This is a hack how to get access to the performed request from nock
         // nock isn't able to provide it
@@ -280,7 +316,11 @@ describe('ApiaryReporter', () => {
 
       it('should set uuid', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         return emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.uuid);
           return done();
@@ -289,7 +329,11 @@ describe('ApiaryReporter', () => {
 
       it('should set start time', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.startedAt);
           done();
@@ -298,7 +342,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test run" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isTrue(call.isDone());
           done();
@@ -307,7 +351,11 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run ID back to the reporter as remoteId', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.remoteId);
           done();
@@ -316,7 +364,11 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run reportUrl to the reporter as reportUrl', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.reportUrl);
           done();
@@ -325,16 +377,24 @@ describe('ApiaryReporter', () => {
 
       it('should have blueprints key in the request and it should be an array and members should have proper structure', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.isArray(parsedBody.blueprints);
           assert.lengthOf(parsedBody.blueprints, 1);
           for (const blueprint of parsedBody.blueprints) {
             assert.property(blueprint, 'raw');
-            assert.propertyVal(blueprint, 'raw', 'FORMAT: 1A\n\n# Machines API\n\n# Group Machines\n\n# Machines collection [/machines/{id}]\n  + Parameters\n    - id (number, `1`)\n\n## Get Machines [GET]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `2`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `3`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n');
+            assert.propertyVal(
+              blueprint,
+              'raw',
+              'FORMAT: 1A\n\n# Machines API\n\n# Group Machines\n\n# Machines collection [/machines/{id}]\n  + Parameters\n    - id (number, `1`)\n\n## Get Machines [GET]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `2`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n\n- Request (application/json)\n  + Parameters\n    - id (number, `3`)\n\n- Response 200 (application/json; charset=utf-8)\n\n    [\n      {\n        "type": "bulldozer",\n        "name": "willy"\n      }\n    ]\n',
+            );
             assert.property(blueprint, 'filename');
-            assert.propertyVal(blueprint, 'filename', './test/fixtures/multiple-examples.apib');
+            assert.propertyVal(
+              blueprint,
+              'filename',
+              './test/fixtures/multiple-examples.apib',
+            );
             assert.property(blueprint, 'annotations');
             assert.isArray(blueprint.annotations);
           }
@@ -344,17 +404,35 @@ describe('ApiaryReporter', () => {
 
       it('should have various needed keys in test-run payload sent to apiary', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(
+          emitter,
+          {},
+          {
+            server: 'http://my.server.co:8080',
+            custom: { apiaryReporterEnv: env },
+          },
+        );
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
-          assert.propertyVal(parsedBody, 'endpoint', 'http://my.server.co:8080');
+          assert.propertyVal(
+            parsedBody,
+            'endpoint',
+            'http://my.server.co:8080',
+          );
           done();
         });
       });
 
       it('should send the test-run as public one', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(
+          emitter,
+          {},
+          {
+            server: 'http://my.server.co:8080',
+            custom: { apiaryReporterEnv: env },
+          },
+        );
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.strictEqual(parsedBody.public, true);
@@ -362,15 +440,20 @@ describe('ApiaryReporter', () => {
         });
       });
 
-      describe('serverError is true', () => it('should not do anything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.serverError = true;
-        emitter.emit('start', apiDescriptions, () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('serverError is true', () =>
+        it('should not do anything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.serverError = true;
+          emitter.emit('start', apiDescriptions, () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
 
     describe('when adding passing test', () => {
@@ -397,7 +480,11 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           assert.isTrue(call.isDone());
@@ -407,7 +494,11 @@ describe('ApiaryReporter', () => {
 
       it('should have origin with filename in the request', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           const parsedBody = JSON.parse(requestBody);
@@ -418,25 +509,34 @@ describe('ApiaryReporter', () => {
 
       it('should have startedAt timestamp in the request', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           const parsedBody = JSON.parse(requestBody);
-          assert.propertyVal(parsedBody, 'startedAt', (1234567890 * 1000));
+          assert.propertyVal(parsedBody, 'startedAt', 1234567890 * 1000);
           done();
         });
       });
 
-      describe('serverError is true', () => it('should not do anything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.remoteId = runId;
-        apiaryReporter.serverError = true;
-        emitter.emit('test pass', test, () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('serverError is true', () =>
+        it('should not do anything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.remoteId = runId;
+          apiaryReporter.serverError = true;
+          emitter.emit('test pass', test, () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
 
     describe('when adding failing test', () => {
@@ -453,7 +553,11 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test fail', test, () => {
           assert.isTrue(call.isDone());
@@ -461,16 +565,21 @@ describe('ApiaryReporter', () => {
         });
       });
 
-      describe('when serverError is true', () => it('should not do anything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.remoteId = runId;
-        apiaryReporter.serverError = true;
-        emitter.emit('test fail', test, () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('when serverError is true', () =>
+        it('should not do anything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.remoteId = runId;
+          apiaryReporter.serverError = true;
+          emitter.emit('test fail', test, () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
 
     describe('when adding skipped test', () => {
@@ -500,7 +609,11 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test skip', clonedTest, () => {
           assert.isTrue(call.isDone());
@@ -510,7 +623,11 @@ describe('ApiaryReporter', () => {
 
       it('should send status skipped', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test skip', clonedTest, () => {
           assert.equal(JSON.parse(requestBody).result, 'skip');
@@ -518,18 +635,22 @@ describe('ApiaryReporter', () => {
         });
       });
 
-      describe('when serverError is true', () => it('should not do anything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.remoteId = runId;
-        apiaryReporter.serverError = true;
-        emitter.emit('test skip', clonedTest, () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('when serverError is true', () =>
+        it('should not do anything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.remoteId = runId;
+          apiaryReporter.serverError = true;
+          emitter.emit('test skip', clonedTest, () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
-
 
     describe('when adding test with error', () => {
       let call = null;
@@ -555,13 +676,25 @@ describe('ApiaryReporter', () => {
           .reply(201, { _id: runId });
       });
 
-      const connectionErrors = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE'];
+      const connectionErrors = [
+        'ECONNRESET',
+        'ENOTFOUND',
+        'ESOCKETTIMEDOUT',
+        'ETIMEDOUT',
+        'ECONNREFUSED',
+        'EHOSTUNREACH',
+        'EPIPE',
+      ];
 
       connectionErrors.forEach((errType) => {
         describe(`when error type is ${errType}`, () => {
           it('should call "create new test step" HTTP resource', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(
+              emitter,
+              {},
+              { custom: { apiaryReporterEnv: env } },
+            );
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
@@ -573,7 +706,11 @@ describe('ApiaryReporter', () => {
 
           it('should set result to error', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(
+              emitter,
+              {},
+              { custom: { apiaryReporterEnv: env } },
+            );
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
@@ -583,17 +720,24 @@ describe('ApiaryReporter', () => {
             });
           });
 
-
           it('should set error message', (done) => {
             emitter = new EventEmitter();
-            const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+            const apiaryReporter = new ApiaryReporter(
+              emitter,
+              {},
+              { custom: { apiaryReporterEnv: env } },
+            );
             apiaryReporter.remoteId = runId;
             const error = new Error('some error');
             error.code = errType;
             emitter.emit('test error', error, test, () => {
               assert.isArray(JSON.parse(requestBody).results.errors);
-              assert.include(JSON.parse(requestBody).results.errors.map(value => JSON.stringify(value)).join(),
-                'Error connecting to server under test!');
+              assert.include(
+                JSON.parse(requestBody)
+                  .results.errors.map((value) => JSON.stringify(value))
+                  .join(),
+                'Error connecting to server under test!',
+              );
               done();
             });
           });
@@ -603,7 +747,11 @@ describe('ApiaryReporter', () => {
       describe('when any other error', () => {
         it('should call "create new test step" HTTP resource', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
@@ -614,7 +762,11 @@ describe('ApiaryReporter', () => {
 
         it('should set result to error', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
@@ -625,30 +777,42 @@ describe('ApiaryReporter', () => {
 
         it('should set descriptive error', (done) => {
           emitter = new EventEmitter();
-          const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
           apiaryReporter.remoteId = runId;
           const error = new Error('some error');
           emitter.emit('test error', error, test, () => {
             assert.isArray(JSON.parse(requestBody).results.errors);
-            assert.include(JSON.parse(requestBody).results.errors.map(value => JSON.stringify(value)).join(),
-              'Unhandled error occured when executing the transaction.');
+            assert.include(
+              JSON.parse(requestBody)
+                .results.errors.map((value) => JSON.stringify(value))
+                .join(),
+              'Unhandled error occured when executing the transaction.',
+            );
             done();
           });
         });
       });
 
-
-      describe('when serverError is true', () => it('should not do anything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.remoteId = runId;
-        apiaryReporter.serverError = true;
-        const error = new Error('some error');
-        emitter.emit('test error', error, test, () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('when serverError is true', () =>
+        it('should not do anything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.remoteId = runId;
+          apiaryReporter.serverError = true;
+          const error = new Error('some error');
+          emitter.emit('test error', error, test, () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
 
     describe('when ending', () => {
@@ -673,7 +837,11 @@ describe('ApiaryReporter', () => {
 
       it('should update "test run" resource with result data', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isTrue(call.isDone());
@@ -683,21 +851,38 @@ describe('ApiaryReporter', () => {
 
       it('should return generated url if no reportUrl is available', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
-          assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://app.apiary.io/public/tests/run/507f1f77bcf86cd799439011'));
+          assert.isOk(
+            reporterOutputLoggerStub.complete.calledWith(
+              'See results in Apiary at: https://app.apiary.io/public/tests/run/507f1f77bcf86cd799439011',
+            ),
+          );
           done();
         });
       });
 
       it('should return reportUrl from testRun entity', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
-        apiaryReporter.reportUrl = 'https://absolutely.fancy.url/wich-can-change/some/id';
+        apiaryReporter.reportUrl =
+          'https://absolutely.fancy.url/wich-can-change/some/id';
         emitter.emit('end', () => {
-          assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'));
+          assert.isOk(
+            reporterOutputLoggerStub.complete.calledWith(
+              'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id',
+            ),
+          );
           done();
         });
       });
@@ -705,7 +890,12 @@ describe('ApiaryReporter', () => {
       it('should send runner.logs to Apiary at the end of testRun', (done) => {
         emitter = new EventEmitter();
         const logMessages = ['a', 'b'];
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }, { logs: clone(logMessages) });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+          { logs: clone(logMessages) },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isString(requestBody);
@@ -717,16 +907,21 @@ describe('ApiaryReporter', () => {
         });
       });
 
-      describe('serverError is true', () => it('should not do enything', (done) => {
-        emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
-        apiaryReporter.remoteId = runId;
-        apiaryReporter.serverError = true;
-        emitter.emit('end', () => {
-          assert.isFalse(call.isDone());
-          done();
-        });
-      }));
+      describe('serverError is true', () =>
+        it('should not do enything', (done) => {
+          emitter = new EventEmitter();
+          const apiaryReporter = new ApiaryReporter(
+            emitter,
+            {},
+            { custom: { apiaryReporterEnv: env } },
+          );
+          apiaryReporter.remoteId = runId;
+          apiaryReporter.serverError = true;
+          emitter.emit('end', () => {
+            assert.isFalse(call.isDone());
+            done();
+          });
+        }));
     });
   });
 
@@ -745,9 +940,10 @@ describe('ApiaryReporter', () => {
       test = {
         status: 'fail',
         title: 'POST /machines',
-        message: "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
+        message:
+          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
 
-        startedAt: (1234567890 * 1000), // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
+        startedAt: 1234567890 * 1000, // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
 
         actual: {
           statusCode: 400,
@@ -763,7 +959,8 @@ describe('ApiaryReporter', () => {
             'content-type': 'application/json',
           },
 
-          body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+          body:
+            '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           status: '202',
         },
 
@@ -781,11 +978,13 @@ describe('ApiaryReporter', () => {
 
         results: {
           headers: {
-            results: [{
-              pointer: '/content-type',
-              severity: 'error',
-              message: 'Value of the ‘content-type’ must be application/json.',
-            },
+            results: [
+              {
+                pointer: '/content-type',
+                severity: 'error',
+                message:
+                  'Value of the ‘content-type’ must be application/json.',
+              },
             ],
             realType: 'application/vnd.apiary.http-headers+json',
             expectedType: 'application/vnd.apiary.http-headers+json',
@@ -796,7 +995,8 @@ describe('ApiaryReporter', () => {
                 propertyValue: 'text/plain',
                 attributeName: 'enum',
                 attributeValue: ['application/json'],
-                message: 'Value of the ‘content-type’ must be application/json.',
+                message:
+                  'Value of the ‘content-type’ must be application/json.',
                 validator: 'enum',
                 validatorName: 'enum',
                 validatorValue: ['application/json'],
@@ -807,10 +1007,12 @@ describe('ApiaryReporter', () => {
           },
 
           body: {
-            results: [{
-              message: "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
-              severity: 'error',
-            },
+            results: [
+              {
+                message:
+                  "No validator found for real data media type 'text/plain' and expected data media type 'application/json'.",
+                severity: 'error',
+              },
             ],
             realType: 'text/plain',
             expectedType: 'application/json',
@@ -823,10 +1025,11 @@ describe('ApiaryReporter', () => {
             expectedType: 'text/vnd.apiary.status-code',
             validator: 'TextDiff',
             rawData: '@@ -1,3 +1,9 @@\n-400\n+undefined\n',
-            results: [{
-              severity: 'error',
-              message: 'Real and expected data does not match.',
-            },
+            results: [
+              {
+                severity: 'error',
+                message: 'Real and expected data does not match.',
+              },
             ],
           },
         },
@@ -866,7 +1069,11 @@ describe('ApiaryReporter', () => {
 
       it('should set uuid', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.uuid);
           done();
@@ -875,7 +1082,11 @@ describe('ApiaryReporter', () => {
 
       it('should set start time', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.startedAt);
           done();
@@ -884,7 +1095,7 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test run" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
         emitter.emit('start', apiDescriptions, () => {
           assert.isTrue(call.isDone());
           done();
@@ -893,7 +1104,11 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run ID back to the reporter as remoteId', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.remoteId);
           done();
@@ -902,7 +1117,11 @@ describe('ApiaryReporter', () => {
 
       it('should attach test run reportUrl to the reporter as reportUrl', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         emitter.emit('start', apiDescriptions, () => {
           assert.isNotNull(apiaryReporter.reportUrl);
           done();
@@ -911,7 +1130,14 @@ describe('ApiaryReporter', () => {
 
       it('should send the test-run as non-public', (done) => {
         emitter = new EventEmitter();
-        (new ApiaryReporter(emitter, {}, { server: 'http://my.server.co:8080', custom: { apiaryReporterEnv: env } }));
+        new ApiaryReporter(
+          emitter,
+          {},
+          {
+            server: 'http://my.server.co:8080',
+            custom: { apiaryReporterEnv: env },
+          },
+        );
         emitter.emit('start', apiDescriptions, () => {
           const parsedBody = JSON.parse(requestBody);
           assert.strictEqual(parsedBody.public, false);
@@ -935,7 +1161,11 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test pass', test, () => {
           assert.isTrue(call.isDone());
@@ -959,7 +1189,11 @@ describe('ApiaryReporter', () => {
 
       it('should call "create new test step" HTTP resource', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('test fail', test, () => {
           assert.isTrue(call.isDone());
@@ -967,7 +1201,6 @@ describe('ApiaryReporter', () => {
         });
       });
     });
-
 
     describe('when ending', () => {
       let call = null;
@@ -983,7 +1216,11 @@ describe('ApiaryReporter', () => {
 
       it('should update "test run" resource with result data', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
           assert.isTrue(call.isDone());
@@ -993,21 +1230,38 @@ describe('ApiaryReporter', () => {
 
       it('should return generated url if reportUrl is not available', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
         emitter.emit('end', () => {
-          assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://app.apiary.io/jakubtest/tests/run/507f1f77bcf86cd799439011'));
+          assert.isOk(
+            reporterOutputLoggerStub.complete.calledWith(
+              'See results in Apiary at: https://app.apiary.io/jakubtest/tests/run/507f1f77bcf86cd799439011',
+            ),
+          );
           done();
         });
       });
 
       it('should return reportUrl from testRun entity', (done) => {
         emitter = new EventEmitter();
-        const apiaryReporter = new ApiaryReporter(emitter, {}, { custom: { apiaryReporterEnv: env } });
+        const apiaryReporter = new ApiaryReporter(
+          emitter,
+          {},
+          { custom: { apiaryReporterEnv: env } },
+        );
         apiaryReporter.remoteId = runId;
-        apiaryReporter.reportUrl = 'https://absolutely.fancy.url/wich-can-change/some/id';
+        apiaryReporter.reportUrl =
+          'https://absolutely.fancy.url/wich-can-change/some/id';
         emitter.emit('end', () => {
-          assert.isOk(reporterOutputLoggerStub.complete.calledWith('See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id'));
+          assert.isOk(
+            reporterOutputLoggerStub.complete.calledWith(
+              'See results in Apiary at: https://absolutely.fancy.url/wich-can-change/some/id',
+            ),
+          );
           done();
         });
       });

--- a/test/unit/reporters/BaseReporter-test.js
+++ b/test/unit/reporters/BaseReporter-test.js
@@ -25,7 +25,7 @@ describe('BaseReporter', () => {
       duration: 0,
     };
     emitter = new EventEmitter();
-    (new BaseReporter(emitter, stats));
+    new BaseReporter(emitter, stats);
   });
 
   describe('when starting', () => {
@@ -33,10 +33,11 @@ describe('BaseReporter', () => {
       stats = { start: null };
     });
 
-    it('should set the start date', done => emitter.emit('start', '', () => {
-      assert.isOk(stats.start);
-      done();
-    }));
+    it('should set the start date', (done) =>
+      emitter.emit('start', '', () => {
+        assert.isOk(stats.start);
+        done();
+      }));
   });
 
   describe('when ending', () => {
@@ -44,10 +45,11 @@ describe('BaseReporter', () => {
       stats = { start: null };
     });
 
-    it('should set the end date', done => emitter.emit('end', () => {
-      assert.isOk(stats.end);
-      done();
-    }));
+    it('should set the end date', (done) =>
+      emitter.emit('end', () => {
+        assert.isOk(stats.end);
+        done();
+      }));
   });
 
   describe('when test starts', () => {

--- a/test/unit/reporters/CLIReporter-test.js
+++ b/test/unit/reporters/CLIReporter-test.js
@@ -31,7 +31,7 @@ describe('CLIReporter', () => {
 
     it('should write starting to the console', (done) => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, true));
+      new CLIReporter(emitter, {}, true);
       loggerStub.debug.resetHistory();
       emitter.emit('start', '', () => {
         assert.isOk(loggerStub.debug.calledOnce);
@@ -54,7 +54,7 @@ describe('CLIReporter', () => {
 
     it('should write pass to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, true));
+      new CLIReporter(emitter, {}, true);
       emitter.emit('test pass', test);
       assert.isOk(reporterOutputLoggerStub.pass.calledOnce);
     });
@@ -66,7 +66,7 @@ describe('CLIReporter', () => {
 
       it('should write details for passing tests', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, true, true));
+        new CLIReporter(emitter, {}, true, true);
         emitter.emit('test pass', test);
         assert.isOk(reporterOutputLoggerStub.request.calledOnce);
       });
@@ -88,7 +88,7 @@ describe('CLIReporter', () => {
 
       it('should write fail to the console', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, true));
+        new CLIReporter(emitter, {}, true);
         emitter.emit('test fail', test);
         assert.isOk(reporterOutputLoggerStub.fail.calledTwice);
       });
@@ -101,7 +101,7 @@ describe('CLIReporter', () => {
 
       it('should not write full failure to the console at the time of failure', () => {
         const emitter = new EventEmitter();
-        (new CLIReporter(emitter, {}, false));
+        new CLIReporter(emitter, {}, false);
         emitter.emit('test fail', test);
         assert.isOk(reporterOutputLoggerStub.fail.calledOnce);
       });
@@ -132,12 +132,11 @@ describe('CLIReporter', () => {
 
     it('should write error to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, false));
+      new CLIReporter(emitter, {}, false);
       emitter.emit('test error', new Error('Error'), test);
       assert.isOk(reporterOutputLoggerStub.error.calledTwice);
     });
   });
-
 
   describe('when adding error test with connection refused', () => {
     before(() => {
@@ -151,19 +150,32 @@ describe('CLIReporter', () => {
 
     afterEach(() => reporterOutputLoggerStub.error.restore());
 
-    const connectionErrors = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE'];
+    const connectionErrors = [
+      'ECONNRESET',
+      'ENOTFOUND',
+      'ESOCKETTIMEDOUT',
+      'ETIMEDOUT',
+      'ECONNREFUSED',
+      'EHOSTUNREACH',
+      'EPIPE',
+    ];
 
-    Array.from(connectionErrors).forEach(errType => describe(`when error type ${errType}`, () => it('should write error to the console', () => {
-      const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, false));
-      const error = new Error('connect');
-      error.code = errType;
-      emitter.emit('test error', error, test);
+    Array.from(connectionErrors).forEach((errType) =>
+      describe(`when error type ${errType}`, () =>
+        it('should write error to the console', () => {
+          const emitter = new EventEmitter();
+          new CLIReporter(emitter, {}, false);
+          const error = new Error('connect');
+          error.code = errType;
+          emitter.emit('test error', error, test);
 
-      const messages = Object.keys(reporterOutputLoggerStub.error.args).map((value, index) => reporterOutputLoggerStub.error.args[index][0]);
+          const messages = Object.keys(reporterOutputLoggerStub.error.args).map(
+            (value, index) => reporterOutputLoggerStub.error.args[index][0],
+          );
 
-      assert.include(messages.join(), 'Error connecting');
-    })));
+          assert.include(messages.join(), 'Error connecting');
+        })),
+    );
   });
 
   describe('when adding skipped test', () => {
@@ -180,12 +192,11 @@ describe('CLIReporter', () => {
 
     it('should write skip to the console', () => {
       const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, false));
+      new CLIReporter(emitter, {}, false);
       emitter.emit('test skip', test);
       assert.isOk(reporterOutputLoggerStub.skip.calledOnce);
     });
   });
-
 
   describe('when creating report', () => {
     before(() => {
@@ -199,23 +210,25 @@ describe('CLIReporter', () => {
 
     afterEach(() => reporterOutputLoggerStub.complete.restore());
 
-    describe('when there is at least one test', () => it('should write to the console', (done) => {
-      const emitter = new EventEmitter();
-      const cliReporter = new CLIReporter(emitter, {}, false);
-      cliReporter.stats.tests = 1;
-      emitter.emit('end', () => {
-        assert.isOk(reporterOutputLoggerStub.complete.calledTwice);
-        done();
-      });
-    }));
+    describe('when there is at least one test', () =>
+      it('should write to the console', (done) => {
+        const emitter = new EventEmitter();
+        const cliReporter = new CLIReporter(emitter, {}, false);
+        cliReporter.stats.tests = 1;
+        emitter.emit('end', () => {
+          assert.isOk(reporterOutputLoggerStub.complete.calledTwice);
+          done();
+        });
+      }));
 
-    describe('when there are no tests', () => it('should write to the console', (done) => {
-      const emitter = new EventEmitter();
-      (new CLIReporter(emitter, {}, false));
-      emitter.emit('end', () => {
-        assert.isOk(reporterOutputLoggerStub.complete.calledOnce);
-        done();
-      });
-    }));
+    describe('when there are no tests', () =>
+      it('should write to the console', (done) => {
+        const emitter = new EventEmitter();
+        new CLIReporter(emitter, {}, false);
+        emitter.emit('end', () => {
+          assert.isOk(reporterOutputLoggerStub.complete.calledOnce);
+          done();
+        });
+      }));
   });
 });

--- a/test/unit/reporters/DotReporter-test.js
+++ b/test/unit/reporters/DotReporter-test.js
@@ -17,9 +17,13 @@ describe('DotReporter', () => {
   let emitter;
   let dotReporter;
 
-  before(() => { loggerStub.transports.console.silent = true; });
+  before(() => {
+    loggerStub.transports.console.silent = true;
+  });
 
-  after(() => { loggerStub.transports.console.silent = false; });
+  after(() => {
+    loggerStub.transports.console.silent = false;
+  });
 
   beforeEach(() => {
     stats = {
@@ -41,7 +45,8 @@ describe('DotReporter', () => {
 
     afterEach(() => loggerStub.debug.restore());
 
-    it('should log that testing has begun', () => emitter.emit('start', '', () => assert.isOk(loggerStub.debug.called)));
+    it('should log that testing has begun', () =>
+      emitter.emit('start', '', () => assert.isOk(loggerStub.debug.called)));
   });
 
   describe('when ending', () => {
@@ -56,7 +61,10 @@ describe('DotReporter', () => {
       dotReporter.write.restore();
     });
 
-    it('should log that testing is complete', () => emitter.emit('end', () => assert.isOk(reporterOutputLoggerStub.complete.calledTwice)));
+    it('should log that testing is complete', () =>
+      emitter.emit('end', () =>
+        assert.isOk(reporterOutputLoggerStub.complete.calledTwice),
+      ));
 
     describe('when there are failures', () => {
       before(() => {
@@ -75,10 +83,11 @@ describe('DotReporter', () => {
 
       afterEach(() => reporterOutputLoggerStub.fail.restore());
 
-      it('should log the failures at the end of testing', done => emitter.emit('end', () => {
-        assert.isOk(reporterOutputLoggerStub.fail.called);
-        done();
-      }));
+      it('should log the failures at the end of testing', (done) =>
+        emitter.emit('end', () => {
+          assert.isOk(reporterOutputLoggerStub.fail.called);
+          done();
+        }));
     });
   });
 
@@ -98,7 +107,8 @@ describe('DotReporter', () => {
 
     after(() => dotReporter.write.restore());
 
-    it('should write a .', () => assert.isOk(dotReporter.write.calledWith('.')));
+    it('should write a .', () =>
+      assert.isOk(dotReporter.write.calledWith('.')));
   });
 
   describe('when test is skipped', () => {
@@ -117,7 +127,8 @@ describe('DotReporter', () => {
 
     after(() => dotReporter.write.restore());
 
-    it('should write a -', () => assert.isOk(dotReporter.write.calledWith('-')));
+    it('should write a -', () =>
+      assert.isOk(dotReporter.write.calledWith('-')));
   });
 
   describe('when test fails', () => {
@@ -136,7 +147,8 @@ describe('DotReporter', () => {
 
     after(() => dotReporter.write.restore());
 
-    it('should write an F', () => assert.isOk(dotReporter.write.calledWith('F')));
+    it('should write an F', () =>
+      assert.isOk(dotReporter.write.calledWith('F')));
   });
 
   describe('when test errors', () => {
@@ -155,6 +167,7 @@ describe('DotReporter', () => {
 
     after(() => dotReporter.write.restore());
 
-    it('should write an E', () => assert.isOk(dotReporter.write.calledWith('E')));
+    it('should write an E', () =>
+      assert.isOk(dotReporter.write.calledWith('E')));
   });
 });

--- a/test/unit/reporters/HTMLReporter-test.js
+++ b/test/unit/reporters/HTMLReporter-test.js
@@ -62,7 +62,8 @@ describe('HTMLReporter', () => {
         loggerStub.warn.restore();
       });
 
-      it('should warn about the existing file', () => assert.isOk(loggerStub.warn.called));
+      it('should warn about the existing file', () =>
+        assert.isOk(loggerStub.warn.called));
     });
 
     describe('when file does not exist', () => {
@@ -76,21 +77,27 @@ describe('HTMLReporter', () => {
         fsStub.unlinkSync.restore();
       });
 
-      it('should not attempt to delete a file', () => assert.isOk(fsStub.unlinkSync.notCalled));
+      it('should not attempt to delete a file', () =>
+        assert.isOk(fsStub.unlinkSync.notCalled));
     });
 
-    it('should write the prelude to the buffer', done => emitter.emit('start', '', () => {
-      assert.isOk(htmlReporter.buf.includes('Dredd'));
-      done();
-    }));
+    it('should write the prelude to the buffer', (done) =>
+      emitter.emit('start', '', () => {
+        assert.isOk(htmlReporter.buf.includes('Dredd'));
+        done();
+      }));
   });
 
   describe('when ending', () => {
-    before(() => { stats.tests = 1; });
+    before(() => {
+      stats.tests = 1;
+    });
 
     describe('when can create output directory', () => {
       beforeEach(() => {
-        sinon.stub(fsStub, 'writeFile').callsFake((path, data, callback) => callback());
+        sinon
+          .stub(fsStub, 'writeFile')
+          .callsFake((path, data, callback) => callback());
         makeDirStubImpl = sinon.spy(makeDirStubImpl);
       });
 
@@ -99,18 +106,23 @@ describe('HTMLReporter', () => {
         makeDirStubImpl = makeDirStubImplBackup;
       });
 
-      it('should write the file', done => emitter.emit('end', () => {
-        assert.isOk(makeDirStubImpl.called);
-        assert.isOk(fsStub.writeFile.called);
-        done();
-      }));
+      it('should write the file', (done) =>
+        emitter.emit('end', () => {
+          assert.isOk(makeDirStubImpl.called);
+          assert.isOk(fsStub.writeFile.called);
+          done();
+        }));
     });
 
     describe('when cannot create output directory', () => {
       beforeEach(() => {
         sinon.stub(reporterOutputLoggerStub, 'error');
-        sinon.stub(fsStub, 'writeFile').callsFake((path, data, callback) => callback());
-        makeDirStubImpl = sinon.stub().callsFake(() => Promise.reject(new Error()));
+        sinon
+          .stub(fsStub, 'writeFile')
+          .callsFake((path, data, callback) => callback());
+        makeDirStubImpl = sinon
+          .stub()
+          .callsFake(() => Promise.reject(new Error()));
       });
 
       after(() => {
@@ -119,12 +131,13 @@ describe('HTMLReporter', () => {
         makeDirStubImpl = makeDirStubImplBackup;
       });
 
-      it('should write to log', done => emitter.emit('end', () => {
-        assert.isOk(makeDirStubImpl.called);
-        assert.isOk(fsStub.writeFile.notCalled);
-        assert.isOk(reporterOutputLoggerStub.error.called);
-        done();
-      }));
+      it('should write to log', (done) =>
+        emitter.emit('end', () => {
+          assert.isOk(makeDirStubImpl.called);
+          assert.isOk(fsStub.writeFile.notCalled);
+          assert.isOk(reporterOutputLoggerStub.error.called);
+          done();
+        }));
     });
   });
 
@@ -142,11 +155,12 @@ describe('HTMLReporter', () => {
       assert.isOk(htmlReporter.buf.includes('Pass'));
     });
 
-    describe('when details=true', () => it('should write details for passing tests', () => {
-      htmlReporter.details = true;
-      emitter.emit('test pass', test);
-      assert.isOk(htmlReporter.buf.includes('Request'));
-    }));
+    describe('when details=true', () =>
+      it('should write details for passing tests', () => {
+        htmlReporter.details = true;
+        emitter.emit('test pass', test);
+        assert.isOk(htmlReporter.buf.includes('Request'));
+      }));
   });
 
   describe('when test is skipped', () => {

--- a/test/unit/reporters/MarkdownReporter-test.js
+++ b/test/unit/reporters/MarkdownReporter-test.js
@@ -50,7 +50,6 @@ describe('MarkdownReporter', () => {
     mdReporter = new MarkdownReporter(emitter, stats, 'test.md');
   });
 
-
   describe('when creating', () => {
     describe('when file exists', () => {
       before(() => {
@@ -63,7 +62,8 @@ describe('MarkdownReporter', () => {
         loggerStub.warn.restore();
       });
 
-      it('should warn about the existing file', () => assert.isOk(loggerStub.warn.called));
+      it('should warn about the existing file', () =>
+        assert.isOk(loggerStub.warn.called));
     });
 
     describe('when file does not exist', () => {
@@ -84,15 +84,19 @@ describe('MarkdownReporter', () => {
     });
   });
 
-  describe('when starting', () => it('should write the title to the buffer', done => emitter.emit('start', '', () => {
-    assert.isOk(mdReporter.buf.includes('Dredd'));
-    done();
-  })));
+  describe('when starting', () =>
+    it('should write the title to the buffer', (done) =>
+      emitter.emit('start', '', () => {
+        assert.isOk(mdReporter.buf.includes('Dredd'));
+        done();
+      })));
 
   describe('when ending', () => {
     describe('when can create output directory', () => {
       beforeEach(() => {
-        sinon.stub(fsStub, 'writeFile').callsFake((path, data, callback) => callback());
+        sinon
+          .stub(fsStub, 'writeFile')
+          .callsFake((path, data, callback) => callback());
         makeDirStubImpl = sinon.spy(makeDirStubImpl);
       });
 
@@ -101,19 +105,24 @@ describe('MarkdownReporter', () => {
         makeDirStubImpl = makeDirStubImplBackup;
       });
 
-      it('should write buffer to file', done => emitter.emit('end', () => {
-        emitter.emit('end', () => {});
-        assert.isOk(makeDirStubImpl.called);
-        assert.isOk(fsStub.writeFile.called);
-        done();
-      }));
+      it('should write buffer to file', (done) =>
+        emitter.emit('end', () => {
+          emitter.emit('end', () => {});
+          assert.isOk(makeDirStubImpl.called);
+          assert.isOk(fsStub.writeFile.called);
+          done();
+        }));
     });
 
     describe('when cannot create output directory', () => {
       beforeEach(() => {
-        sinon.stub(fsStub, 'writeFile').callsFake((path, data, callback) => callback());
+        sinon
+          .stub(fsStub, 'writeFile')
+          .callsFake((path, data, callback) => callback());
         sinon.stub(reporterOutputLoggerStub, 'error');
-        makeDirStubImpl = sinon.stub().callsFake(() => Promise.reject(new Error()));
+        makeDirStubImpl = sinon
+          .stub()
+          .callsFake(() => Promise.reject(new Error()));
       });
 
       after(() => {
@@ -122,12 +131,13 @@ describe('MarkdownReporter', () => {
         makeDirStubImpl = makeDirStubImplBackup;
       });
 
-      it('should write to log', done => emitter.emit('end', () => {
-        assert.isOk(makeDirStubImpl.called);
-        assert.isOk(fsStub.writeFile.notCalled);
-        assert.isOk(reporterOutputLoggerStub.error.called);
-        done();
-      }));
+      it('should write to log', (done) =>
+        emitter.emit('end', () => {
+          assert.isOk(makeDirStubImpl.called);
+          assert.isOk(fsStub.writeFile.notCalled);
+          assert.isOk(reporterOutputLoggerStub.error.called);
+          done();
+        }));
     });
   });
 
@@ -146,12 +156,13 @@ describe('MarkdownReporter', () => {
       done();
     });
 
-    describe('when details=true', () => it('should write details for passing tests', (done) => {
-      mdReporter.details = true;
-      emitter.emit('test pass', test);
-      assert.isOk(mdReporter.buf.includes('Request'));
-      done();
-    }));
+    describe('when details=true', () =>
+      it('should write details for passing tests', (done) => {
+        mdReporter.details = true;
+        emitter.emit('test pass', test);
+        assert.isOk(mdReporter.buf.includes('Request'));
+        done();
+      }));
   });
 
   describe('when test is skipped', () => {

--- a/test/unit/reporters/NyanReporter-test.js
+++ b/test/unit/reporters/NyanReporter-test.js
@@ -51,11 +51,12 @@ describe('NyanCatReporter', () => {
       nyanReporter.write.restore();
     });
 
-    it('should hide the cursor and draw the cat', done => emitter.emit('start', '', () => {
-      assert.isOk(nyanReporter.cursorHide.calledOnce);
-      assert.isOk(nyanReporter.draw.calledOnce);
-      done();
-    }));
+    it('should hide the cursor and draw the cat', (done) =>
+      emitter.emit('start', '', () => {
+        assert.isOk(nyanReporter.cursorHide.calledOnce);
+        assert.isOk(nyanReporter.draw.calledOnce);
+        done();
+      }));
   });
 
   describe('when ending', () => {
@@ -71,10 +72,11 @@ describe('NyanCatReporter', () => {
       nyanReporter.write.restore();
     });
 
-    it('should log that testing is complete', done => emitter.emit('end', () => {
-      assert.isOk(reporterOutputLoggerStub.complete.calledTwice);
-      done();
-    }));
+    it('should log that testing is complete', (done) =>
+      emitter.emit('end', () => {
+        assert.isOk(reporterOutputLoggerStub.complete.calledTwice);
+        done();
+      }));
 
     describe('when there are failures', () => {
       beforeEach(() => {
@@ -89,10 +91,11 @@ describe('NyanCatReporter', () => {
 
       afterEach(() => reporterOutputLoggerStub.fail.restore());
 
-      it('should log the failures at the end of testing', done => emitter.emit('end', () => {
-        assert.isOk(reporterOutputLoggerStub.fail.calledTwice);
-        done();
-      }));
+      it('should log the failures at the end of testing', (done) =>
+        emitter.emit('end', () => {
+          assert.isOk(reporterOutputLoggerStub.fail.calledTwice);
+          done();
+        }));
     });
   });
 
@@ -113,7 +116,8 @@ describe('NyanCatReporter', () => {
         nyanReporter.write.restore();
       });
 
-      it('should draw the cat', () => assert.isOk(nyanReporter.draw.calledOnce));
+      it('should draw the cat', () =>
+        assert.isOk(nyanReporter.draw.calledOnce));
     });
 
     describe('when test is skipped', () => {
@@ -132,7 +136,8 @@ describe('NyanCatReporter', () => {
         nyanReporter.write.restore();
       });
 
-      it('should draw the cat', () => assert.isOk(nyanReporter.draw.calledOnce));
+      it('should draw the cat', () =>
+        assert.isOk(nyanReporter.draw.calledOnce));
     });
 
     describe('when test fails', () => {
@@ -151,7 +156,8 @@ describe('NyanCatReporter', () => {
         nyanReporter.write.restore();
       });
 
-      it('should draw the cat', () => assert.isOk(nyanReporter.draw.calledOnce));
+      it('should draw the cat', () =>
+        assert.isOk(nyanReporter.draw.calledOnce));
     });
 
     describe('when test errors', () => {
@@ -170,7 +176,8 @@ describe('NyanCatReporter', () => {
         nyanReporter.draw.restore();
       });
 
-      it('should draw the cat', () => assert.isOk(nyanReporter.draw.calledOnce));
+      it('should draw the cat', () =>
+        assert.isOk(nyanReporter.draw.calledOnce));
     });
   });
 });

--- a/test/unit/reporters/XUnitReporter-test.js
+++ b/test/unit/reporters/XUnitReporter-test.js
@@ -48,7 +48,7 @@ describe('XUnitReporter', () => {
 
       it('should warn about the existing file', () => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, 'test.xml'));
+        new XUnitReporter(emitter, {}, 'test.xml');
         assert.isOk(loggerStub.warn.called);
       });
     });
@@ -66,7 +66,7 @@ describe('XUnitReporter', () => {
 
       it('should create the file', () => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, 'test.xml'));
+        new XUnitReporter(emitter, {}, 'test.xml');
         assert.isOk(fsStub.unlinkSync.notCalled);
       });
     });
@@ -86,7 +86,7 @@ describe('XUnitReporter', () => {
 
       it('should write opening to file', (done) => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, 'test.xml'));
+        new XUnitReporter(emitter, {}, 'test.xml');
         emitter.emit('start', '', () => {
           assert.isOk(makeDirStubImpl.called);
           assert.isOk(fsStub.appendFileSync.called);
@@ -99,7 +99,9 @@ describe('XUnitReporter', () => {
       beforeEach(() => {
         sinon.stub(fsStub, 'appendFileSync');
         sinon.stub(reporterOutputLoggerStub, 'error');
-        makeDirStubImpl = sinon.stub().callsFake(() => Promise.reject(new Error()));
+        makeDirStubImpl = sinon
+          .stub()
+          .callsFake(() => Promise.reject(new Error()));
       });
 
       after(() => {
@@ -110,7 +112,7 @@ describe('XUnitReporter', () => {
 
       it('should write to log', (done) => {
         const emitter = new EventEmitter();
-        (new XUnitReporter(emitter, {}, 'test.xml'));
+        new XUnitReporter(emitter, {}, 'test.xml');
         emitter.emit('start', '', () => {
           assert.isOk(makeDirStubImpl.called);
           assert.isOk(fsStub.appendFileSync.notCalled);
@@ -145,26 +147,28 @@ describe('XUnitReporter', () => {
         assert.isOk(fsStub.appendFileSync.called);
       });
 
-      describe('when the file writes successfully', () => it('should read the file and update the stats', (done) => {
-        const emitter = new EventEmitter();
-        const xUnitReporter = new XUnitReporter(emitter, {});
-        xUnitReporter.stats.tests = 1;
+      describe('when the file writes successfully', () =>
+        it('should read the file and update the stats', (done) => {
+          const emitter = new EventEmitter();
+          const xUnitReporter = new XUnitReporter(emitter, {});
+          xUnitReporter.stats.tests = 1;
 
+          emitter.emit('end', () => {
+            assert.isOk(fsStub.writeFile.called);
+            done();
+          });
+        }));
+    });
+
+    describe('when there are no tests', () =>
+      it('should write empty suite', (done) => {
+        const emitter = new EventEmitter();
+        new XUnitReporter(emitter, {});
         emitter.emit('end', () => {
           assert.isOk(fsStub.writeFile.called);
           done();
         });
       }));
-    });
-
-    describe('when there are no tests', () => it('should write empty suite', (done) => {
-      const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}));
-      emitter.emit('end', () => {
-        assert.isOk(fsStub.writeFile.called);
-        done();
-      });
-    }));
   });
 
   describe('when test passes', () => {
@@ -201,19 +205,20 @@ describe('XUnitReporter', () => {
 
     it('should write a passing test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, 'test.xml'));
+      new XUnitReporter(emitter, {}, 'test.xml');
       emitter.emit('test start', test);
       emitter.emit('test pass', test);
       assert.isOk(fsStub.appendFileSync.called);
     });
 
-    describe('when details=true', () => it('should write details for passing tests', () => {
-      const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, 'test.xml', true));
-      emitter.emit('test start', test);
-      emitter.emit('test pass', test);
-      assert.isOk(fsStub.appendFileSync.called);
-    }));
+    describe('when details=true', () =>
+      it('should write details for passing tests', () => {
+        const emitter = new EventEmitter();
+        new XUnitReporter(emitter, {}, 'test.xml', true);
+        emitter.emit('test start', test);
+        emitter.emit('test pass', test);
+        assert.isOk(fsStub.appendFileSync.called);
+      }));
   });
 
   describe('when test is skipped', () => {
@@ -230,7 +235,7 @@ describe('XUnitReporter', () => {
 
     it('should write a skipped test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, 'test.xml'));
+      new XUnitReporter(emitter, {}, 'test.xml');
       emitter.emit('test start', test);
       emitter.emit('test skip', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -251,7 +256,7 @@ describe('XUnitReporter', () => {
 
     it('should write a failed test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, 'test.xml'));
+      new XUnitReporter(emitter, {}, 'test.xml');
       emitter.emit('test start', test);
       emitter.emit('test fail', test);
       assert.isOk(fsStub.appendFileSync.called);
@@ -272,7 +277,7 @@ describe('XUnitReporter', () => {
 
     it('should write an error test', () => {
       const emitter = new EventEmitter();
-      (new XUnitReporter(emitter, {}, 'test.xml'));
+      new XUnitReporter(emitter, {}, 'test.xml');
       emitter.emit('test start', test);
       emitter.emit('test error', new Error('Error'), test);
       assert.isOk(fsStub.appendFileSync.called);

--- a/test/unit/resolveLocations-test.js
+++ b/test/unit/resolveLocations-test.js
@@ -3,7 +3,6 @@ const { assert } = require('chai');
 
 const resolveLocations = require('../../lib/resolveLocations');
 
-
 describe('resolveLocations()', () => {
   const workingDirectory = path.join(__filename, '..', '..', 'fixtures');
 

--- a/test/unit/resolveModule-test.js
+++ b/test/unit/resolveModule-test.js
@@ -3,28 +3,27 @@ const { assert } = require('chai');
 
 const resolveModule = require('../../lib/resolveModule');
 
-
 describe('resolveModule()', () => {
   const workingDirectory = path.join(__dirname, '..', 'fixtures');
 
   it('resolves a local module name', () => {
     assert.equal(
       resolveModule(workingDirectory, 'requiredModule'),
-      path.join(workingDirectory, 'requiredModule')
+      path.join(workingDirectory, 'requiredModule'),
     );
   });
 
   it('resolves a local module name with .js extension', () => {
     assert.equal(
       resolveModule(workingDirectory, 'requiredModule.js'),
-      path.join(workingDirectory, 'requiredModule.js')
+      path.join(workingDirectory, 'requiredModule.js'),
     );
   });
 
   it('resolves an installed module name', () => {
     assert.equal(
       resolveModule(workingDirectory, 'coffeescript/register'),
-      'coffeescript/register'
+      'coffeescript/register',
     );
   });
 });

--- a/test/unit/resolvePaths-test.js
+++ b/test/unit/resolvePaths-test.js
@@ -3,7 +3,6 @@ const { assert } = require('chai');
 
 const resolvePaths = require('../../lib/resolvePaths');
 
-
 describe('resolvePaths()', () => {
   const workingDirectory = path.join(__filename, '..', '..', 'fixtures');
 
@@ -29,7 +28,10 @@ describe('resolvePaths()', () => {
 
   describe('when given existing relative filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(workingDirectory, ['./hooks.js', './non-js-hooks.rb']);
+      const paths = resolvePaths(workingDirectory, [
+        './hooks.js',
+        './non-js-hooks.rb',
+      ]);
       assert.deepEqual(paths, [
         path.join(workingDirectory, 'hooks.js'),
         path.join(workingDirectory, 'non-js-hooks.rb'),
@@ -48,23 +50,27 @@ describe('resolvePaths()', () => {
   describe('when given glob pattern resolving to existing files', () => {
     it('resolves them into absolute paths', () => {
       const paths = resolvePaths(workingDirectory, ['./**/hooks.js']);
-      assert.deepEqual(paths, [
-        path.join(workingDirectory, 'hooks.js'),
-      ]);
+      assert.deepEqual(paths, [path.join(workingDirectory, 'hooks.js')]);
     });
   });
 
   describe('when given glob pattern resolving to no files', () => {
     it('throws an error', () => {
       assert.throws(() => {
-        resolvePaths(workingDirectory, ['./**/hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(workingDirectory, [
+          './**/hooks.js',
+          './**/foo/bar/foobar.js',
+        ]);
       }, './**/foo/bar/foobar.js');
     });
   });
 
   describe('when given both globs and filenames', () => {
     it('resolves them into absolute paths', () => {
-      const paths = resolvePaths(workingDirectory, ['./non-js-hooks.rb', './**/hooks.js']);
+      const paths = resolvePaths(workingDirectory, [
+        './non-js-hooks.rb',
+        './**/hooks.js',
+      ]);
       assert.deepEqual(paths, [
         path.join(workingDirectory, 'hooks.js'),
         path.join(workingDirectory, 'non-js-hooks.rb'),
@@ -79,7 +85,10 @@ describe('resolvePaths()', () => {
 
     it('throws an error on globs resolving to no files', () => {
       assert.throws(() => {
-        resolvePaths(workingDirectory, ['./hooks.js', './**/foo/bar/foobar.js']);
+        resolvePaths(workingDirectory, [
+          './hooks.js',
+          './**/foo/bar/foobar.js',
+        ]);
       }, './**/foo/bar/foobar.js');
     });
 

--- a/test/unit/transactionRunner-test.js
+++ b/test/unit/transactionRunner-test.js
@@ -49,61 +49,69 @@ describe('TransactionRunner', () => {
   });
 
   describe('constructor', () => {
-    beforeEach(() => { runner = new Runner(configuration); });
+    beforeEach(() => {
+      runner = new Runner(configuration);
+    });
 
-    it('should copy configuration', () => assert.isOk(runner.configuration.endpoint));
+    it('should copy configuration', () =>
+      assert.isOk(runner.configuration.endpoint));
 
-    it('should have an empty hookStash object', () => assert.deepEqual(runner.hookStash, {}));
+    it('should have an empty hookStash object', () =>
+      assert.deepEqual(runner.hookStash, {}));
 
-    it('should have an empty array of logs object', () => assert.deepEqual(runner.logs, []));
+    it('should have an empty array of logs object', () =>
+      assert.deepEqual(runner.logs, []));
   });
 
   describe('config(config)', () => {
-    describe('when single file in apiDescriptions is present', () => it('should set multiBlueprint to false', () => {
-      configuration = {
-        endpoint: 'http://127.0.0.1:3000',
-        emitter: new EventEmitter(),
-        apiDescriptions: [{ location: 'filename.api', content: '...' }],
-        custom: { cwd: process.cwd() },
-        'dry-run': false,
-        method: [],
-        only: [],
-        header: [],
-        reporter: [],
-      };
+    describe('when single file in apiDescriptions is present', () =>
+      it('should set multiBlueprint to false', () => {
+        configuration = {
+          endpoint: 'http://127.0.0.1:3000',
+          emitter: new EventEmitter(),
+          apiDescriptions: [{ location: 'filename.api', content: '...' }],
+          custom: { cwd: process.cwd() },
+          'dry-run': false,
+          method: [],
+          only: [],
+          header: [],
+          reporter: [],
+        };
 
-      runner = new Runner(configuration);
-      runner.config(configuration);
+        runner = new Runner(configuration);
+        runner.config(configuration);
 
-      assert.notOk(runner.multiBlueprint);
-    }));
+        assert.notOk(runner.multiBlueprint);
+      }));
 
-    describe('when multiple files in apiDescriptions are present', () => it('should set multiBlueprint to true', () => {
-      configuration = {
-        endpoint: 'http://127.0.0.1:3000',
-        emitter: new EventEmitter(),
-        apiDescriptions: [
-          { location: 'filename1.api', content: '...' },
-          { location: 'filename2.api', content: '...' },
-        ],
-        custom: { cwd: process.cwd() },
-        'dry-run': false,
-        method: [],
-        only: [],
-        header: [],
-        reporter: [],
-      };
-      runner = new Runner(configuration);
-      runner.config(configuration);
+    describe('when multiple files in apiDescriptions are present', () =>
+      it('should set multiBlueprint to true', () => {
+        configuration = {
+          endpoint: 'http://127.0.0.1:3000',
+          emitter: new EventEmitter(),
+          apiDescriptions: [
+            { location: 'filename1.api', content: '...' },
+            { location: 'filename2.api', content: '...' },
+          ],
+          custom: { cwd: process.cwd() },
+          'dry-run': false,
+          method: [],
+          only: [],
+          header: [],
+          reporter: [],
+        };
+        runner = new Runner(configuration);
+        runner.config(configuration);
 
-      assert.isOk(runner.multiBlueprint);
-    }));
+        assert.isOk(runner.multiBlueprint);
+      }));
   });
 
   describe('configureTransaction(transaction)', () => {
     beforeEach(() => {
       transaction = {
-        name: 'Machines API > Group Machine > Machine > Delete Message > Bogus example name',
+        name:
+          'Machines API > Group Machine > Machine > Delete Message > Bogus example name',
         request: {
           body: '{\n  "type": "bulldozer",\n  "name": "willy"}\n',
           headers: {
@@ -115,7 +123,8 @@ describe('TransactionRunner', () => {
           method: 'POST',
         },
         response: {
-          body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+          body:
+            '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           headers: {
             'content-type': {
               value: 'application/json',
@@ -140,146 +149,212 @@ describe('TransactionRunner', () => {
       const filename = 'api-description.apib';
       let configuredTransaction;
 
-      [{
-        description: 'is hostname',
-        input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello',
+      [
+        {
+          description: 'is hostname',
+          input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'https:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'is IPv4',
-        input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'https:', fullPath: '/hello',
+        {
+          description: 'is IPv4',
+          input: { serverUrl: 'https://127.0.0.1:8000', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'https:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'has path',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello',
+        {
+          description: 'has path',
+          input: {
+            serverUrl: 'http://127.0.0.1:8000/v1',
+            requestPath: '/hello',
+          },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1/hello',
+          },
         },
-      },
-      {
-        description: 'has path with trailing slash',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/hello',
+        {
+          description: 'has path with trailing slash',
+          input: {
+            serverUrl: 'http://127.0.0.1:8000/v1/',
+            requestPath: '/hello',
+          },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1/hello',
+          },
         },
-      },
-      {
-        description: 'has path and request path is /',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/',
+        {
+          description: 'has path and request path is /',
+          input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '/' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1/',
+          },
         },
-      },
-      {
-        description: 'has path with trailing slash and request path is /',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/',
+        {
+          description: 'has path with trailing slash and request path is /',
+          input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '/' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1/',
+          },
         },
-      },
-      {
-        description: 'has path and request has no path',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1',
+        {
+          description: 'has path and request has no path',
+          input: { serverUrl: 'http://127.0.0.1:8000/v1', requestPath: '' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1',
+          },
         },
-      },
-      {
-        description: 'has path with trailing slash and request has no path',
-        input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '' },
-        expected: {
-          host: '127.0.0.1', port: '8000', protocol: 'http:', fullPath: '/v1/',
+        {
+          description: 'has path with trailing slash and request has no path',
+          input: { serverUrl: 'http://127.0.0.1:8000/v1/', requestPath: '' },
+          expected: {
+            host: '127.0.0.1',
+            port: '8000',
+            protocol: 'http:',
+            fullPath: '/v1/',
+          },
         },
-      },
-      {
-        description: 'is hostname with no protocol',
-        input: { serverUrl: '127.0.0.1', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello',
+        {
+          description: 'is hostname with no protocol',
+          input: { serverUrl: '127.0.0.1', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: null,
+            protocol: 'http:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'is IPv4 with no protocol',
-        input: { serverUrl: '127.0.0.1:4000', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: '4000', protocol: 'http:', fullPath: '/hello',
+        {
+          description: 'is IPv4 with no protocol',
+          input: { serverUrl: '127.0.0.1:4000', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: '4000',
+            protocol: 'http:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'is hostname with // instead of protocol',
-        input: { serverUrl: '//127.0.0.1', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello',
+        {
+          description: 'is hostname with // instead of protocol',
+          input: { serverUrl: '//127.0.0.1', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: null,
+            protocol: 'http:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'is hostname with trailing slash',
-        input: { serverUrl: 'http://127.0.0.1/', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello',
+        {
+          description: 'is hostname with trailing slash',
+          input: { serverUrl: 'http://127.0.0.1/', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: null,
+            protocol: 'http:',
+            fullPath: '/hello',
+          },
         },
-      },
-      {
-        description: 'is hostname with no protocol and with trailing slash',
-        input: { serverUrl: '127.0.0.1/', requestPath: '/hello' },
-        expected: {
-          host: '127.0.0.1', port: null, protocol: 'http:', fullPath: '/hello',
+        {
+          description: 'is hostname with no protocol and with trailing slash',
+          input: { serverUrl: '127.0.0.1/', requestPath: '/hello' },
+          expected: {
+            host: '127.0.0.1',
+            port: null,
+            protocol: 'http:',
+            fullPath: '/hello',
+          },
         },
-      },
+      ].forEach(({ description, input, expected }) =>
+        context(
+          `${description}: '${input.serverUrl}' + '${input.requestPath}'`,
+          () => {
+            beforeEach(() => {
+              runner.configuration.endpoint = input.serverUrl;
+              transaction.request.uri = input.requestPath;
+              transaction.origin.filename = filename;
+              transaction.apiDescription = {
+                mediaType: 'text/vnd.apiblueprint',
+              };
+              configuredTransaction = runner.configureTransaction(transaction);
+            });
 
-      ].forEach(({ description, input, expected }) => context(`${description}: '${input.serverUrl}' + '${input.requestPath}'`, () => {
-        beforeEach(() => {
-          runner.configuration.endpoint = input.serverUrl;
-          transaction.request.uri = input.requestPath;
-          transaction.origin.filename = filename;
-          transaction.apiDescription = { mediaType: 'text/vnd.apiblueprint' };
-          configuredTransaction = runner.configureTransaction(transaction);
-        });
-
-        it(`the transaction gets configured with fullPath '${expected.fullPath}' and has expected host, port, and protocol`, () => assert.deepEqual({
-          host: configuredTransaction.host,
-          port: configuredTransaction.port,
-          protocol: configuredTransaction.protocol,
-          fullPath: configuredTransaction.fullPath,
-        }, expected));
-      }));
+            it(`the transaction gets configured with fullPath '${expected.fullPath}' and has expected host, port, and protocol`, () =>
+              assert.deepEqual(
+                {
+                  host: configuredTransaction.host,
+                  port: configuredTransaction.port,
+                  protocol: configuredTransaction.protocol,
+                  fullPath: configuredTransaction.fullPath,
+                },
+                expected,
+              ));
+          },
+        ),
+      );
     });
 
     describe('when processing OpenAPI 2 document and given transaction has non-2xx status code', () => {
       const filename = 'api-description.yml';
       let configuredTransaction;
 
-      ['100', '400', 199, 300].forEach(status => context(`status code: ${JSON.stringify(status)}`, () => {
-        beforeEach(() => {
-          transaction.response.status = status;
-          transaction.origin.filename = filename;
-          transaction.apiDescription = { mediaType: 'application/swagger+json' };
-          configuredTransaction = runner.configureTransaction(transaction);
-        });
+      ['100', '400', 199, 300].forEach((status) =>
+        context(`status code: ${JSON.stringify(status)}`, () => {
+          beforeEach(() => {
+            transaction.response.status = status;
+            transaction.origin.filename = filename;
+            transaction.apiDescription = {
+              mediaType: 'application/swagger+json',
+            };
+            configuredTransaction = runner.configureTransaction(transaction);
+          });
 
-        it('skips the transaction by default', () => assert.isTrue(configuredTransaction.skip));
-      }));
+          it('skips the transaction by default', () =>
+            assert.isTrue(configuredTransaction.skip));
+        }),
+      );
     });
 
     describe('when processing OpenAPI 2 document and given transaction has 2xx status code', () => {
       const filename = 'api-description.yml';
       let configuredTransaction;
 
-      ['200', 299].forEach(status => context(`status code: ${JSON.stringify(status)}`, () => {
-        beforeEach(() => {
-          transaction.response.status = status;
-          transaction.origin.filename = filename;
-          transaction.apiDescription = { mediaType: 'application/swagger+json' };
-          configuredTransaction = runner.configureTransaction(transaction);
-        });
+      ['200', 299].forEach((status) =>
+        context(`status code: ${JSON.stringify(status)}`, () => {
+          beforeEach(() => {
+            transaction.response.status = status;
+            transaction.origin.filename = filename;
+            transaction.apiDescription = {
+              mediaType: 'application/swagger+json',
+            };
+            configuredTransaction = runner.configureTransaction(transaction);
+          });
 
-        it('does not skip the transaction by default', () => assert.isFalse(configuredTransaction.skip));
-      }));
+          it('does not skip the transaction by default', () =>
+            assert.isFalse(configuredTransaction.skip));
+        }),
+      );
     });
 
     describe('when processing other than OpenAPI 2 document and given transaction has non-2xx status code', () => {
@@ -293,25 +368,29 @@ describe('TransactionRunner', () => {
         configuredTransaction = runner.configureTransaction(transaction);
       });
 
-      it('does not skip the transaction by default', () => assert.isFalse(configuredTransaction.skip));
+      it('does not skip the transaction by default', () =>
+        assert.isFalse(configuredTransaction.skip));
     });
 
-    describe('when processing multiple API description documents', () => it('should include api name in the transaction name', () => {
-      runner.multiBlueprint = true;
-      const configuredTransaction = runner.configureTransaction(transaction);
-      assert.include(configuredTransaction.name, 'Machines API');
-    }));
+    describe('when processing multiple API description documents', () =>
+      it('should include api name in the transaction name', () => {
+        runner.multiBlueprint = true;
+        const configuredTransaction = runner.configureTransaction(transaction);
+        assert.include(configuredTransaction.name, 'Machines API');
+      }));
 
-    describe('when processing only single API description document', () => it('should not include api name in the transaction name', () => {
-      runner.multiBlueprint = false;
-      const configuredTransaction = runner.configureTransaction(transaction);
-      assert.notInclude(configuredTransaction.name, 'Machines API');
-    }));
+    describe('when processing only single API description document', () =>
+      it('should not include api name in the transaction name', () => {
+        runner.multiBlueprint = false;
+        const configuredTransaction = runner.configureTransaction(transaction);
+        assert.notInclude(configuredTransaction.name, 'Machines API');
+      }));
 
-    describe('when request does not have User-Agent', () => it('should add the Dredd User-Agent', () => {
-      const configuredTransaction = runner.configureTransaction(transaction);
-      assert.isOk(configuredTransaction.request.headers['User-Agent']);
-    }));
+    describe('when request does not have User-Agent', () =>
+      it('should add the Dredd User-Agent', () => {
+        const configuredTransaction = runner.configureTransaction(transaction);
+        assert.isOk(configuredTransaction.request.headers['User-Agent']);
+      }));
 
     describe('when an additional header has a colon', () => {
       beforeEach(() => {
@@ -322,24 +401,32 @@ describe('TransactionRunner', () => {
 
       it('should include the entire value in the header', () => {
         const configuredTransaction = runner.configureTransaction(transaction);
-        assert.equal(configuredTransaction.request.headers.MyCustomDate, 'Wed, 10 Sep 2014 12:34:26 GMT');
+        assert.equal(
+          configuredTransaction.request.headers.MyCustomDate,
+          'Wed, 10 Sep 2014 12:34:26 GMT',
+        );
       });
     });
 
-    describe('when configuring a transaction', () => it('should callback with a properly configured transaction', () => {
-      const configuredTransaction = runner.configureTransaction(transaction);
-      assert.equal(configuredTransaction.name, 'Group Machine > Machine > Delete Message > Bogus example name');
-      assert.equal(configuredTransaction.id, 'POST (202) /machines');
-      assert.isOk(configuredTransaction.host);
-      assert.isOk(configuredTransaction.request);
-      assert.isOk(configuredTransaction.expected);
-      assert.strictEqual(transaction.origin, configuredTransaction.origin);
-    }));
+    describe('when configuring a transaction', () =>
+      it('should callback with a properly configured transaction', () => {
+        const configuredTransaction = runner.configureTransaction(transaction);
+        assert.equal(
+          configuredTransaction.name,
+          'Group Machine > Machine > Delete Message > Bogus example name',
+        );
+        assert.equal(configuredTransaction.id, 'POST (202) /machines');
+        assert.isOk(configuredTransaction.host);
+        assert.isOk(configuredTransaction.request);
+        assert.isOk(configuredTransaction.expected);
+        assert.strictEqual(transaction.origin, configuredTransaction.origin);
+      }));
 
     describe('when endpoint URL contains PORT and path', () => {
       beforeEach(() => {
         const configurationWithPath = clone(configuration);
-        configurationWithPath.endpoint = 'https://hostname.tld:9876/my/path/to/api/';
+        configurationWithPath.endpoint =
+          'https://hostname.tld:9876/my/path/to/api/';
         runner = new Runner(configurationWithPath);
       });
 
@@ -349,14 +436,20 @@ describe('TransactionRunner', () => {
         assert.strictEqual(configuredTransaction.host, 'hostname.tld');
         assert.equal(configuredTransaction.port, 9876);
         assert.strictEqual(configuredTransaction.protocol, 'https:');
-        assert.strictEqual(configuredTransaction.fullPath, '/my/path/to/api/machines');
+        assert.strictEqual(
+          configuredTransaction.fullPath,
+          '/my/path/to/api/machines',
+        );
       });
 
       it('should keep trailing slash in url if present', () => {
         transaction.request.uri = '/machines/';
         const configuredTransaction = runner.configureTransaction(transaction);
         assert.equal(configuredTransaction.id, 'POST (202) /machines/');
-        assert.strictEqual(configuredTransaction.fullPath, '/my/path/to/api/machines/');
+        assert.strictEqual(
+          configuredTransaction.fullPath,
+          '/my/path/to/api/machines/',
+        );
       });
     });
   });
@@ -380,7 +473,8 @@ describe('TransactionRunner', () => {
         },
         expected: {
           headers: { 'content-type': 'application/json' },
-          body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+          body:
+            '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           status: '202',
         },
         origin: {
@@ -406,10 +500,11 @@ describe('TransactionRunner', () => {
         configuration.names = false;
       });
 
-      it('should print the names and return', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(loggerStub.debug.called);
-        done();
-      }));
+      it('should print the names and return', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(loggerStub.debug.called);
+          done();
+        }));
     });
 
     describe('when a dry run', () => {
@@ -419,16 +514,16 @@ describe('TransactionRunner', () => {
         sinon.spy(runner, 'performRequestAndValidate');
       });
 
-
       afterEach(() => {
         configuration['dry-run'] = false;
         runner.performRequestAndValidate.restore();
       });
 
-      it('should skip the tests', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(runner.performRequestAndValidate.notCalled);
-        done();
-      }));
+      it('should skip the tests', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(runner.performRequestAndValidate.notCalled);
+          done();
+        }));
     });
 
     describe('when only certain methods are allowed by the configuration', () => {
@@ -443,21 +538,24 @@ describe('TransactionRunner', () => {
         runner.skipTransaction.restore();
       });
 
-      it('should only perform those requests', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(runner.skipTransaction.called);
-        done();
-      }));
+      it('should only perform those requests', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(runner.skipTransaction.called);
+          done();
+        }));
     });
 
     describe('when only certain names are allowed by the configuration', () => {
       beforeEach(() => {
         server = nock('http://127.0.0.1:3000')
           .post('/machines', { type: 'bulldozer', name: 'willy' })
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
 
-        configuration.only = ['Group Machine > Machine > Delete Message > Bogus example name'];
+        configuration.only = [
+          'Group Machine > Machine > Delete Message > Bogus example name',
+        ];
         runner = new Runner(configuration);
         sinon.spy(runner, 'skipTransaction');
       });
@@ -468,13 +566,15 @@ describe('TransactionRunner', () => {
         nock.cleanAll();
       });
 
-      it('should not skip transactions with matching names', done => runner.executeTransaction(transaction, () => {
-        assert.notOk(runner.skipTransaction.called);
-        done();
-      }));
+      it('should not skip transactions with matching names', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.notOk(runner.skipTransaction.called);
+          done();
+        }));
 
       it('should skip transactions with different names', (done) => {
-        transaction.name = 'Group Machine > Machine > Delete Message > Bogus different example name';
+        transaction.name =
+          'Group Machine > Machine > Delete Message > Bogus different example name';
         runner.executeTransaction(transaction, () => {
           assert.isOk(runner.skipTransaction.called);
           done();
@@ -493,11 +593,15 @@ describe('TransactionRunner', () => {
         runner = new Runner(configuration);
 
         addHooks(runner, [clonedTransaction], (err) => {
-          if (err) { return done(err); }
+          if (err) {
+            return done(err);
+          }
 
           runner.hooks.beforeHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.skip = true; },
+              (hookTransaction) => {
+                hookTransaction.skip = true;
+              },
             ],
           };
           done();
@@ -509,56 +613,99 @@ describe('TransactionRunner', () => {
       // If you happen to wonder why some of the callbacks in following tests
       // get executed twice, see try/catch in runHooksForData() in TransactionRunner.js
 
-      it('should skip the test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
-        assert.isOk(configuration.emitter.emit.calledWith('test skip'));
-        done(err);
-      }));
+      it('should skip the test', (done) =>
+        runner.executeAllTransactions(
+          [clonedTransaction],
+          runner.hooks,
+          (err) => {
+            assert.isOk(configuration.emitter.emit.calledWith('test skip'));
+            done(err);
+          },
+        ));
 
-      it('should add skip message as a warning under `errors` to the results on transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
-        const messages = clonedTransaction.errors.map(value => value.message);
-        assert.include(messages.join().toLowerCase(), 'skipped');
-        done(err);
-      }));
+      it('should add skip message as a warning under `errors` to the results on transaction', (done) =>
+        runner.executeAllTransactions(
+          [clonedTransaction],
+          runner.hooks,
+          (err) => {
+            const messages = clonedTransaction.errors.map(
+              (value) => value.message,
+            );
+            assert.include(messages.join().toLowerCase(), 'skipped');
+            done(err);
+          },
+        ));
 
-      it('should add fail message as a warning under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
-        const messages = [];
-        const { callCount } = configuration.emitter.emit;
-        for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-          messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-            value => value.message
-          ));
-        }
-        assert.include(messages.join().toLowerCase(), 'skipped');
-        done(err);
-      }));
+      it('should add fail message as a warning under `errors` to the results on test passed to the emitter', (done) =>
+        runner.executeAllTransactions(
+          [clonedTransaction],
+          runner.hooks,
+          (err) => {
+            const messages = [];
+            const { callCount } = configuration.emitter.emit;
+            for (
+              let callNo = 0, end = callCount - 1, asc = end >= 0;
+              asc ? callNo <= end : callNo >= end;
+              asc ? callNo++ : callNo--
+            ) {
+              messages.push(
+                configuration.emitter.emit
+                  .getCall(callNo)
+                  .args[1].errors.map((value) => value.message),
+              );
+            }
+            assert.include(messages.join().toLowerCase(), 'skipped');
+            done(err);
+          },
+        ));
 
-      it('should set status `skip` on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, (err) => {
-        const tests = [];
-        Object.keys(configuration.emitter.emit.args).forEach((value) => {
-          const args = configuration.emitter.emit.args[value];
-          if (args[0] === 'test skip') { tests.push(args[1]); }
-        });
+      it('should set status `skip` on test passed to the emitter', (done) =>
+        runner.executeAllTransactions(
+          [clonedTransaction],
+          runner.hooks,
+          (err) => {
+            const tests = [];
+            Object.keys(configuration.emitter.emit.args).forEach((value) => {
+              const args = configuration.emitter.emit.args[value];
+              if (args[0] === 'test skip') {
+                tests.push(args[1]);
+              }
+            });
 
-        assert.equal(tests.length, 1);
-        assert.equal(tests[0].status, 'skip');
-        done(err);
-      }));
+            assert.equal(tests.length, 1);
+            assert.equal(tests[0].status, 'skip');
+            done(err);
+          },
+        ));
 
-      it('should set transaction info on the skipped test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-        assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
-        assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
-        assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
-        done();
-      }));
+      it('should set transaction info on the skipped test', (done) =>
+        runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
+          assert.propertyVal(
+            clonedTransaction.test,
+            'request',
+            clonedTransaction.request,
+          );
+          assert.propertyVal(
+            clonedTransaction.test,
+            'expected',
+            clonedTransaction.expected,
+          );
+          assert.propertyVal(
+            clonedTransaction.test,
+            'actual',
+            clonedTransaction.real,
+          );
+          done();
+        }));
     });
 
     describe('when server uses https', () => {
       beforeEach(() => {
         server = nock('https://127.0.0.1:3000')
           .post('/machines', { type: 'bulldozer', name: 'willy' })
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
         configuration.endpoint = 'https://127.0.0.1:3000';
         transaction.protocol = 'https:';
         runner = new Runner(configuration);
@@ -566,19 +713,20 @@ describe('TransactionRunner', () => {
 
       afterEach(() => nock.cleanAll());
 
-      it('should make the request with https', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(server.isDone());
-        done();
-      }));
+      it('should make the request with https', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(server.isDone());
+          done();
+        }));
     });
 
     describe('when server uses http', () => {
       beforeEach(() => {
         server = nock('http://127.0.0.1:3000')
           .post('/machines', { type: 'bulldozer', name: 'willy' })
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
         configuration.endpoint = 'http://127.0.0.1:3000';
         transaction.protocol = 'http:';
         runner = new Runner(configuration);
@@ -586,51 +734,53 @@ describe('TransactionRunner', () => {
 
       afterEach(() => nock.cleanAll());
 
-      it('should make the request with http', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(server.isDone());
-        done();
-      }));
+      it('should make the request with http', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(server.isDone());
+          done();
+        }));
     });
 
     describe('when backend responds as it should', () => {
       beforeEach(() => {
         server = nock('http://127.0.0.1:3000')
           .post('/machines', { type: 'bulldozer', name: 'willy' })
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
         runner = new Runner(configuration);
       });
 
       afterEach(() => nock.cleanAll());
 
-      it('should perform the request', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(server.isDone());
-        done();
-      }));
+      it('should perform the request', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(server.isDone());
+          done();
+        }));
 
-      it('should not return an error', done => runner.executeTransaction(transaction, (error) => {
-        assert.notOk(error);
-        done();
-      }));
+      it('should not return an error', (done) =>
+        runner.executeTransaction(transaction, (error) => {
+          assert.notOk(error);
+          done();
+        }));
     });
 
     describe('when backend responds with invalid response', () => {
       beforeEach(() => {
         server = nock('http://127.0.0.1:3000')
           .post('/machines', { type: 'bulldozer', name: 'willy' })
-          .reply(400,
-            'Foo bar',
-            { 'Content-Type': 'text/plain' });
+          .reply(400, 'Foo bar', { 'Content-Type': 'text/plain' });
         runner = new Runner(configuration);
       });
 
       afterEach(() => nock.cleanAll());
 
-      it('should perform the request', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(server.isDone());
-        done();
-      }));
+      it('should perform the request', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(server.isDone());
+          done();
+        }));
     });
 
     describe('when backend responds a GET request with a redirection', () => {
@@ -642,19 +792,20 @@ describe('TransactionRunner', () => {
           .get('/machines/latest')
           .reply(303, '', { Location: '/machines/123' })
           .get('/machines/123')
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
         runner = new Runner(configuration);
       });
 
       afterEach(() => nock.cleanAll());
 
-      it('should not follow the redirect', done => runner.executeTransaction(transaction, () => {
-        assert.equal(transaction.real.statusCode, 303);
-        assert.notOk(server.isDone());
-        done();
-      }));
+      it('should not follow the redirect', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.equal(transaction.real.statusCode, 303);
+          assert.notOk(server.isDone());
+          done();
+        }));
     });
 
     describe('when backend responds a POST request with a redirection', () => {
@@ -664,19 +815,20 @@ describe('TransactionRunner', () => {
           .post('/machines')
           .reply(303, '', { Location: '/machines/123' })
           .get('/machines/123')
-          .reply(transaction.expected.status,
-            transaction.expected.body,
-            { 'Content-Type': 'application/json' });
+          .reply(transaction.expected.status, transaction.expected.body, {
+            'Content-Type': 'application/json',
+          });
         runner = new Runner(configuration);
       });
 
       afterEach(() => nock.cleanAll());
 
-      it('should not follow the redirect', done => runner.executeTransaction(transaction, () => {
-        assert.equal(transaction.real.statusCode, 303);
-        assert.notOk(server.isDone());
-        done();
-      }));
+      it('should not follow the redirect', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.equal(transaction.real.statusCode, 303);
+          assert.notOk(server.isDone());
+          done();
+        }));
     });
 
     describe('when server is not running', () => {
@@ -687,12 +839,15 @@ describe('TransactionRunner', () => {
 
       afterEach(() => configuration.emitter.emit.restore());
 
-      it('should report a error', done => runner.executeTransaction(transaction, () => {
-        assert.isOk(configuration.emitter.emit.called);
-        const events = Object.keys(configuration.emitter.emit.args).map(value => configuration.emitter.emit.args[value][0]);
-        assert.include(events, 'test error');
-        done();
-      }));
+      it('should report a error', (done) =>
+        runner.executeTransaction(transaction, () => {
+          assert.isOk(configuration.emitter.emit.called);
+          const events = Object.keys(configuration.emitter.emit.args).map(
+            (value) => configuration.emitter.emit.args[value][0],
+          );
+          assert.include(events, 'test error');
+          done();
+        }));
     });
   });
 
@@ -727,7 +882,8 @@ describe('TransactionRunner', () => {
           },
           expected: {
             headers: { 'content-type': 'application/json' },
-            body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+            body:
+              '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
             statusCode: '202',
           },
           origin: {
@@ -760,7 +916,9 @@ describe('TransactionRunner', () => {
       spies = {};
       spyNames.forEach((name) => {
         spies[name] = (data, hooksCallback) => hooksCallback();
-        sinon.stub(spies, name).callsFake((data, hooksCallback) => hooksCallback());
+        sinon
+          .stub(spies, name)
+          .callsFake((data, hooksCallback) => hooksCallback());
       });
 
       hooks.beforeAll(spies.beforeAllSpy);
@@ -779,21 +937,23 @@ describe('TransactionRunner', () => {
 
       serverNock1 = nock('http://127.0.0.1:3000')
         .post('/machines1', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode,
-          transaction.expected.body,
-          { 'Content-Type': 'application/json' });
+        .reply(transaction.expected.statusCode, transaction.expected.body, {
+          'Content-Type': 'application/json',
+        });
 
       serverNock2 = nock('http://127.0.0.1:3000')
         .post('/machines2', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode,
-          transaction.expected.body,
-          { 'Content-Type': 'application/json' });
+        .reply(transaction.expected.statusCode, transaction.expected.body, {
+          'Content-Type': 'application/json',
+        });
     });
 
     afterEach(() => {
       nock.cleanAll();
 
-      Object.keys(spies).forEach((name) => { spies[name].restore(); });
+      Object.keys(spies).forEach((name) => {
+        spies[name].restore();
+      });
 
       runner = null;
       hooks = null;
@@ -806,39 +966,60 @@ describe('TransactionRunner', () => {
 
     describe('when the hooks handler is used', () => {
       describe("and it doesn't crash", () => {
-        it('should perform all transactions', done => runner.executeAllTransactions(transactions, hooks, (error) => {
-          if (error) { return done(error); }
-          assert.isTrue(serverNock1.isDone(), 'first resource');
-          assert.isTrue(serverNock2.isDone(), 'second resource');
-          done();
-        }));
+        it('should perform all transactions', (done) =>
+          runner.executeAllTransactions(transactions, hooks, (error) => {
+            if (error) {
+              return done(error);
+            }
+            assert.isTrue(serverNock1.isDone(), 'first resource');
+            assert.isTrue(serverNock2.isDone(), 'second resource');
+            done();
+          }));
 
-        it('should execute all ‘all’ hooks once', done => runner.executeAllTransactions(transactions, hooks, (error) => {
-          if (error) { return done(error); }
-          Object.keys(spies).forEach((spyName) => {
-            if (spyName !== 'beforeAllSpy') { return; }
-            if (spyName !== 'afterAllSpy') { return; }
-            assert.isTrue(spies[spyName].called, spyName);
-          });
-          done();
-        }));
+        it('should execute all ‘all’ hooks once', (done) =>
+          runner.executeAllTransactions(transactions, hooks, (error) => {
+            if (error) {
+              return done(error);
+            }
+            Object.keys(spies).forEach((spyName) => {
+              if (spyName !== 'beforeAllSpy') {
+                return;
+              }
+              if (spyName !== 'afterAllSpy') {
+                return;
+              }
+              assert.isTrue(spies[spyName].called, spyName);
+            });
+            done();
+          }));
 
-        it('should execute all other hooks once', done => runner.executeAllTransactions(transactions, hooks, (error) => {
-          if (error) { return done(error); }
-          if (error) { return done(error); }
-          Object.keys(spies).forEach((spyName) => {
-            if (spyName !== 'beforeAllSpy') { return; }
-            if (spyName !== 'afterAllSpy') { return; }
-            assert.isTrue(spies[spyName].calledTwice, spyName);
-          });
-          done();
-        }));
+        it('should execute all other hooks once', (done) =>
+          runner.executeAllTransactions(transactions, hooks, (error) => {
+            if (error) {
+              return done(error);
+            }
+            if (error) {
+              return done(error);
+            }
+            Object.keys(spies).forEach((spyName) => {
+              if (spyName !== 'beforeAllSpy') {
+                return;
+              }
+              if (spyName !== 'afterAllSpy') {
+                return;
+              }
+              assert.isTrue(spies[spyName].calledTwice, spyName);
+            });
+            done();
+          }));
       });
 
       describe('and it crashes (hooks handler error was set)', () => {
         describe('before any hook is executed', () => {
           beforeEach((done) => {
-            runner.hookHandlerError = new Error('handler died in before everything');
+            runner.hookHandlerError = new Error(
+              'handler died in before everything',
+            );
             runner.executeAllTransactions(transactions, hooks, (error) => {
               // Setting expectation for this error below in each describe block
               returnedError = error;
@@ -857,7 +1038,8 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'everything'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'everything'));
         });
 
         describe('after ‘beforeAll’ hook is executed', () => {
@@ -876,11 +1058,14 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
           it('should not perform any other hook', () => {
             Object.keys(spies || {}).forEach((spyName) => {
-              if (spyName === 'beforeAllSpy') { return; }
+              if (spyName === 'beforeAllSpy') {
+                return;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             });
           });
@@ -890,7 +1075,8 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'beforeAll'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'beforeAll'));
         });
 
         describe('after ‘beforeEach’ hook is executed', () => {
@@ -909,14 +1095,20 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledOnce));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledOnce));
 
           it('should not perform any other hook', () => {
             Object.keys(spies || {}).forEach((spyName) => {
-              if (spyName === 'beforeAllSpy') { return; }
-              if (spyName === 'beforeEachSpy') { return; }
+              if (spyName === 'beforeAllSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachSpy') {
+                return;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             });
           });
@@ -926,7 +1118,8 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'beforeEach'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'beforeEach'));
         });
 
         describe('after ‘before’ hook is executed', () => {
@@ -945,17 +1138,26 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledOnce));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledOnce));
 
-          it('should perform the ‘before’ hook', () => assert.isTrue(spies.beforeSpy.calledOnce));
+          it('should perform the ‘before’ hook', () =>
+            assert.isTrue(spies.beforeSpy.calledOnce));
 
           it('should not perform any other hook', () => {
             Object.keys(spies || {}).forEach((spyName) => {
-              if (spyName === 'beforeAllSpy') { return; }
-              if (spyName === 'beforeEachSpy') { return; }
-              if (spyName === 'beforeSpy') { return; }
+              if (spyName === 'beforeAllSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachSpy') {
+                return;
+              }
+              if (spyName === 'beforeSpy') {
+                return;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             });
           });
@@ -965,12 +1167,15 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'before 1'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'before 1'));
         });
 
         describe('after ‘beforeEachValidation’ hook is executed', () => {
           beforeEach((done) => {
-            const hookHandlerError = new Error('handler died in before each validation');
+            const hookHandlerError = new Error(
+              'handler died in before each validation',
+            );
 
             hooks.beforeEachValidation((data, callback) => {
               runner.hookHandlerError = hookHandlerError;
@@ -984,20 +1189,32 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.equal(spies.beforeAllSpy.callCount, 1));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.equal(spies.beforeAllSpy.callCount, 1));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.equal(spies.beforeEachSpy.callCount, 1));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.equal(spies.beforeEachSpy.callCount, 1));
 
-          it('should perform the ‘before’ hook', () => assert.equal(spies.beforeSpy.callCount, 1));
+          it('should perform the ‘before’ hook', () =>
+            assert.equal(spies.beforeSpy.callCount, 1));
 
-          it('should perform the ‘beforeEachValidation’ hook', () => assert.equal(spies.beforeEachValidationSpy.callCount, 1));
+          it('should perform the ‘beforeEachValidation’ hook', () =>
+            assert.equal(spies.beforeEachValidationSpy.callCount, 1));
 
           it('should not perform any other hook', () => {
             Object.keys(spies || {}).forEach((spyName) => {
-              if (spyName === 'beforeAllSpy') { return; }
-              if (spyName === 'beforeEachSpy') { return; }
-              if (spyName === 'beforeSpy') { return; }
-              if (spyName === 'beforeEachValidationSpy') { return; }
+              if (spyName === 'beforeAllSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachSpy') {
+                return;
+              }
+              if (spyName === 'beforeSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachValidationSpy') {
+                return;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             });
           });
@@ -1007,12 +1224,15 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'before each validation'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'before each validation'));
         });
 
         describe('after ‘beforeValidation’ hook is executed', () => {
           beforeEach((done) => {
-            const hookHandlerError = new Error('handler died in before validation 1');
+            const hookHandlerError = new Error(
+              'handler died in before validation 1',
+            );
 
             hooks.beforeValidation('1', (data, callback) => {
               runner.hookHandlerError = hookHandlerError;
@@ -1026,23 +1246,38 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledOnce));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledOnce));
 
-          it('should perform the ‘before’ hook', () => assert.isTrue(spies.beforeSpy.calledOnce));
+          it('should perform the ‘before’ hook', () =>
+            assert.isTrue(spies.beforeSpy.calledOnce));
 
-          it('should perform the ‘beforeEachValidation’ hook', () => assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
+          it('should perform the ‘beforeEachValidation’ hook', () =>
+            assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
 
-          it('should perform the ‘beforeValidation’ hook', () => assert.isTrue(spies.beforeValidationSpy.calledOnce));
+          it('should perform the ‘beforeValidation’ hook', () =>
+            assert.isTrue(spies.beforeValidationSpy.calledOnce));
 
           it('should not perform any other hook', () => {
             Object.keys(spies || {}).forEach((spyName) => {
-              if (spyName === 'beforeAllSpy') { return; }
-              if (spyName === 'beforeEachSpy') { return; }
-              if (spyName === 'beforeSpy') { return; }
-              if (spyName === 'beforeEachValidationSpy') { return; }
-              if (spyName === 'beforeValidationSpy') { return; }
+              if (spyName === 'beforeAllSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachSpy') {
+                return;
+              }
+              if (spyName === 'beforeSpy') {
+                return;
+              }
+              if (spyName === 'beforeEachValidationSpy') {
+                return;
+              }
+              if (spyName === 'beforeValidationSpy') {
+                return;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             });
           });
@@ -1052,7 +1287,8 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'before validation 1'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'before validation 1'));
         });
 
         describe('after ‘after’ hook is executed', () => {
@@ -1071,28 +1307,47 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledOnce));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledOnce));
 
-          it('should perform the ‘before’ hook', () => assert.isTrue(spies.beforeSpy.calledOnce));
+          it('should perform the ‘before’ hook', () =>
+            assert.isTrue(spies.beforeSpy.calledOnce));
 
-          it('should perform the ‘beforeEachValidation’ hook', () => assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
+          it('should perform the ‘beforeEachValidation’ hook', () =>
+            assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
 
-          it('should perform the ‘beforeValidation’ hook', () => assert.isTrue(spies.beforeValidationSpy.calledOnce));
+          it('should perform the ‘beforeValidation’ hook', () =>
+            assert.isTrue(spies.beforeValidationSpy.calledOnce));
 
-          it('should perform the ‘afterEach’ hook', () => assert.isTrue(spies.afterEachSpy.calledOnce));
+          it('should perform the ‘afterEach’ hook', () =>
+            assert.isTrue(spies.afterEachSpy.calledOnce));
 
-          it('should perform the ‘after’ hook', () => assert.isTrue(spies.afterSpy.calledOnce));
+          it('should perform the ‘after’ hook', () =>
+            assert.isTrue(spies.afterSpy.calledOnce));
 
           it('should not perform any other hook', () => {
             for (const spyName of Object.keys(spies || {})) {
-              if (spyName === 'beforeAllSpy') { break; }
-              if (spyName === 'beforeEachSpy') { break; }
-              if (spyName === 'beforeSpy') { break; }
-              if (spyName === 'beforeEachValidationSpy') { break; }
-              if (spyName === 'beforeValidationSpy') { break; }
-              if (spyName === 'after') { break; }
+              if (spyName === 'beforeAllSpy') {
+                break;
+              }
+              if (spyName === 'beforeEachSpy') {
+                break;
+              }
+              if (spyName === 'beforeSpy') {
+                break;
+              }
+              if (spyName === 'beforeEachValidationSpy') {
+                break;
+              }
+              if (spyName === 'beforeValidationSpy') {
+                break;
+              }
+              if (spyName === 'after') {
+                break;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             }
           });
@@ -1102,7 +1357,8 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'after 1'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'after 1'));
         });
 
         describe('after ‘afterEach’ hook is executed', () => {
@@ -1121,27 +1377,47 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledOnce));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledOnce));
 
-          it('should perform the ‘before’ hook', () => assert.isTrue(spies.beforeSpy.calledOnce));
+          it('should perform the ‘before’ hook', () =>
+            assert.isTrue(spies.beforeSpy.calledOnce));
 
-          it('should perform the ‘beforeEachValidation’ hook', () => assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
+          it('should perform the ‘beforeEachValidation’ hook', () =>
+            assert.isTrue(spies.beforeEachValidationSpy.calledOnce));
 
-          it('should perform the ‘beforeValidation’ hook', () => assert.isTrue(spies.beforeValidationSpy.calledOnce));
+          it('should perform the ‘beforeValidation’ hook', () =>
+            assert.isTrue(spies.beforeValidationSpy.calledOnce));
 
-          it('should perform the ‘afterEach’ hook', () => assert.isTrue(spies.afterEachSpy.calledOnce));
+          it('should perform the ‘afterEach’ hook', () =>
+            assert.isTrue(spies.afterEachSpy.calledOnce));
 
           it('should not perform any other hook', () => {
             for (const spyName of Object.keys(spies || {})) {
-              if (spyName === 'beforeAllSpy') { break; }
-              if (spyName === 'beforeEachSpy') { break; }
-              if (spyName === 'beforeSpy') { break; }
-              if (spyName === 'beforeEachValidationSpy') { break; }
-              if (spyName === 'beforeValidationSpy') { break; }
-              if (spyName === 'after') { break; }
-              if (spyName === 'afterEach') { break; }
+              if (spyName === 'beforeAllSpy') {
+                break;
+              }
+              if (spyName === 'beforeEachSpy') {
+                break;
+              }
+              if (spyName === 'beforeSpy') {
+                break;
+              }
+              if (spyName === 'beforeEachValidationSpy') {
+                break;
+              }
+              if (spyName === 'beforeValidationSpy') {
+                break;
+              }
+              if (spyName === 'after') {
+                break;
+              }
+              if (spyName === 'afterEach') {
+                break;
+              }
               assert.isFalse(spies[spyName].called, spyName);
             }
           });
@@ -1151,7 +1427,8 @@ describe('TransactionRunner', () => {
             assert.isFalse(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'after each'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'after each'));
         });
 
         describe('after ‘afterAll’ hook is executed', () => {
@@ -1170,28 +1447,37 @@ describe('TransactionRunner', () => {
             });
           });
 
-          it('should perform the ‘beforeAll’ hook', () => assert.isTrue(spies.beforeAllSpy.called));
+          it('should perform the ‘beforeAll’ hook', () =>
+            assert.isTrue(spies.beforeAllSpy.called));
 
-          it('should perform the ‘beforeEach’ hook', () => assert.isTrue(spies.beforeEachSpy.calledTwice));
+          it('should perform the ‘beforeEach’ hook', () =>
+            assert.isTrue(spies.beforeEachSpy.calledTwice));
 
-          it('should perform the ‘before’ hook', () => assert.isTrue(spies.beforeSpy.calledTwice));
+          it('should perform the ‘before’ hook', () =>
+            assert.isTrue(spies.beforeSpy.calledTwice));
 
-          it('should perform the ‘beforeEachValidation’ hook', () => assert.isTrue(spies.beforeEachValidationSpy.calledTwice));
+          it('should perform the ‘beforeEachValidation’ hook', () =>
+            assert.isTrue(spies.beforeEachValidationSpy.calledTwice));
 
-          it('should perform the ‘beforeValidation’ hook', () => assert.isTrue(spies.beforeValidationSpy.calledTwice));
+          it('should perform the ‘beforeValidation’ hook', () =>
+            assert.isTrue(spies.beforeValidationSpy.calledTwice));
 
-          it('should perform the ‘afterEach’ hook', () => assert.isTrue(spies.afterEachSpy.calledTwice));
+          it('should perform the ‘afterEach’ hook', () =>
+            assert.isTrue(spies.afterEachSpy.calledTwice));
 
-          it('should perform the ‘after’ hook', () => assert.isTrue(spies.afterSpy.calledTwice));
+          it('should perform the ‘after’ hook', () =>
+            assert.isTrue(spies.afterSpy.calledTwice));
 
-          it('should perform the ‘afterAll’ hook', () => assert.isTrue(spies.afterAllSpy.calledOnce));
+          it('should perform the ‘afterAll’ hook', () =>
+            assert.isTrue(spies.afterAllSpy.calledOnce));
 
           it('should perform both transactions', () => {
             assert.isTrue(serverNock1.isDone(), 'first resource');
             assert.isTrue(serverNock2.isDone(), 'second resource');
           });
 
-          it('should return the error', () => assert.include(returnedError.message, 'after all'));
+          it('should return the error', () =>
+            assert.include(returnedError.message, 'after all'));
         });
       });
     });
@@ -1234,7 +1520,8 @@ describe('TransactionRunner', () => {
         },
         expected: {
           headers: { 'content-type': 'application/json' },
-          body: '{\n  "type": "bulldozer",\n "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+          body:
+            '{\n  "type": "bulldozer",\n "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
           statusCode: '202',
         },
         origin: {
@@ -1249,9 +1536,9 @@ describe('TransactionRunner', () => {
 
       server = nock('http://127.0.0.1:3000')
         .post('/machines', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode,
-          transaction.expected.body,
-          { 'Content-Type': 'application/json' });
+        .reply(transaction.expected.statusCode, transaction.expected.body, {
+          'Content-Type': 'application/json',
+        });
 
       transactions = {};
       transactions[transaction.name] = clone(transaction, false);
@@ -1267,19 +1554,19 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => loggerStub.debug('before')
+            (transaction) => loggerStub.debug('before'),
           ],
         };
         runner.hooks.beforeValidationHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => loggerStub.debug('beforeValidation')
+            (transaction) => loggerStub.debug('beforeValidation'),
           ],
         };
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            function (transaction, done) {
+            function(transaction, done) {
               loggerStub.debug('after');
               done();
             },
@@ -1289,12 +1576,13 @@ describe('TransactionRunner', () => {
 
       afterEach(() => loggerStub.debug.restore());
 
-      it('should run the hooks', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(loggerStub.debug.calledWith('before'));
-        assert.isOk(loggerStub.debug.calledWith('beforeValidation'));
-        assert.isOk(loggerStub.debug.calledWith('after'));
-        done();
-      }));
+      it('should run the hooks', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(loggerStub.debug.calledWith('before'));
+          assert.isOk(loggerStub.debug.calledWith('beforeValidation'));
+          assert.isOk(loggerStub.debug.calledWith('after'));
+          done();
+        }));
     });
 
     describe('with hooks, but without hooks.transactions set', () => {
@@ -1304,19 +1592,19 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => loggerStub.debug('before')
+            (transaction) => loggerStub.debug('before'),
           ],
         };
         runner.hooks.beforeValidationHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => loggerStub.debug('beforeValidation')
+            (transaction) => loggerStub.debug('beforeValidation'),
           ],
         };
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            function (transaction, done) {
+            function(transaction, done) {
               loggerStub.debug('after');
               done();
             },
@@ -1343,9 +1631,9 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => loggerStub.debug('first'),
+            (transaction) => loggerStub.debug('first'),
             // eslint-disable-next-line
-            function (transaction, cb) {
+            function(transaction, cb) {
               loggerStub.debug('second');
               cb();
             },
@@ -1355,11 +1643,12 @@ describe('TransactionRunner', () => {
 
       afterEach(() => loggerStub.debug.restore());
 
-      it('should run all hooks', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(loggerStub.debug.calledWith('first'));
-        assert.isOk(loggerStub.debug.calledWith('second'));
-        done();
-      }));
+      it('should run all hooks', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(loggerStub.debug.calledWith('first'));
+          assert.isOk(loggerStub.debug.calledWith('second'));
+          done();
+        }));
     });
 
     describe('‘*All’ hooks with standard async API (first argument transactions, second callback)', () => {
@@ -1371,10 +1660,11 @@ describe('TransactionRunner', () => {
 
         beforeEach(() => runner.hooks.beforeAll(beforeAllStub));
 
-        it('should run the hooks', done => runner.executeAllTransactions([], runner.hooks, () => {
-          assert.isOk(beforeAllStub.called);
-          done();
-        }));
+        it('should run the hooks', (done) =>
+          runner.executeAllTransactions([], runner.hooks, () => {
+            assert.isOk(beforeAllStub.called);
+            done();
+          }));
       });
 
       describe('with an ‘afterAll’ hook', () => {
@@ -1385,10 +1675,11 @@ describe('TransactionRunner', () => {
 
         beforeEach(() => runner.hooks.afterAll(afterAllStub));
 
-        it('should run the hooks', done => runner.executeAllTransactions([], runner.hooks, () => {
-          assert.isOk(afterAllStub.called);
-          done();
-        }));
+        it('should run the hooks', (done) =>
+          runner.executeAllTransactions([], runner.hooks, () => {
+            assert.isOk(afterAllStub.called);
+            done();
+          }));
       });
 
       describe('with multiple hooks for the same events', () => {
@@ -1407,14 +1698,15 @@ describe('TransactionRunner', () => {
           runner.hooks.beforeAll(beforeAllStub2);
         });
 
-        it('should run all the events in order', done => runner.executeAllTransactions([], runner.hooks, () => {
-          assert.isOk(beforeAllStub1.calledBefore(beforeAllStub2));
-          assert.isOk(beforeAllStub2.called);
-          assert.isOk(beforeAllStub2.calledBefore(afterAllStub1));
-          assert.isOk(afterAllStub1.calledBefore(afterAllStub2));
-          assert.isOk(afterAllStub2.called);
-          done();
-        }));
+        it('should run all the events in order', (done) =>
+          runner.executeAllTransactions([], runner.hooks, () => {
+            assert.isOk(beforeAllStub1.calledBefore(beforeAllStub2));
+            assert.isOk(beforeAllStub2.called);
+            assert.isOk(beforeAllStub2.calledBefore(afterAllStub1));
+            assert.isOk(afterAllStub1.calledBefore(afterAllStub2));
+            assert.isOk(afterAllStub2.called);
+            done();
+          }));
       });
     });
 
@@ -1439,7 +1731,8 @@ describe('TransactionRunner', () => {
           },
           expected: {
             headers: { 'content-type': 'application/json' },
-            body: '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
+            body:
+              '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
             statusCode: '202',
           },
           origin: {
@@ -1469,9 +1762,11 @@ describe('TransactionRunner', () => {
           runner.hooks.beforeEach(beforeEachStub);
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
-            .reply(transactionsForExecution[0].expected.statusCode,
+            .reply(
+              transactionsForExecution[0].expected.statusCode,
               transactionsForExecution[0].expected.body,
-              { 'Content-Type': 'application/json' });
+              { 'Content-Type': 'application/json' },
+            );
         });
 
         afterEach(() => {
@@ -1479,20 +1774,33 @@ describe('TransactionRunner', () => {
           nock.cleanAll();
         });
 
-        it('should run the hooks', done => runner.executeAllTransactions(transactionsForExecution, runner.hooks, () => {
-          assert.isOk(beforeEachStub.called);
-          done();
-        }));
+        it('should run the hooks', (done) =>
+          runner.executeAllTransactions(
+            transactionsForExecution,
+            runner.hooks,
+            () => {
+              assert.isOk(beforeEachStub.called);
+              done();
+            },
+          ));
 
-        it('should run the hook for each transaction', done => runner.executeAllTransactions(transactionsForExecution, runner.hooks, () => {
-          assert.equal(beforeEachStub.callCount, transactionsForExecution.length);
-          done();
-        }));
+        it('should run the hook for each transaction', (done) =>
+          runner.executeAllTransactions(
+            transactionsForExecution,
+            runner.hooks,
+            () => {
+              assert.equal(
+                beforeEachStub.callCount,
+                transactionsForExecution.length,
+              );
+              done();
+            },
+          ));
       });
 
       describe('with a ‘beforeEachValidation’ hook', () => {
         // eslint-disable-next-line
-        const hook = function (transaction, callback) {
+        const hook = function(transaction, callback) {
           transaction.real.statusCode = '403';
           callback();
         };
@@ -1503,9 +1811,11 @@ describe('TransactionRunner', () => {
           runner.hooks.beforeEachValidation(beforeEachValidationStub);
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
-            .reply(transactionsForExecution[0].expected.statusCode,
+            .reply(
+              transactionsForExecution[0].expected.statusCode,
               transactionsForExecution[0].expected.body,
-              { 'Content-Type': 'application/json' });
+              { 'Content-Type': 'application/json' },
+            );
         });
 
         afterEach(() => {
@@ -1531,10 +1841,18 @@ describe('TransactionRunner', () => {
           });
         });
 
-        it('should run the hook for each transaction', done => runner.executeAllTransactions(transactionsForExecution, runner.hooks, () => {
-          assert.equal(beforeEachValidationStub.callCount, transactionsForExecution.length);
-          done();
-        }));
+        it('should run the hook for each transaction', (done) =>
+          runner.executeAllTransactions(
+            transactionsForExecution,
+            runner.hooks,
+            () => {
+              assert.equal(
+                beforeEachValidationStub.callCount,
+                transactionsForExecution.length,
+              );
+              done();
+            },
+          ));
       });
 
       describe('with a ‘afterEach’ hook', () => {
@@ -1547,9 +1865,11 @@ describe('TransactionRunner', () => {
           runner.hooks.afterEach(afterEachStub);
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
-            .reply(transactionsForExecution[0].expected.statusCode,
+            .reply(
+              transactionsForExecution[0].expected.statusCode,
               transactionsForExecution[0].expected.body,
-              { 'Content-Type': 'application/json' });
+              { 'Content-Type': 'application/json' },
+            );
         });
 
         afterEach(() => {
@@ -1557,15 +1877,28 @@ describe('TransactionRunner', () => {
           nock.cleanAll();
         });
 
-        it('should run the hooks', done => runner.executeAllTransactions(transactionsForExecution, runner.hooks, () => {
-          assert.isOk(afterEachStub.called);
-          done();
-        }));
+        it('should run the hooks', (done) =>
+          runner.executeAllTransactions(
+            transactionsForExecution,
+            runner.hooks,
+            () => {
+              assert.isOk(afterEachStub.called);
+              done();
+            },
+          ));
 
-        it('should run the hook for each transaction', done => runner.executeAllTransactions(transactionsForExecution, runner.hooks, () => {
-          assert.equal(afterEachStub.callCount, transactionsForExecution.length);
-          done();
-        }));
+        it('should run the hook for each transaction', (done) =>
+          runner.executeAllTransactions(
+            transactionsForExecution,
+            runner.hooks,
+            () => {
+              assert.equal(
+                afterEachStub.callCount,
+                transactionsForExecution.length,
+              );
+              done();
+            },
+          ));
       });
 
       describe('with multiple hooks for the same events', () => {
@@ -1584,13 +1917,14 @@ describe('TransactionRunner', () => {
           runner.hooks.beforeAll(beforeAllStub2);
         });
 
-        it('should run all the events in order', done => runner.executeAllTransactions([], runner.hooks, () => {
-          assert.isOk(beforeAllStub1.calledBefore(beforeAllStub2));
-          assert.isOk(beforeAllStub2.called);
-          assert.isOk(afterAllStub1.calledBefore(afterAllStub2));
-          assert.isOk(afterAllStub2.called);
-          done();
-        }));
+        it('should run all the events in order', (done) =>
+          runner.executeAllTransactions([], runner.hooks, () => {
+            assert.isOk(beforeAllStub1.calledBefore(beforeAllStub2));
+            assert.isOk(beforeAllStub2.called);
+            assert.isOk(afterAllStub1.calledBefore(afterAllStub2));
+            assert.isOk(afterAllStub2.called);
+            done();
+          }));
       });
     });
 
@@ -1599,7 +1933,7 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => JSON.parse('<<<>>>!@#!@#!@#4234234')
+            (transaction) => JSON.parse('<<<>>>!@#!@#!@#4234234'),
           ],
         };
         sinon.stub(configuration.emitter, 'emit');
@@ -1607,17 +1941,23 @@ describe('TransactionRunner', () => {
 
       afterEach(() => configuration.emitter.emit.restore());
 
-      it('should report an error with the test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(configuration.emitter.emit.calledWith('test error'));
-        done();
-      }));
+      it('should report an error with the test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(configuration.emitter.emit.calledWith('test error'));
+          done();
+        }));
 
-      it('should set transaction info on the errored test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.propertyVal(transaction.test, 'request', transaction.request);
-        assert.propertyVal(transaction.test, 'expected', transaction.expected);
-        assert.propertyVal(transaction.test, 'actual', transaction.real);
-        done();
-      }));
+      it('should set transaction info on the errored test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.propertyVal(transaction.test, 'request', transaction.request);
+          assert.propertyVal(
+            transaction.test,
+            'expected',
+            transaction.expected,
+          );
+          assert.propertyVal(transaction.test, 'actual', transaction.real);
+          done();
+        }));
     });
 
     describe('with ‘after’ hook that throws an error', () => {
@@ -1625,7 +1965,7 @@ describe('TransactionRunner', () => {
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => JSON.parse('<<<>>>!@#!@#!@#4234234')
+            (transaction) => JSON.parse('<<<>>>!@#!@#!@#4234234'),
           ],
         };
         sinon.stub(configuration.emitter, 'emit');
@@ -1633,17 +1973,23 @@ describe('TransactionRunner', () => {
 
       afterEach(() => configuration.emitter.emit.restore());
 
-      it('should report an error with the test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(configuration.emitter.emit.calledWith('test error'));
-        done();
-      }));
+      it('should report an error with the test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(configuration.emitter.emit.calledWith('test error'));
+          done();
+        }));
 
-      it('should set transaction info on the errored test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.propertyVal(transaction.test, 'request', transaction.request);
-        assert.propertyVal(transaction.test, 'expected', transaction.expected);
-        assert.propertyVal(transaction.test, 'actual', transaction.real);
-        done();
-      }));
+      it('should set transaction info on the errored test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.propertyVal(transaction.test, 'request', transaction.request);
+          assert.propertyVal(
+            transaction.test,
+            'expected',
+            transaction.expected,
+          );
+          assert.propertyVal(transaction.test, 'actual', transaction.real);
+          done();
+        }));
     });
 
     describe('with ‘before’ hook that throws a chai expectation error', () => {
@@ -1651,7 +1997,7 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => assert.isOk(false)
+            (transaction) => assert.isOk(false),
           ],
         };
         sinon.stub(configuration.emitter, 'emit');
@@ -1659,40 +2005,55 @@ describe('TransactionRunner', () => {
 
       afterEach(() => configuration.emitter.emit.restore());
 
-      it('should not report an error', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.notOk(configuration.emitter.emit.calledWith('test error'));
-        done();
-      }));
+      it('should not report an error', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.notOk(configuration.emitter.emit.calledWith('test error'));
+          done();
+        }));
 
-      it('should report a fail', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(configuration.emitter.emit.calledWith('test fail'));
-        done();
-      }));
+      it('should report a fail', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(configuration.emitter.emit.calledWith('test fail'));
+          done();
+        }));
 
-      it('should add fail message as a error under `errors` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        const messages = transaction.errors.map(value => value.message);
-        assert.include(messages.join(), 'expected false to be truthy');
-        done();
-      }));
+      it('should add fail message as a error under `errors` to the results on transaction', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          const messages = transaction.errors.map((value) => value.message);
+          assert.include(messages.join(), 'expected false to be truthy');
+          done();
+        }));
 
-      it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        const messages = [];
-        const { callCount } = configuration.emitter.emit;
-        for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-          messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-            value => value.message
-          ));
-        }
-        assert.include(messages.join(), 'expected false to be truthy');
-        done();
-      }));
+      it('should add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          const messages = [];
+          const { callCount } = configuration.emitter.emit;
+          for (
+            let callNo = 0, end = callCount - 1, asc = end >= 0;
+            asc ? callNo <= end : callNo >= end;
+            asc ? callNo++ : callNo--
+          ) {
+            messages.push(
+              configuration.emitter.emit
+                .getCall(callNo)
+                .args[1].errors.map((value) => value.message),
+            );
+          }
+          assert.include(messages.join(), 'expected false to be truthy');
+          done();
+        }));
 
-      it('should set transaction info on the failed test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.propertyVal(transaction.test, 'request', transaction.request);
-        assert.propertyVal(transaction.test, 'expected', transaction.expected);
-        assert.propertyVal(transaction.test, 'actual', transaction.real);
-        done();
-      }));
+      it('should set transaction info on the failed test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.propertyVal(transaction.test, 'request', transaction.request);
+          assert.propertyVal(
+            transaction.test,
+            'expected',
+            transaction.expected,
+          );
+          assert.propertyVal(transaction.test, 'actual', transaction.real);
+          done();
+        }));
     });
 
     describe('with ‘after’ hook that throws a chai expectation error', () => {
@@ -1700,7 +2061,7 @@ describe('TransactionRunner', () => {
         runner.hooks.afterHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            transaction => assert.isOk(false)
+            (transaction) => assert.isOk(false),
           ],
         };
         sinon.stub(configuration.emitter, 'emit');
@@ -1708,45 +2069,61 @@ describe('TransactionRunner', () => {
 
       afterEach(() => configuration.emitter.emit.restore());
 
-      it('should not report an error', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.notOk(configuration.emitter.emit.calledWith('test error'));
-        done();
-      }));
+      it('should not report an error', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.notOk(configuration.emitter.emit.calledWith('test error'));
+          done();
+        }));
 
-      it('should report a fail', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.isOk(configuration.emitter.emit.calledWith('test fail'));
-        done();
-      }));
+      it('should report a fail', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.isOk(configuration.emitter.emit.calledWith('test fail'));
+          done();
+        }));
 
-      it('should set test as failed', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.equal(transaction.test.status, 'fail');
-        done();
-      }));
+      it('should set test as failed', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.equal(transaction.test.status, 'fail');
+          done();
+        }));
 
-      it('should add fail message as a error under `errors` to the results on transaction', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        const messages = transaction.errors.map(value => value.message);
-        assert.include(messages.join(), 'expected false to be truthy');
-        done();
-      }));
+      it('should add fail message as a error under `errors` to the results on transaction', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          const messages = transaction.errors.map((value) => value.message);
+          assert.include(messages.join(), 'expected false to be truthy');
+          done();
+        }));
 
-      it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        const messages = [];
-        const { callCount } = configuration.emitter.emit;
-        for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-          messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-            value => value.message
-          ));
-        }
-        assert.include(messages.join(), 'expected false to be truthy');
-        done();
-      }));
+      it('should add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          const messages = [];
+          const { callCount } = configuration.emitter.emit;
+          for (
+            let callNo = 0, end = callCount - 1, asc = end >= 0;
+            asc ? callNo <= end : callNo >= end;
+            asc ? callNo++ : callNo--
+          ) {
+            messages.push(
+              configuration.emitter.emit
+                .getCall(callNo)
+                .args[1].errors.map((value) => value.message),
+            );
+          }
+          assert.include(messages.join(), 'expected false to be truthy');
+          done();
+        }));
 
-      it('should set transaction info on the failed test', done => runner.executeAllTransactions([transaction], runner.hooks, () => {
-        assert.propertyVal(transaction.test, 'request', transaction.request);
-        assert.propertyVal(transaction.test, 'expected', transaction.expected);
-        assert.propertyVal(transaction.test, 'actual', transaction.real);
-        done();
-      }));
+      it('should set transaction info on the failed test', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () => {
+          assert.propertyVal(transaction.test, 'request', transaction.request);
+          assert.propertyVal(
+            transaction.test,
+            'expected',
+            transaction.expected,
+          );
+          assert.propertyVal(transaction.test, 'actual', transaction.real);
+          done();
+        }));
     });
 
     describe('with hook failing the transaction', () => {
@@ -1756,7 +2133,9 @@ describe('TransactionRunner', () => {
           clonedTransaction = clone(transaction);
           runner.hooks.beforeHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message before'; },
+              (hookTransaction) => {
+                hookTransaction.fail = 'Message before';
+              },
             ],
           };
           sinon.stub(configuration.emitter, 'emit');
@@ -1764,60 +2143,127 @@ describe('TransactionRunner', () => {
 
         afterEach(() => configuration.emitter.emit.restore());
 
-        it('should fail the test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.isOk(configuration.emitter.emit.calledWith('test fail'));
-          done();
-        }));
+        it('should fail the test', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.isOk(configuration.emitter.emit.calledWith('test fail'));
+              done();
+            },
+          ));
 
-        it('should not run the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.notOk(server.isDone());
-          done();
-        }));
+        it('should not run the transaction', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.notOk(server.isDone());
+              done();
+            },
+          ));
 
-        it('should pass the failing message to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.include(messages.join(), 'Message before');
-          done();
-        }));
+        it('should pass the failing message to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.include(messages.join(), 'Message before');
+              done();
+            },
+          ));
 
-        it('should mention before hook in the error message', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.include(messages.join(), 'Failed in before hook:');
-          done();
-        }));
+        it('should mention before hook in the error message', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.include(messages.join(), 'Failed in before hook:');
+              done();
+            },
+          ));
 
-        it('should add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = clonedTransaction.errors.map(value => value.message);
-          assert.include(messages.join(), 'Message before');
-          done();
-        }));
+        it('should add fail message as a error under `errors` to the results on the transaction', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = clonedTransaction.errors.map(
+                (value) => value.message,
+              );
+              assert.include(messages.join(), 'Message before');
+              done();
+            },
+          ));
 
-        it('should add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-              value => value.message
-            ));
-          }
-          assert.include(messages.join(), 'Message before');
-          done();
-        }));
+        it('should add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit
+                    .getCall(callNo)
+                    .args[1].errors.map((value) => value.message),
+                );
+              }
+              assert.include(messages.join(), 'Message before');
+              done();
+            },
+          ));
 
-        it('should set transaction info on the failed test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
-          assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
-          assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
-          done();
-        }));
+        it('should set transaction info on the failed test', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.propertyVal(
+                clonedTransaction.test,
+                'request',
+                clonedTransaction.request,
+              );
+              assert.propertyVal(
+                clonedTransaction.test,
+                'expected',
+                clonedTransaction.expected,
+              );
+              assert.propertyVal(
+                clonedTransaction.test,
+                'actual',
+                clonedTransaction.real,
+              );
+              done();
+            },
+          ));
 
         describe('when message is set to fail also in ‘after’ hook', () => {
           clonedTransaction = null;
@@ -1825,55 +2271,114 @@ describe('TransactionRunner', () => {
             clonedTransaction = clone(transaction);
             runner.hooks.afterHooks = {
               'Group Machine > Machine > Delete Message > Bogus example name': [
-                (hookTransaction) => { hookTransaction.fail = 'Message after'; },
+                (hookTransaction) => {
+                  hookTransaction.fail = 'Message after';
+                },
               ],
             };
           });
 
-          it('should not pass the failing message to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-            const messages = [];
-            const { callCount } = configuration.emitter.emit;
-            for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-              messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-            }
-            assert.notInclude(messages.join(), 'Message after fail');
-            done();
-          }));
+          it('should not pass the failing message to the emitter', (done) =>
+            runner.executeAllTransactions(
+              [clonedTransaction],
+              runner.hooks,
+              () => {
+                const messages = [];
+                const { callCount } = configuration.emitter.emit;
+                for (
+                  let callNo = 0, end = callCount - 1, asc = end >= 0;
+                  asc ? callNo <= end : callNo >= end;
+                  asc ? callNo++ : callNo--
+                ) {
+                  messages.push(
+                    configuration.emitter.emit.getCall(callNo).args[1].message,
+                  );
+                }
+                assert.notInclude(messages.join(), 'Message after fail');
+                done();
+              },
+            ));
 
-          it('should not mention after hook in the error message', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-            const messages = [];
-            const { callCount } = configuration.emitter.emit;
-            for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-              messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-            }
-            assert.notInclude(messages.join(), 'Failed in after hook:');
-            done();
-          }));
+          it('should not mention after hook in the error message', (done) =>
+            runner.executeAllTransactions(
+              [clonedTransaction],
+              runner.hooks,
+              () => {
+                const messages = [];
+                const { callCount } = configuration.emitter.emit;
+                for (
+                  let callNo = 0, end = callCount - 1, asc = end >= 0;
+                  asc ? callNo <= end : callNo >= end;
+                  asc ? callNo++ : callNo--
+                ) {
+                  messages.push(
+                    configuration.emitter.emit.getCall(callNo).args[1].message,
+                  );
+                }
+                assert.notInclude(messages.join(), 'Failed in after hook:');
+                done();
+              },
+            ));
 
-          it('should not add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-            const messages = clonedTransaction.errors.map(value => value.message);
-            assert.notInclude(messages.join(), 'Message after fail');
-            done();
-          }));
+          it('should not add fail message as a error under `errors` to the results on the transaction', (done) =>
+            runner.executeAllTransactions(
+              [clonedTransaction],
+              runner.hooks,
+              () => {
+                const messages = clonedTransaction.errors.map(
+                  (value) => value.message,
+                );
+                assert.notInclude(messages.join(), 'Message after fail');
+                done();
+              },
+            ));
 
-          it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-            const messages = [];
-            const { callCount } = configuration.emitter.emit;
-            for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-              messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-                value => value.message
-              ));
-            }
-            assert.notInclude(messages.join(), 'Message after fail');
-            done();
-          }));
+          it('should not add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+            runner.executeAllTransactions(
+              [clonedTransaction],
+              runner.hooks,
+              () => {
+                const messages = [];
+                const { callCount } = configuration.emitter.emit;
+                for (
+                  let callNo = 0, end = callCount - 1, asc = end >= 0;
+                  asc ? callNo <= end : callNo >= end;
+                  asc ? callNo++ : callNo--
+                ) {
+                  messages.push(
+                    configuration.emitter.emit
+                      .getCall(callNo)
+                      .args[1].errors.map((value) => value.message),
+                  );
+                }
+                assert.notInclude(messages.join(), 'Message after fail');
+                done();
+              },
+            ));
 
-          it('should set transaction info on the failed test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-            assert.propertyVal(clonedTransaction.test, 'request', clonedTransaction.request);
-            assert.propertyVal(clonedTransaction.test, 'expected', clonedTransaction.expected);
-            assert.propertyVal(clonedTransaction.test, 'actual', clonedTransaction.real);
-            done();
-          }));
+          it('should set transaction info on the failed test', (done) =>
+            runner.executeAllTransactions(
+              [clonedTransaction],
+              runner.hooks,
+              () => {
+                assert.propertyVal(
+                  clonedTransaction.test,
+                  'request',
+                  clonedTransaction.request,
+                );
+                assert.propertyVal(
+                  clonedTransaction.test,
+                  'expected',
+                  clonedTransaction.expected,
+                );
+                assert.propertyVal(
+                  clonedTransaction.test,
+                  'actual',
+                  clonedTransaction.real,
+                );
+                done();
+              },
+            ));
         });
       });
 
@@ -1885,7 +2390,9 @@ describe('TransactionRunner', () => {
 
           runner.hooks.afterHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message after fail'; },
+              (hookTransaction) => {
+                hookTransaction.fail = 'Message after fail';
+              },
             ],
           };
           sinon.stub(configuration.emitter, 'emit');
@@ -1896,67 +2403,145 @@ describe('TransactionRunner', () => {
           configuration.emitter.emit.restore();
         });
 
-        it('should make the request', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          assert.isOk(server.isDone());
-          done();
-        }));
+        it('should make the request', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              assert.isOk(server.isDone());
+              done();
+            },
+          ));
 
-        it('should not fail again', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          let failCount = 0;
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            if (configuration.emitter.emit.getCall(callNo).args[0] === 'test fail') { failCount++; }
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.equal(failCount, 1);
-          done();
-        }));
+        it('should not fail again', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              let failCount = 0;
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                if (
+                  configuration.emitter.emit.getCall(callNo).args[0] ===
+                  'test fail'
+                ) {
+                  failCount++;
+                }
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.equal(failCount, 1);
+              done();
+            },
+          ));
 
-        it('should not pass the hook message to the emitter', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.notInclude(messages, 'Message after fail');
-          done();
-        }));
+        it('should not pass the hook message to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.notInclude(messages, 'Message after fail');
+              done();
+            },
+          ));
 
-        it('should not mention after hook in the error message', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.notInclude(messages, 'Failed in after hook:');
-          done();
-        }));
+        it('should not mention after hook in the error message', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.notInclude(messages, 'Failed in after hook:');
+              done();
+            },
+          ));
 
-        it('should not add fail message as a error under `errors` to the results on the transaction', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          const messages = modifiedTransaction.errors.map(value => value.message);
-          assert.notInclude(messages.join(), 'Message after fail');
-          done();
-        }));
+        it('should not add fail message as a error under `errors` to the results on the transaction', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              const messages = modifiedTransaction.errors.map(
+                (value) => value.message,
+              );
+              assert.notInclude(messages.join(), 'Message after fail');
+              done();
+            },
+          ));
 
-        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-              value => value.message
-            ));
-          }
-          assert.notInclude(messages.join(), 'Message after fail');
-          done();
-        }));
+        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit
+                    .getCall(callNo)
+                    .args[1].errors.map((value) => value.message),
+                );
+              }
+              assert.notInclude(messages.join(), 'Message after fail');
+              done();
+            },
+          ));
 
-        it('should set transaction info on the failed test', done => runner.executeAllTransactions([modifiedTransaction], runner.hooks, () => {
-          assert.propertyVal(modifiedTransaction.test, 'request', modifiedTransaction.request);
-          assert.propertyVal(modifiedTransaction.test, 'expected', modifiedTransaction.expected);
-          assert.propertyVal(modifiedTransaction.test, 'actual', modifiedTransaction.real);
-          done();
-        }));
+        it('should set transaction info on the failed test', (done) =>
+          runner.executeAllTransactions(
+            [modifiedTransaction],
+            runner.hooks,
+            () => {
+              assert.propertyVal(
+                modifiedTransaction.test,
+                'request',
+                modifiedTransaction.request,
+              );
+              assert.propertyVal(
+                modifiedTransaction.test,
+                'expected',
+                modifiedTransaction.expected,
+              );
+              assert.propertyVal(
+                modifiedTransaction.test,
+                'actual',
+                modifiedTransaction.real,
+              );
+              done();
+            },
+          ));
       });
 
       describe('in ‘after’ hook when transaction passes ', () => {
@@ -1965,7 +2550,9 @@ describe('TransactionRunner', () => {
           clonedTransaction = clone(transaction);
           runner.hooks.afterHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [
-              (hookTransaction) => { hookTransaction.fail = 'Message after pass'; },
+              (hookTransaction) => {
+                hookTransaction.fail = 'Message after pass';
+              },
             ],
           };
           sinon.stub(configuration.emitter, 'emit');
@@ -1976,63 +2563,123 @@ describe('TransactionRunner', () => {
           configuration.emitter.emit.restore();
         });
 
-        it('should make the request', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.isOk(server.isDone());
-          done();
-        }));
+        it('should make the request', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.isOk(server.isDone());
+              done();
+            },
+          ));
 
-        it('it should fail the test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.isOk(configuration.emitter.emit.calledWith('test fail'));
-          done();
-        }));
+        it('it should fail the test', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.isOk(configuration.emitter.emit.calledWith('test fail'));
+              done();
+            },
+          ));
 
-        it('it should not pass the test', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.notOk(configuration.emitter.emit.calledWith('test pass'));
-          done();
-        }));
+        it('it should not pass the test', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.notOk(configuration.emitter.emit.calledWith('test pass'));
+              done();
+            },
+          ));
 
-        it('it should pass the failing message to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.include(messages.join(), 'Message after pass');
-          done();
-        }));
+        it('it should pass the failing message to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.include(messages.join(), 'Message after pass');
+              done();
+            },
+          ));
 
-        it('should mention after hook in the error message', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].message);
-          }
-          assert.include(messages.join(), 'Failed in after hook:');
-          done();
-        }));
+        it('should mention after hook in the error message', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit.getCall(callNo).args[1].message,
+                );
+              }
+              assert.include(messages.join(), 'Failed in after hook:');
+              done();
+            },
+          ));
 
-        it('should set transaction test status to failed', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          assert.equal(clonedTransaction.test.status, 'fail');
-          done();
-        }));
+        it('should set transaction test status to failed', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              assert.equal(clonedTransaction.test.status, 'fail');
+              done();
+            },
+          ));
 
-        it('should add fail message as a error under `errors` to the results', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = clonedTransaction.errors.map(value => value.message);
-          assert.include(messages.join(), 'Message after pass');
-          done();
-        }));
+        it('should add fail message as a error under `errors` to the results', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = clonedTransaction.errors.map(
+                (value) => value.message,
+              );
+              assert.include(messages.join(), 'Message after pass');
+              done();
+            },
+          ));
 
-        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', done => runner.executeAllTransactions([clonedTransaction], runner.hooks, () => {
-          const messages = [];
-          const { callCount } = configuration.emitter.emit;
-          for (let callNo = 0, end = callCount - 1, asc = end >= 0; asc ? callNo <= end : callNo >= end; asc ? callNo++ : callNo--) {
-            messages.push(configuration.emitter.emit.getCall(callNo).args[1].errors.map(
-              value => value.message
-            ));
-          }
-          assert.include(messages.join(), 'Message after pass');
-          done();
-        }));
+        it('should not add fail message as a error under `errors` to the results on test passed to the emitter', (done) =>
+          runner.executeAllTransactions(
+            [clonedTransaction],
+            runner.hooks,
+            () => {
+              const messages = [];
+              const { callCount } = configuration.emitter.emit;
+              for (
+                let callNo = 0, end = callCount - 1, asc = end >= 0;
+                asc ? callNo <= end : callNo >= end;
+                asc ? callNo++ : callNo--
+              ) {
+                messages.push(
+                  configuration.emitter.emit
+                    .getCall(callNo)
+                    .args[1].errors.map((value) => value.message),
+                );
+              }
+              assert.include(messages.join(), 'Message after pass');
+              done();
+            },
+          ));
       });
     });
 
@@ -2044,13 +2691,19 @@ describe('TransactionRunner', () => {
         configuration.emitter.emit.restore();
       });
 
-      it('should not run the hooks', done => runner.executeAllTransactions([transaction], runner.hooks, () => done()));
+      it('should not run the hooks', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, () =>
+          done(),
+        ));
 
-      it('should pass the transactions', done => runner.executeAllTransactions([transaction], runner.hooks, (error) => {
-        if (error) { done(error); }
-        assert.isOk(configuration.emitter.emit.calledWith('test pass'));
-        done();
-      }));
+      it('should pass the transactions', (done) =>
+        runner.executeAllTransactions([transaction], runner.hooks, (error) => {
+          if (error) {
+            done(error);
+          }
+          assert.isOk(configuration.emitter.emit.calledWith('test pass'));
+          done();
+        }));
     });
 
     describe('with hook modifying the transaction body and backend Express app using the body parser', () => {
@@ -2058,7 +2711,7 @@ describe('TransactionRunner', () => {
 
       after(() => nock.disableNetConnect());
 
-      it('should perform the transaction and don\'t hang', (done) => {
+      it("should perform the transaction and don't hang", (done) => {
         nock.cleanAll();
 
         const receivedRequests = [];
@@ -2066,11 +2719,12 @@ describe('TransactionRunner', () => {
         runner.hooks.beforeHooks = {
           'Group Machine > Machine > Delete Message > Bogus example name': [
             // eslint-disable-next-line
-            function (transaction) {
+            function(transaction) {
               const body = JSON.parse(transaction.request.body);
               body.name = 'Michael';
               transaction.request.body = JSON.stringify(body);
-              transaction.request.headers['Content-Length'] = transaction.request.body.length;
+              transaction.request.headers['Content-Length'] =
+                transaction.request.body.length;
             },
           ],
         };
@@ -2083,11 +2737,13 @@ describe('TransactionRunner', () => {
           res.json([{ type: 'bulldozer', name: 'willy' }]);
         });
 
-        server = app.listen(transaction.port, () => runner.executeAllTransactions([transaction], runner.hooks, () => {
-          // Should not hang here
-          assert.isOk(true);
-          server.close();
-        }));
+        server = app.listen(transaction.port, () =>
+          runner.executeAllTransactions([transaction], runner.hooks, () => {
+            // Should not hang here
+            assert.isOk(true);
+            server.close();
+          }),
+        );
 
         server.on('close', () => {
           assert.equal(receivedRequests.length, 1);


### PR DESCRIPTION
#### :rocket: Why this change?

- Automatic code formatting allows to focus on writing code, not maintaining semicolons, tabs, spacing, and other opinionated code format rules;
- Prettier provides consistent codebase-wide formatting of code. When integrated into Git hooks, or CI workflow, it makes your entire source code beautiful by default;
- When it can be automated it must be automated;

#### :memo: Related issues and Pull Requests

- Indirectly related to #1524 

#### :white_check_mark: What didn't I forget?

> Current Pull request introduces no changes to Dredd's logic. It only contains re-formatting of existing source code and test suites.

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
- [x] To format existing source code
- [x] To format existing tests
- [x] To integrate Prettier with Git hooks/CI pipeline
- [x] Set `format-check` job as optional in the repository settings