### PR TITLE
Adds "LINK" and "UNLINK" HTTP methods

### DIFF
--- a/packages/dredd/lib/general.ts
+++ b/packages/dredd/lib/general.ts
@@ -6,8 +6,10 @@ export enum HTTPMethod {
   HEAD = 'HEAD',
   PUT = 'PUT',
   PATCH = 'PATCH',
+  LINK = 'LINK',
+  UNLINK = 'UNLINK',
   DELETE = 'DELETE',
-  TRACE = 'TRACE',
+  TRACE = 'TRACE'
 }
 
 export enum BodyEncoding {

--- a/packages/dredd/lib/sortTransactions.ts
+++ b/packages/dredd/lib/sortTransactions.ts
@@ -8,6 +8,8 @@ const sortedMethods: HTTPMethod[] = [
   HTTPMethod.HEAD,
   HTTPMethod.PUT,
   HTTPMethod.PATCH,
+  HTTPMethod.LINK,
+  HTTPMethod.UNLINK,
   HTTPMethod.DELETE,
   HTTPMethod.TRACE,
 ];

--- a/packages/dredd/options.json
+++ b/packages/dredd/options.json
@@ -64,7 +64,7 @@
   },
   "sorted": {
     "alias": "s",
-    "description": "Sorts requests in a sensible way so that objects are not modified before they are created. Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.",
+    "description": "Sorts requests in a sensible way so that objects are not modified before they are created. Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, LINK, UNLINK, DELETE, TRACE.",
     "default": false
   },
   "user": {

--- a/packages/dredd/test/unit/sortTransactions-test.ts
+++ b/packages/dredd/test/unit/sortTransactions-test.ts
@@ -35,10 +35,12 @@ describe('sortTransactions', () => {
       transactions.TRACE,
       transactions.OPTIONS,
       transactions.HEAD,
+      transactions.LINK,
       transactions.DELETE,
       transactions.POST,
       transactions.PATCH,
       transactions.PUT,
+      transactions.UNLINK,
       transactions.CONNECT,
     ]);
 
@@ -51,6 +53,8 @@ describe('sortTransactions', () => {
         transactions.HEAD,
         transactions.PUT,
         transactions.PATCH,
+        transactions.LINK,
+        transactions.UNLINK,
         transactions.DELETE,
         transactions.TRACE,
       ]);
@@ -92,6 +96,8 @@ describe('sortTransactions', () => {
       transactions.HEAD,
       transactions.PUT,
       transactions.PATCH,
+      transactions.LINK,
+      transactions.UNLINK,
       transactions.DELETE,
       transactions.TRACE,
     ];


### PR DESCRIPTION
#### :rocket: Why this change?

Adds missing `LINK` and `UNLINK` HTTP methods to abide by the `--sorted` CLI flag. Sets them in the expected order in correspondence to other methods and provides unit tests.

#### :memo: Related issues and Pull Requests

- Fixes #267 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
