### PR TITLE
Uses "API Project Name" term over "API Project Subdomain"

### DIFF
--- a/docs/how-to-guides.rst
+++ b/docs/how-to-guides.rst
@@ -685,7 +685,7 @@ Command-line output of complex HTTP responses and expectations can be hard to re
 ::
 
    $ dredd apiary.apib http://127.0.0.1 --reporter=apiary
-   warn: Apiary API Key or API Project Subdomain were not provided. Configure Dredd to be able to save test reports alongside your Apiary API project: https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
+   warn: Apiary API Key or API Project Name were not provided. Configure Dredd to be able to save test reports alongside your Apiary API project: https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
    pass: DELETE /honey duration: 884ms
    complete: 1 passing, 0 failing, 0 errors, 0 skipped, 1 total
    complete: Tests took 1631ms
@@ -712,12 +712,12 @@ As you can see, the parameters go like this:
 
 ::
 
-   $ dredd -j apiaryApiKey:<Apiary API Key> -j apiaryApiName:<API Project Subdomain>
+   $ dredd -j apiaryApiKey:<Apiary API Key> -j apiaryApiName:<API Project Name>
 
 In addition to using parameters and ``dredd.yml``, you can also use environment variables:
 
 -  ``APIARY_API_KEY=<Apiary API Key>`` - Alternative way to pass credentials to Apiary Reporter.
--  ``APIARY_API_NAME=<API Project Subdomain>`` - Alternative way to pass credentials to Apiary Reporter.
+-  ``APIARY_API_NAME=<API Project Name>`` - Alternative way to pass credentials to Apiary Reporter.
 
 When sending test reports to Apiary, Dredd inspects the environment where it was executed and sends some information about it alongside test results. Those are used mainly for detection whether the environment is Continuous Integration and also, they help you to identify individual test reports on the *Tests* page. You can use the following variables to tell Dredd what to send:
 

--- a/packages/dredd/ApiaryReportingApi.apib
+++ b/packages/dredd/ApiaryReportingApi.apib
@@ -19,7 +19,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 ### Test Runs [/apis/{apiProject}/tests/runs]
 
 + Parameters
-    + apiProject: exampleapi (required) - API project subdomain
+    + apiProject: exampleapi (required) - API Project Name
 
 #### Create a Test Run [POST]
 
@@ -47,7 +47,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 ### Test Run [/apis/{apiProject}/tests/run/{id}]
 
 + Parameters
-    + apiProject: exampleapi (required) - API project subdomain
+    + apiProject: exampleapi (required) - API Project Name
     + id: 507f1f77bcf86cd799439011 (required) - unique ID of the test report
 
 #### Retrieve a Test Run [GET]
@@ -87,7 +87,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 ### Test Steps [/apis/{apiProject}/tests/steps{?testRunId}]
 
 + Parameters
-    + apiProject: exampleapi (required) - API project subdomain
+    + apiProject: exampleapi (required) - API Project Name
     + testRunId: 507f1f77bcf86cd799439011 (required) - filter by test report ID
 
 #### Create a Test Step [POST]
@@ -118,7 +118,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 #### Retreive a Test Step [GET]
 
 + Parameters
-    + apiProject: exampleapi (required) - API project subdomain
+    + apiProject: exampleapi (required) - API Project Name
     + id: 508c7f79bcf86cd7994f6c0e (required) - Unique identifier of test step in Apiary
 
 + Request (application/json)

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -45,7 +45,7 @@ function ApiaryReporter(emitter, stats, config, runner) {
 
   if (!this.configuration.apiToken && !this.configuration.apiSuite) {
     logger.warn(`
-Apiary API Key or API Project Subdomain were not provided.
+Apiary API Key or API Project Name were not provided.
 Configure Dredd to be able to save test reports alongside your Apiary API project:
 https://dredd.org/en/latest/how-to-guides/#using-apiary-reporter-and-apiary-tests
 `);

--- a/packages/dredd/test/integration/apiary-reporter-test.js
+++ b/packages/dredd/test/integration/apiary-reporter-test.js
@@ -140,7 +140,7 @@ describe('Apiary reporter', () => {
     it('should not print warning about missing Apiary API settings', () =>
       assert.notInclude(
         output,
-        'Apiary API Key or API Project Subdomain were not provided.',
+        'Apiary API Key or API Project Name were not provided.',
       ));
 
     it('should contain Authentication header thanks to apiaryApiKey and apiaryApiName configuration', () => {
@@ -300,7 +300,7 @@ describe('Apiary reporter', () => {
       it('should print warning about missing Apiary API settings', () =>
         assert.include(
           output,
-          'Apiary API Key or API Project Subdomain were not provided.',
+          'Apiary API Key or API Project Name were not provided.',
         ));
 
       it('should print link to documentation', () =>

--- a/packages/dredd/test/integration/cli/reporters-cli-test.js
+++ b/packages/dredd/test/integration/cli/reporters-cli-test.js
@@ -98,7 +98,7 @@ describe('CLI - Reporters', () => {
       it('should print warning about missing Apiary API settings', () =>
         assert.include(
           cliInfo.stdout,
-          'Apiary API Key or API Project Subdomain were not provided.'
+          'Apiary API Key or API Project Name were not provided.'
         ))
       it('should exit with status 0', () => assert.equal(cliInfo.exitStatus, 0))
       it('should perform 3 requests to Apiary', () => {


### PR DESCRIPTION
#### :rocket: Why this change?

Changes the phrasing from "API Project Subdomain" to "API Project Name" to make the expectations more obvious. 

#### :memo: Related issues and Pull Requests

- Closes #611 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests (not relevant)
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
