### PR TITLE
fix: bumps "fury-adapter-swagger" to 0.28.2

### DIFF
--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -29,7 +29,7 @@
     "fury": "3.0.0-beta.13",
     "fury-adapter-apib-parser": "0.17.0",
     "fury-adapter-oas3-parser": "0.10.1",
-    "fury-adapter-swagger": "0.28.1",
+    "fury-adapter-swagger": "0.28.2",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,10 +3117,10 @@ fury-adapter-oas3-parser@0.10.1:
     ramda "0.26.1"
     yaml-js "^0.2.3"
 
-fury-adapter-swagger@0.28.1:
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/fury-adapter-swagger/-/fury-adapter-swagger-0.28.1.tgz#0cfe53d0a469103e9f2c05ee7ddc38d6b315d803"
-  integrity sha512-jc9NnpqjN6d5N8a63Snxjj4GUTblGyCu0K+CIA3HDx3YxhWpgAH9BMLlJprYVA9/Ix+gX9DAjlVK6zM4oYrRgA==
+fury-adapter-swagger@0.28.2:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/fury-adapter-swagger/-/fury-adapter-swagger-0.28.2.tgz#78cbbac000adecb3d12dccd1bcb06d3587982ca4"
+  integrity sha512-qe9MzfDK1AP/9DEbhUeC9b4mDGKAS0NGnJfLN+2Rb/iqrTvmhQO2QjGmJxCYrI1wlnS8kHJLnovqBLiILkN8uA==
   dependencies:
     content-type "^1.0.4"
     js-yaml "^3.12.0"


### PR DESCRIPTION
#### :rocket: Why this change?

- To keep dependencies up-to-date

#### :memo: Related issues and Pull Requests

- No related task, governance

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
