### PR TITLE
test: adds OA2 produces/consumes integration test

### DIFF
--- a/packages/dredd/test/fixtures/531-produces-consumes.yaml
+++ b/packages/dredd/test/fixtures/531-produces-consumes.yaml
@@ -1,0 +1,45 @@
+swagger: "2.0"
+info:
+  title: "Blog API"
+  version: "1.0"
+consumes:
+  - "application/hal+json; charset=utf-8"
+produces:
+  - "application/hal+json; charset=utf-8"
+paths:
+  "/articles":
+    x-summary: "Articles"
+    get:
+      summary: "List articles"
+      description: "Retrieve a list of all articles"
+      responses:
+        200:
+          description: "Articles list"
+          examples:
+            "application/hal+json; charset=utf-8":
+              - id: 1
+                title: "Creamy cucumber salad"
+                text: "Slice cucumbers…"
+                _links: {
+                  self: {
+                    href: "/articles/1"
+                  }
+                }
+    post:
+      summary: "Publish an article"
+      description: "Create and publish a new article"
+      parameters:
+        - name: "body"
+          in: "body"
+          schema:
+            example:
+              title: "Crispy schnitzel"
+              text: "Prepare eggs…"
+      responses:
+        201:
+          description: "New article"
+          examples:
+            "application/hal+json; charset=utf-8":
+              id: 2
+              title: "Crispy schnitzel"
+              text: "Prepare eggs…"

--- a/packages/dredd/test/integration/regressions/regression-531-test.js
+++ b/packages/dredd/test/integration/regressions/regression-531-test.js
@@ -1,0 +1,62 @@
+import { assert } from 'chai';
+
+import { runDreddWithServer, createServer } from '../helpers';
+import Dredd from '../../../lib/Dredd';
+
+describe(`Sending and receiving "application/hal+json" according to produces/consumes in OpenAPI 2.0`, () => {
+  let runtimeInfo;
+
+  before((done) => {
+    const app = createServer();
+    app.get('/articles', (req, res) =>
+      res
+        .set({
+          'content-type': 'application/hal+json',
+        })
+        .json([
+          {
+            id: 1,
+            title: 'Creamy',
+            text: 'Arbitrary',
+            _links: {
+              self: {
+                href: '/articles/1',
+              },
+            },
+          },
+        ]),
+    );
+    app.post('/articles', (req, res) => {
+      res.status(201).json({
+        id: 2,
+        title: 'Crispy schnitzel',
+        text: 'Prepare eggs...',
+      });
+    });
+
+    const dredd = new Dredd({
+      options: {
+        path: './test/fixtures/531-produces-consumes.yaml',
+      },
+    });
+
+    runDreddWithServer(dredd, app, (err, info) => {
+      runtimeInfo = info;
+      done(err);
+    });
+  });
+
+  it('results in one passed request test', () => {
+    assert.equal(runtimeInfo.dredd.stats.passes, 1);
+    assert.include(runtimeInfo.dredd.logging, 'pass: GET (200) /articles');
+  });
+
+  it('results in one failed response test', () => {
+    assert.equal(runtimeInfo.dredd.stats.failures, 1);
+    assert.include(runtimeInfo.dredd.logging, 'fail: POST (201) /articles');
+    assert.include(
+      runtimeInfo.dredd.logging,
+      `fail: headers: At '/content-type' No enum match for: "application/json; charset=utf-8"`,
+    );
+  });
+});


### PR DESCRIPTION
#### :rocket: Why this change?

Adds missing integration test for OA2 `produces`/`consumes` properties. 

#### :memo: Related issues and Pull Requests

- Closes #531 

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
