### PR TITLE
Fix dependencies bundling for yarn workspaces

### DIFF
--- a/packages/dredd-transactions/.gitignore
+++ b/packages/dredd-transactions/.gitignore
@@ -1,2 +1,3 @@
 dredd-transactions-*.tgz
+prepack-symlinks.log
 /test/fixtures/**/*.json

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -30,6 +30,7 @@
     "fury-adapter-apib-parser": "0.16.0",
     "fury-adapter-oas3-parser": "0.9.1",
     "fury-adapter-swagger": "0.27.2",
+    "rimraf": "3.0.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [
@@ -44,7 +45,6 @@
     "mocha": "6.2.1",
     "mocha-lcov-reporter": "1.3.0",
     "proxyquire": "2.1.3",
-    "rimraf": "3.0.0",
     "sinon": "7.5.0"
   },
   "keywords": [

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "prepack": "node ./scripts/prepack.js",
+    "postpack": "node ./scripts/postpack.js",
     "build": "exit 0",
     "clean": "rimraf ./coverage",
     "lint": "eslint --ignore-path .gitignore .",

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -30,7 +30,6 @@
     "fury-adapter-apib-parser": "0.16.0",
     "fury-adapter-oas3-parser": "0.9.1",
     "fury-adapter-swagger": "0.27.2",
-    "rimraf": "3.0.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [
@@ -45,6 +44,7 @@
     "mocha": "6.2.1",
     "mocha-lcov-reporter": "1.3.0",
     "proxyquire": "2.1.3",
+    "rimraf": "3.0.0",
     "sinon": "7.5.0"
   },
   "keywords": [

--- a/packages/dredd-transactions/scripts/postpack.js
+++ b/packages/dredd-transactions/scripts/postpack.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Cleans up after the prepack.js script
+
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_DIR = path.resolve(path.dirname(__filename), '..');
+const SYMLINKS_LOG = path.join(PACKAGE_DIR, 'prepack-symlinks.log');
+
+
+if (fs.existsSync(SYMLINKS_LOG)) {
+  fs.readFileSync(SYMLINKS_LOG, 'utf8')
+    .split('\n')
+    .filter(line => line.trim())
+    .map(dependencyName => path.join(PACKAGE_DIR, 'node_modules', dependencyName))
+    .filter(symlinkPath => fs.existsSync(symlinkPath))
+    .forEach(symlinkPath => fs.unlinkSync(symlinkPath));
+
+  fs.unlinkSync(SYMLINKS_LOG);
+}

--- a/packages/dredd-transactions/scripts/prepack.js
+++ b/packages/dredd-transactions/scripts/prepack.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+/* eslint-disable import/no-extraneous-dependencies */
 const rimraf = require('rimraf');
 
 const PACKAGE_DIR = path.resolve(__dirname, '..');

--- a/packages/dredd-transactions/scripts/prepack.js
+++ b/packages/dredd-transactions/scripts/prepack.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
-const PACKAGE_DIR = path.resolve(path.dirname(__filename), '..');
+const PACKAGE_DIR = path.resolve(__dirname, '..');
 const SYMLINKS_LOG = path.join(PACKAGE_DIR, 'prepack-symlinks.log');
 const DRAFTER_PATH = path.join(PACKAGE_DIR, 'node_modules', 'drafter');
 
@@ -44,7 +44,7 @@ function symlinkDependencyTreeToLocalNodeModules(dependencyName) {
 
 
 // make sure all bundled deps are accessible in the local 'node_modules' dir
-const packageData = readPackageJson(PACKAGE_DIR, 'package.json');
+const packageData = readPackageJson(PACKAGE_DIR);
 const { bundledDependencies } = packageData;
 bundledDependencies.forEach(symlinkDependencyTreeToLocalNodeModules);
 


### PR DESCRIPTION
#### :rocket: Why this change?

This improves the hack which gets rid of protagonist (i.e. C++ compilation of drafter, the API Blueprint parser). When we moved dredd-transactions to the monorepo, where dependencies are managed by yarn workspaces, the hack to get rid of protagonist stopped to work. The hack relies on 'bundledDependencies', but those stopped to work. 'npm pack' cannot find the dependencies to bundle if they're in the root 'node_modules' directory. 'yarn pack' doesn't work either, it has bugs and it doesn't support 'bundledDependencies' or the workspaces very well - see https://github.com/yarnpkg/yarn/issues/6794

This change overcomes the limitation by improving the prepack.js script. It now iterates over the 'bundledDependencies' and symlinks them to the local 'node_modules' directory where 'npm pack' can pick them up. After packing is done, there's a new postpack.js script, which makes sure the symlinks get cleaned up. The resulting .tgz then contains the dependencies bundled - without protagonist.

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd/pull/1551

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
