### PR TITLE
Updates Gavel for JSON Schema Draft 6/7 support

### DIFF
--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -100,7 +100,7 @@ To validate the structure Dredd uses `JSON Schema`_ inferred from the API descri
 API Blueprint
 ^^^^^^^^^^^^^
 
-1. :apib:`Schema <def-schema-section>` section - provided custom JSON Schema (`Draft 4 <JSON Schema Draft 4_>`__ and `Draft 3 <JSON Schema Draft 3_>`__) will be used.
+1. :apib:`Schema <def-schema-section>` section - provided custom JSON Schema (`Draft 4 <JSON Schema Draft 4_>`__, `Draft 3 <JSON Schema Draft 3_>`__, `Draft 6 <JSON Schema Draft 6_>`__, and `Draft 7 <JSON Schema Draft 7_>`__) will be used.
 2. :apib:`Attributes <def-attributes-section>` section with data structure description in `MSON`_ - API Blueprint parser automatically generates JSON Schema from MSON.
 3. :apib:`Body <def-body-section>` section with sample JSON payload - `Gavel`_, which is responsible for validation in Dredd, automatically infers some basic expectations described below.
 

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -39,7 +39,7 @@
     "clone": "2.1.2",
     "cross-spawn": "7.0.0",
     "dredd-transactions": "9.0.6",
-    "gavel": "8.1.1",
+    "gavel": "^8.2.0",
     "glob": "7.1.5",
     "html": "1.0.0",
     "htmlencode": "0.0.4",

--- a/packages/dredd/test/fixtures/json-schema-draft-7-boolean.apib
+++ b/packages/dredd/test/fixtures/json-schema-draft-7-boolean.apib
@@ -6,13 +6,13 @@ FORMAT: 1A
 
 # Machines collection [/machines/{id}]
     + Parameters
-        + id (number, `1`)
+        + id: 1 (number)
 
 ## Get Machines [GET]
 
 + Request (application/json)
     + Parameters
-        + id (number, `2`)
+        + id: 2 (number)
 
 + Response 200 (application/json; charset=utf-8)
 

--- a/packages/dredd/test/fixtures/json-schema-draft-7-boolean.apib
+++ b/packages/dredd/test/fixtures/json-schema-draft-7-boolean.apib
@@ -1,0 +1,21 @@
+FORMAT: 1A
+
+# Machines API
+
+# Group Machines
+
+# Machines collection [/machines/{id}]
+    + Parameters
+        + id (number, `1`)
+
+## Get Machines [GET]
+
++ Request (application/json)
+    + Parameters
+        + id (number, `2`)
+
++ Response 200 (application/json; charset=utf-8)
+
+    + Schema
+
+            true

--- a/packages/dredd/test/fixtures/json-schema-draft-7.apib
+++ b/packages/dredd/test/fixtures/json-schema-draft-7.apib
@@ -1,0 +1,32 @@
+FORMAT: 1A
+
+# Machines API
+
+# Group Machines
+
+# Machines collection [/machines]
+
+## Get Machines [GET]
+
+- Response 200 (application/json; charset=utf-8)
+
+    + Schema
+        
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["bulldozer"]
+                        },
+                        "name": {
+                            "not": {
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            }

--- a/packages/dredd/test/fixtures/json-schema-draft-7.apib
+++ b/packages/dredd/test/fixtures/json-schema-draft-7.apib
@@ -20,7 +20,7 @@ FORMAT: 1A
                     "properties": {
                         "type": {
                             "type": "string",
-                            "enum": ["bulldozer"]
+                            "const": "bulldozer"
                         },
                         "name": {
                             "not": {

--- a/packages/dredd/test/integration/json-schema-draft-7-test.js
+++ b/packages/dredd/test/integration/json-schema-draft-7-test.js
@@ -64,7 +64,7 @@ describe('Given API Blueprint with JSON Schema Draft 7', () => {
       it('should output an error about unknown "type" enum value', () => {
         assert.match(
           runtimeInfo.dredd.logging,
-          /data\/0\/type should be equal to one of the allowed values/,
+          /data\/0\/type should be equal to constant/,
         );
       });
     });

--- a/packages/dredd/test/integration/json-schema-draft-7-test.js
+++ b/packages/dredd/test/integration/json-schema-draft-7-test.js
@@ -5,6 +5,8 @@ import { runDreddWithServer, createServer } from './helpers';
 
 describe('Given API Blueprint with JSON Schema Draft 7', () => {
   describe('given explicit version of JSON Schema', () => {
+    const FIXTURE_PATH = './test/fixtures/json-schema-draft-7.apib';
+
     describe('given actual data matches the schema', () => {
       let runtimeInfo;
 
@@ -15,12 +17,11 @@ describe('Given API Blueprint with JSON Schema Draft 7', () => {
         });
 
         const dredd = new Dredd({
-          path: './test/fixtures/json-schema-draft-7.apib',
+          path: FIXTURE_PATH,
         });
 
-        runDreddWithServer(dredd, app, (...args) => {
-          let error;
-          [error, runtimeInfo] = Array.from(args);
+        runDreddWithServer(dredd, app, (error, info) => {
+          runtimeInfo = info;
           done(error);
         });
       });
@@ -47,12 +48,11 @@ describe('Given API Blueprint with JSON Schema Draft 7', () => {
         });
 
         const dredd = new Dredd({
-          path: './test/fixtures/json-schema-draft-7.apib',
+          path: FIXTURE_PATH,
         });
 
-        runDreddWithServer(dredd, app, (...args) => {
-          let error;
-          [error, runtimeInfo] = Array.from(args);
+        runDreddWithServer(dredd, app, (error, info) => {
+          runtimeInfo = info;
           done(error);
         });
       });
@@ -71,24 +71,25 @@ describe('Given API Blueprint with JSON Schema Draft 7', () => {
   });
 
   describe('given a single Boolean value as a JSON Schema', () => {
+    const FIXTURE_PATH = './test/fixtures/json-schema-draft-7-boolean.apib';
+
     describe('given schema equals "true"', () => {
       let runtimeInfo;
 
       before((done) => {
         const app = createServer();
         app.get('/machines/:id', (req, res) => {
-          const { id } = req.params
-          const machines = [{ type: 'bulldozer', name: 'willy' }]
+          const { id } = req.params;
+          const machines = [{ type: 'bulldozer', name: 'willy' }];
           res.json(machines[id] || {});
         });
 
         const dredd = new Dredd({
-          path: './test/fixtures/json-schema-draft-7-boolean.apib',
+          path: FIXTURE_PATH,
         });
 
-        runDreddWithServer(dredd, app, (...args) => {
-          let error;
-          [error, runtimeInfo] = Array.from(args);
+        runDreddWithServer(dredd, app, (error, info) => {
+          runtimeInfo = info;
           done(error);
         });
       });

--- a/packages/dredd/test/integration/json-schema-draft-7-test.js
+++ b/packages/dredd/test/integration/json-schema-draft-7-test.js
@@ -1,0 +1,70 @@
+import { assert } from 'chai';
+
+import Dredd from '../../lib/Dredd';
+import { runDreddWithServer, createServer } from './helpers';
+
+describe('Given API Blueprint with JSON Schema Draft 7', () => {
+  describe('given actual data matches the schema', () => {
+    let runtimeInfo;
+
+    before((done) => {
+      const app = createServer();
+      app.get('/machines', (req, res) => {
+        res.json([{ type: 'bulldozer', name: 'willy' }]);
+      });
+
+      const dredd = new Dredd({
+        path: './test/fixtures/json-schema-draft-7.apib',
+      });
+
+      runDreddWithServer(dredd, app, (...args) => {
+        let error;
+        [error, runtimeInfo] = Array.from(args);
+        done(error);
+      });
+    });
+
+    it('should output no failures or errors', () => {
+      assert.equal(
+        runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+        0,
+      );
+    });
+
+    it('should result into passing test', () => {
+      assert.equal(runtimeInfo.dredd.stats.passes, 1);
+    });
+  });
+
+  describe('given actual data does not match the schema', () => {
+    let runtimeInfo;
+
+    before((done) => {
+      const app = createServer();
+      app.get('/machines', (req, res) => {
+        res.json([{ type: 'unknown', name: 'willy' }]);
+      });
+
+      const dredd = new Dredd({
+        path: './test/fixtures/json-schema-draft-7.apib',
+      });
+
+      runDreddWithServer(dredd, app, (...args) => {
+        let error;
+        [error, runtimeInfo] = Array.from(args);
+        done(error);
+      });
+    });
+
+    it('should result into 1 failing test', () => {
+      assert.equal(runtimeInfo.dredd.stats.failures, 1);
+    });
+
+    it('should output an error about unknown "type" enum value', () => {
+      assert.match(
+        runtimeInfo.dredd.logging,
+        /data\/0\/type should be equal to one of the allowed values/,
+      );
+    });
+  });
+});

--- a/packages/dredd/test/integration/json-schema-draft-7-test.js
+++ b/packages/dredd/test/integration/json-schema-draft-7-test.js
@@ -4,67 +4,108 @@ import Dredd from '../../lib/Dredd';
 import { runDreddWithServer, createServer } from './helpers';
 
 describe('Given API Blueprint with JSON Schema Draft 7', () => {
-  describe('given actual data matches the schema', () => {
-    let runtimeInfo;
+  describe('given explicit version of JSON Schema', () => {
+    describe('given actual data matches the schema', () => {
+      let runtimeInfo;
 
-    before((done) => {
-      const app = createServer();
-      app.get('/machines', (req, res) => {
-        res.json([{ type: 'bulldozer', name: 'willy' }]);
+      before((done) => {
+        const app = createServer();
+        app.get('/machines', (req, res) => {
+          res.json([{ type: 'bulldozer', name: 'willy' }]);
+        });
+
+        const dredd = new Dredd({
+          path: './test/fixtures/json-schema-draft-7.apib',
+        });
+
+        runDreddWithServer(dredd, app, (...args) => {
+          let error;
+          [error, runtimeInfo] = Array.from(args);
+          done(error);
+        });
       });
 
-      const dredd = new Dredd({
-        path: './test/fixtures/json-schema-draft-7.apib',
+      it('should output no failures or errors', () => {
+        assert.equal(
+          runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+          0,
+        );
       });
 
-      runDreddWithServer(dredd, app, (...args) => {
-        let error;
-        [error, runtimeInfo] = Array.from(args);
-        done(error);
+      it('should result into passing test', () => {
+        assert.equal(runtimeInfo.dredd.stats.passes, 1);
       });
     });
 
-    it('should output no failures or errors', () => {
-      assert.equal(
-        runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
-        0,
-      );
-    });
+    describe('given actual data does not match the schema', () => {
+      let runtimeInfo;
 
-    it('should result into passing test', () => {
-      assert.equal(runtimeInfo.dredd.stats.passes, 1);
+      before((done) => {
+        const app = createServer();
+        app.get('/machines', (req, res) => {
+          res.json([{ type: 'unknown', name: 'willy' }]);
+        });
+
+        const dredd = new Dredd({
+          path: './test/fixtures/json-schema-draft-7.apib',
+        });
+
+        runDreddWithServer(dredd, app, (...args) => {
+          let error;
+          [error, runtimeInfo] = Array.from(args);
+          done(error);
+        });
+      });
+
+      it('should result into 1 failing test', () => {
+        assert.equal(runtimeInfo.dredd.stats.failures, 1);
+      });
+
+      it('should output an error about unknown "type" enum value', () => {
+        assert.match(
+          runtimeInfo.dredd.logging,
+          /data\/0\/type should be equal to one of the allowed values/,
+        );
+      });
     });
   });
 
-  describe('given actual data does not match the schema', () => {
-    let runtimeInfo;
+  describe('given a single Boolean value as a JSON Schema', () => {
+    describe('given schema equals "true"', () => {
+      let runtimeInfo;
 
-    before((done) => {
-      const app = createServer();
-      app.get('/machines', (req, res) => {
-        res.json([{ type: 'unknown', name: 'willy' }]);
+      before((done) => {
+        const app = createServer();
+        app.get('/machines/:id', (req, res) => {
+          const { id } = req.params
+          const machines = [{ type: 'bulldozer', name: 'willy' }]
+          res.json(machines[id] || {});
+        });
+
+        const dredd = new Dredd({
+          path: './test/fixtures/json-schema-draft-7-boolean.apib',
+        });
+
+        runDreddWithServer(dredd, app, (...args) => {
+          let error;
+          [error, runtimeInfo] = Array.from(args);
+          done(error);
+        });
       });
 
-      const dredd = new Dredd({
-        path: './test/fixtures/json-schema-draft-7.apib',
+      it('should recognize schema as Draft 7', () => {
+        // No invalid schema version error from Gavel and no failing tests
+        // implies the schema version was properly inferred as Draft 7.
+        assert.notMatch(runtimeInfo.dredd.logging, /not a valid draft/);
+        assert.equal(
+          runtimeInfo.dredd.stats.failures + runtimeInfo.dredd.stats.errors,
+          0,
+        );
       });
 
-      runDreddWithServer(dredd, app, (...args) => {
-        let error;
-        [error, runtimeInfo] = Array.from(args);
-        done(error);
+      it('should always result into passing test', () => {
+        assert.equal(runtimeInfo.dredd.stats.passes, 1);
       });
-    });
-
-    it('should result into 1 failing test', () => {
-      assert.equal(runtimeInfo.dredd.stats.failures, 1);
-    });
-
-    it('should output an error about unknown "type" enum value', () => {
-      assert.match(
-        runtimeInfo.dredd.logging,
-        /data\/0\/type should be equal to one of the allowed values/,
-      );
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,7 +1144,7 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@6.10.2, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -3167,11 +3167,12 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gavel@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/gavel/-/gavel-8.1.1.tgz#c3f82e5ef468661bda9ff7800c58c51e979b3477"
-  integrity sha512-TgMghBKUOL7/zaNvn71X+e7jg16fL1lycDtltrfiSgGhHKNQHN9+77kkEpBVkwCl5kERId3kFlhjqU9W7l4ODw==
+gavel@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/gavel/-/gavel-8.2.0.tgz#404f016cf123ac403e7ebc895b72cbc80d3abb47"
+  integrity sha512-vzdyl98UO5TXJ9wytocbLq56AlG21lAUJgKIXTMN+UZnZcEpX5vMXw7Lbxs2gfdm/iz3U0M+vUWjl/N2mqgoMA==
   dependencies:
+    ajv "6.10.2"
     amanda "1.0.1"
     caseless "0.12.0"
     clone "2.1.2"


### PR DESCRIPTION
> **Currently Dredd release is blocked by https://github.com/lerna/lerna/pull/2358**

#### :rocket: Why this change?

- To support JSON Schema Draft 6/7 validation in Dredd

#### :memo: Related issues and Pull Requests

- Gavel implementation https://github.com/apiaryio/gavel.js/pull/355

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
- [x] Add an integration test asserting JSON Schema Draft 6/7 usage
- [x] Add an integration test with a single Boolean value JSON Schema to be inferred as Draft 7