### PR TITLE
chore(deps): bumps "gavel" to "9.1.1"

### DIFF
--- a/docs/_links.rst
+++ b/docs/_links.rst
@@ -19,7 +19,6 @@
 .. JSON Schema
 
 .. _JSON Schema: https://json-schema.org
-.. _JSON Schema Draft 3: https://tools.ietf.org/html/draft-zyp-json-schema-03
 .. _JSON Schema Draft 4: https://tools.ietf.org/html/draft-zyp-json-schema-04
 .. _JSON Schema Draft 5: https://tools.ietf.org/html/draft-wright-json-schema-00
 .. _JSON Schema Draft 6: https://tools.ietf.org/html/draft-wright-json-schema-01

--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -100,7 +100,7 @@ To validate the structure Dredd uses `JSON Schema`_ inferred from the API descri
 API Blueprint
 ^^^^^^^^^^^^^
 
-1. :apib:`Schema <def-schema-section>` section - provided custom JSON Schema (`Draft 4 <JSON Schema Draft 4_>`__, `Draft 3 <JSON Schema Draft 3_>`__, `Draft 6 <JSON Schema Draft 6_>`__, and `Draft 7 <JSON Schema Draft 7_>`__) will be used.
+1. :apib:`Schema <def-schema-section>` section - provided custom JSON Schema (`Draft 4 <JSON Schema Draft 4_>`__, `Draft 6 <JSON Schema Draft 6_>`__, and `Draft 7 <JSON Schema Draft 7_>`__) will be used.
 2. :apib:`Attributes <def-attributes-section>` section with data structure description in `MSON`_ - API Blueprint parser automatically generates JSON Schema from MSON.
 3. :apib:`Body <def-body-section>` section with sample JSON payload - `Gavel`_, which is responsible for validation in Dredd, automatically infers some basic expectations described below.
 

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -39,7 +39,7 @@
     "clone": "2.1.2",
     "cross-spawn": "7.0.0",
     "dredd-transactions": "9.1.1",
-    "gavel": "^8.2.0",
+    "gavel": "^9.1.1",
     "glob": "7.1.5",
     "html": "1.0.0",
     "htmlencode": "0.0.4",

--- a/packages/dredd/test/fixtures/schema.apib
+++ b/packages/dredd/test/fixtures/schema.apib
@@ -23,19 +23,17 @@ Demonstrates dredd schema test issue [#46](https://github.com/apiaryio/dredd/iss
 
             {
                 "type":"object",
-                "required":true,
+                "required":["data"],
                 "properties":{
                     "data": {
                         "type":"object",
-                        "required":true,
+                        "required":["expires","token"],
                         "properties":{
                             "expires": {
-                                "type":"number",
-                                "required":true
+                                "type":"number"
                             },
                             "token": {
-                                "type":"string",
-                                "required":true
+                                "type":"string"
                             }
                         }
                     }

--- a/packages/dredd/test/integration/cli/hookfiles-cli-test.js
+++ b/packages/dredd/test/integration/cli/hookfiles-cli-test.js
@@ -800,8 +800,9 @@ describe('CLI', () => {
         })
       })
 
-      it('exit status should be 0 (success)', () =>
-        assert.equal(runtimeInfo.dredd.exitStatus, 0))
+      it('exit status should be 0 (success)', () => {
+        assert.equal(runtimeInfo.dredd.exitStatus, 0)
+      })
     })
 
     describe('and server is NOT responding in accordance with the schema', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,11 +1154,6 @@ ajv@6.10.2, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-amanda@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amanda/-/amanda-1.0.1.tgz#0929f3ce0dcd4a74d28d054e2b2e712cbc8ce582"
-  integrity sha512-DJZMA1t7skqQgH5yq4NxBfqun+jDQUSYJRYGg+AqnKc3I0/hs8eX3PDdlfgiADkHgo4HlesD5QuoqFcCYA280Q==
-
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
@@ -2233,7 +2228,19 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@1.1.0, deep-equal@^1.0.0:
+deep-equal@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
+deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.0.tgz#3103cdf8ab6d32cf4a8df7865458f2b8d33f3745"
   integrity sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==
@@ -3145,19 +3152,18 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gavel@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/gavel/-/gavel-8.2.0.tgz#404f016cf123ac403e7ebc895b72cbc80d3abb47"
-  integrity sha512-vzdyl98UO5TXJ9wytocbLq56AlG21lAUJgKIXTMN+UZnZcEpX5vMXw7Lbxs2gfdm/iz3U0M+vUWjl/N2mqgoMA==
+gavel@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/gavel/-/gavel-9.1.1.tgz#4107fa9a21b78ef6d9ee0e6381030829620986f6"
+  integrity sha512-cCNY+LzQsW5uFLUABFreV+7lI8R/6FGpMpKl7eY/SltlDYU1Mdg+xFHgYITX4f1tgJJ8g07yVHW8jGao7IHlUg==
   dependencies:
     ajv "6.10.2"
-    amanda "1.0.1"
     caseless "0.12.0"
     clone "2.1.2"
     commander "3.0.2"
     content-type "1.0.4"
     curl-trace-parser "0.0.10"
-    deep-equal "1.1.0"
+    deep-equal "1.1.1"
     http-string-parser "0.0.6"
     json-pointer "0.6.0"
     media-typer "1.1.0"


### PR DESCRIPTION
#### :rocket: Why this change?

- To include the latest version of Gavel that removes JSON Schema Draft 3 support

#### :memo: Related issues and Pull Requests

- No related issues, governance task

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs (removed mentioning of JSON Schema Draft 3 from the docs)
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
