### PR TITLE
docs: fix Rust hooks link

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -31,6 +31,7 @@ redirects:
   "/hooks-new-language.html": "/hooks/new-language.html"
   "/hooks-perl.html": "/hooks/perl.html"
   "/hooks-ruby.html": "/hooks/ruby.html"
+  "/hooks-rust.html": "/hooks/rust.html"
   "/hooks-php.html": "/hooks/php.html"
   "/hooks-python.html": "/hooks/python.html"
 
@@ -48,5 +49,6 @@ redirects:
   "/hooks-new-language/": "/hooks/new-language.html"
   "/hooks-perl/": "/hooks/perl.html"
   "/hooks-ruby/": "/hooks/ruby.html"
+  "/hooks-rust/": "/hooks/rust.html"
   "/hooks-php/": "/hooks/php.html"
   "/hooks-python/": "/hooks/python.html"


### PR DESCRIPTION
All langs but Rust have redirects set up. Without redirect, the link specified in README.md not going to work, so adding missing conf


#### :rocket: Why this change?

To fix [Rust link in README](https://github.com/apiaryio/dredd/blob/master/README.md#supported-hooks-languages), which is currently 404

![Screen Shot 2019-10-11 at 20 37 21](https://user-images.githubusercontent.com/235297/66676380-9e1d0780-ec67-11e9-8026-127c9602aefc.png)


#### :memo: Related issues and Pull Requests

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
