### PR TITLE
Skips yarn installation on the latest circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
 
 aliases:
   - &install
-    - run: sudo npm i -g yarn && yarn install --frozen-lockfile
+    - run: yarn install --frozen-lockfile
 
   - &node12
     image: circleci/node:12


### PR DESCRIPTION
#### :rocket: Why this change?

- Latest CircleCI images already have Yarn installed. Attempts to install it again break the build.

#### :memo: Related issues and Pull Requests

- https://github.com/apiaryio/api-elements.js/pull/395

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
