### PR TITLE
chore: removes "test:debug" script

### DIFF
--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -16,7 +16,6 @@
     "prettify": "prettier --write lib/**/*.js test/**/*.js",
     "prettify:check": "prettier --check lib/**/*.js test/**/*.js",
     "test": "mocha \"./test/**/*-test.js\"",
-    "test:debug": "mocha --debug-brk \"./test/**/*-test.js\"",
     "test:smoke": "bash ./scripts/smoke.sh",
     "e2e": "yarn e2e:apib && yarn e2e:openapi2",
     "e2e:apib": "cucumber-js",


### PR DESCRIPTION
#### :rocket: Why this change?

Removes `test:debug` command which is not used and is not a valid command.

Instead, it's preferred to use:

```bash
$ npm test -- --grep="sanitation"
$ npm test -- --inspect-brk
```

#### :memo: Related issues and Pull Requests

- Relates to #1393 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
