### PR TITLE
Release dredd 13.1.1

### DIFF
--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd-transactions",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from an API description document",
   "main": "index.js",
   "engines": {

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "HTTP API Testing Framework",
   "main": "build/index.js",
   "bin": {
@@ -38,7 +38,7 @@
     "chai": "4.2.0",
     "clone": "2.1.2",
     "cross-spawn": "7.0.2",
-    "dredd-transactions": "^9.2.0",
+    "dredd-transactions": "^9.2.1",
     "gavel": "^9.1.1",
     "glob": "7.1.6",
     "html": "1.0.0",


### PR DESCRIPTION
The main changes for this release are to update fury-adapter-oas3-parser which incorporates changes to support the explode modifier in OpenAPI 3 query parameters.

This should solve https://github.com/apiaryio/dredd/issues/1737. 