### PR TITLE
Update apielements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ documentation.
 
 - [API Blueprint][]
 - [OpenAPI 2][] (formerly known as Swagger)
-- [OpenAPI 3][] ([experimental](https://github.com/apiaryio/api-elements.js/blob/master/packages/fury-adapter-oas3-parser/STATUS.md), contributions welcome!)
+- [OpenAPI 3][] ([experimental](https://github.com/apiaryio/api-elements.js/blob/master/packages/openapi-parser/STATUS.md), contributions welcome!)
 
 ### Supported Hooks Languages
 

--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -175,7 +175,7 @@ OpenAPI 2
 
 The effective request body is inferred from ``"in": "body"`` and ``"in": "formData"`` parameters (:openapi2:`parameterobject`).
 
-If body parameter has ``schema.example`` (:openapi2:`schemaexample`), it is used as a raw JSON sample for the request body. If it’s not present, Dredd’s `OpenAPI 2 adapter <https://github.com/apiaryio/fury-adapter-swagger/>`__ generates sample values from the JSON Schema provided in the ``schema`` (:openapi2:`parameterschema`) property. Following rules apply when the adapter fills values of the properties, ordered by precedence:
+If body parameter has ``schema.example`` (:openapi2:`schemaexample`), it is used as a raw JSON sample for the request body. If it’s not present, Dredd’s `OpenAPI 2 adapter <https://github.com/apiaryio/api-elements.js/tree/master/packages/openapi2-parser>`__ generates sample values from the JSON Schema provided in the ``schema`` (:openapi2:`parameterschema`) property. Following rules apply when the adapter fills values of the properties, ordered by precedence:
 
 1. Value of ``default``.
 2. First value from ``enum``.

--- a/docs/how-to-guides.rst
+++ b/docs/how-to-guides.rst
@@ -592,7 +592,7 @@ OpenAPI 2
   :language: openapi2
 
 .. note::
-   Do not use the explicit ``binary`` or ``bytes`` formats with response bodies, as Dredd is not able to properly work with those (:ghissue:`fury-adapter-swagger#193`).
+   Do not use the explicit ``binary`` or ``bytes`` formats with response bodies, as Dredd is not able to properly work with those (:ghissue:`api-elements.js#269`).
 
 Hooks
 ~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Supported API Description Formats
 
 -  `API Blueprint`_
 -  `OpenAPI 2`_ (formerly known as Swagger)
--  `OpenAPI 3`_ (`experimental <https://github.com/apiaryio/api-elements.js/blob/master/packages/fury-adapter-oas3-parser/STATUS.md>`__, contributions welcome!)
+-  `OpenAPI 3`_ (`experimental <https://github.com/apiaryio/api-elements.js/blob/master/packages/openapi3-parser/STATUS.md>`__, contributions welcome!)
 
 Supported Hooks Languages
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -27,9 +27,9 @@
   ],
   "dependencies": {
     "@apielements/apib-parser": "0.19.0",
+    "@apielements/openapi2-parser": "0.30.0",
     "@apielements/openapi3-parser": "0.12.0",
     "fury": "3.0.0-beta.14",
-    "fury-adapter-swagger": "0.29.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -26,14 +26,14 @@
     "README.md"
   ],
   "dependencies": {
+    "@apielements/apib-parser": "0.19.0",
     "fury": "3.0.0-beta.14",
-    "fury-adapter-apib-parser": "0.18.1",
     "fury-adapter-oas3-parser": "0.11.1",
     "fury-adapter-swagger": "0.29.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [
-    "fury-adapter-apib-parser"
+    "@apielements/apib-parser"
   ],
   "devDependencies": {
     "chai": "4.2.0",

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -27,8 +27,8 @@
   ],
   "dependencies": {
     "@apielements/apib-parser": "0.19.0",
+    "@apielements/openapi3-parser": "0.12.0",
     "fury": "3.0.0-beta.14",
-    "fury-adapter-oas3-parser": "0.11.1",
     "fury-adapter-swagger": "0.29.0",
     "uri-template": "1.0.1"
   },

--- a/packages/dredd-transactions/parse/index.js
+++ b/packages/dredd-transactions/parse/index.js
@@ -3,7 +3,7 @@ const fury = require('fury');
 
 fury.use(require('@apielements/apib-parser'));
 fury.use(require('fury-adapter-swagger'));
-fury.use(require('fury-adapter-oas3-parser'));
+fury.use(require('@apielements/openapi3-parser'));
 
 const { Annotation, SourceMap, ParseResult } = fury.minim.elements;
 

--- a/packages/dredd-transactions/parse/index.js
+++ b/packages/dredd-transactions/parse/index.js
@@ -2,7 +2,7 @@ const fury = require('fury');
 
 
 fury.use(require('@apielements/apib-parser'));
-fury.use(require('fury-adapter-swagger'));
+fury.use(require('@apielements/openapi2-parser'));
 fury.use(require('@apielements/openapi3-parser'));
 
 const { Annotation, SourceMap, ParseResult } = fury.minim.elements;

--- a/packages/dredd-transactions/parse/index.js
+++ b/packages/dredd-transactions/parse/index.js
@@ -1,7 +1,7 @@
 const fury = require('fury');
 
 
-fury.use(require('fury-adapter-apib-parser'));
+fury.use(require('@apielements/apib-parser'));
 fury.use(require('fury-adapter-swagger'));
 fury.use(require('fury-adapter-oas3-parser'));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,20 @@
   optionalDependencies:
     protagonist "^2.1.0"
 
+"@apielements/openapi2-parser@0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@apielements/openapi2-parser/-/openapi2-parser-0.30.0.tgz#ff5d820fa90fec17c5ec726b7be4e33aeeb5fdf9"
+  integrity sha512-yXPdgTUiIhC8Gg3Q4rDfuFs8i4WD139Tn8qFIWocHSbKHLZ36VNox15lWZKGUMKZ67u6cXTtKHyS4cwHILFflQ==
+  dependencies:
+    content-type "^1.0.4"
+    js-yaml "^3.12.0"
+    json-schema-faker "0.5.0-rc23"
+    lodash "^4.17.0"
+    media-typer "^1.0.1"
+    swagger-parser "^8.0.0"
+    yaml-js "^0.2.3"
+    z-schema "^4.1.0"
+
 "@apielements/openapi3-parser@0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.12.0.tgz#6e1607b42648b6e102753f8f52d62c7f141eaaa5"
@@ -3222,20 +3236,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-fury-adapter-swagger@0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/fury-adapter-swagger/-/fury-adapter-swagger-0.29.0.tgz#36f486c9579a302058806e1641c83593653c8926"
-  integrity sha512-ssbYmqSBgx3VOc6lOpf9xr4ZwsFOdbVAF26XVuezlzo3nXInSGf3PGQ7tmRfVfk5MAZmeGvTc+Fzys9U+ouJ5A==
-  dependencies:
-    content-type "^1.0.4"
-    js-yaml "^3.12.0"
-    json-schema-faker "0.5.0-rc23"
-    lodash "^4.17.0"
-    media-typer "^1.0.1"
-    swagger-parser "^8.0.0"
-    yaml-js "^0.2.3"
-    z-schema "^4.1.0"
 
 fury@3.0.0-beta.14:
   version "3.0.0-beta.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@apielements/apib-parser@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@apielements/apib-parser/-/apib-parser-0.19.0.tgz#c22baf760f14afa9bc6547066170af4f1d72a5ac"
+  integrity sha512-1GA00KxzCSWFeaw2D+i9Zz/e4Jck67XyZAnv8y18F0o8ZANrGhukJSRggjmrGSxLcrbeqe/4CKhf/PQOC14NZA==
+  dependencies:
+    deckardcain "^1.0.0"
+    drafter.js "^3.2.0"
+  optionalDependencies:
+    protagonist "^2.1.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -3202,16 +3212,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-fury-adapter-apib-parser@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/fury-adapter-apib-parser/-/fury-adapter-apib-parser-0.18.1.tgz#23d1842c184b84ee9e238fce6d8ec902cde58a5c"
-  integrity sha512-wKFnUgVJ5/mGNs8rCCu1cVVhfZl1nvgKBwj4z/JXTW6PQuwI8Rp+bn5CGWAyJCXwrElIsfrACnHaJFnHPh0nnQ==
-  dependencies:
-    deckardcain "^1.0.0"
-    drafter.js "^3.2.0"
-  optionalDependencies:
-    protagonist "^2.1.0"
 
 fury-adapter-oas3-parser@0.11.1:
   version "0.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,16 @@
   optionalDependencies:
     protagonist "^2.1.0"
 
+"@apielements/openapi3-parser@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.12.0.tgz#6e1607b42648b6e102753f8f52d62c7f141eaaa5"
+  integrity sha512-zFMfKnSuUNjokIfiEPJHCpneuEiE5fgef5d+bKapivUo0/fh2i8oqAda93GpEHWXXVtxCQOrmalwyEiBxJuF5w==
+  dependencies:
+    content-type "^1.0.4"
+    media-typer "^1.0.1"
+    ramda "0.27.0"
+    yaml-js "^0.2.3"
+
 "@babel/code-frame@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -3212,16 +3222,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-fury-adapter-oas3-parser@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/fury-adapter-oas3-parser/-/fury-adapter-oas3-parser-0.11.1.tgz#18be4a673e6a3ab3544cf0529baa1ca44f8ee320"
-  integrity sha512-UqacuC1B4EIr5UNfPDyf88aczNtISZqQXt2ytUtSC07gKdQoqzJUqvjCgFKzSVN0V5Fq1u5OiKNglJiIqfZt4A==
-  dependencies:
-    content-type "^1.0.4"
-    media-typer "^1.0.1"
-    ramda "0.27.0"
-    yaml-js "^0.2.3"
 
 fury-adapter-swagger@0.29.0:
   version "0.29.0"


### PR DESCRIPTION
API Elements (Fury) is undergoing package renaming. This PR is a first step is updating some of the packages by updating all of the adapters that have been renamed. Fury (core) is to be renamed still.

The biggest changes are to the prepack script, because the "npm pack" process tries to bundle the apib-parser inside the Dredd package. This logic needed to be updated to count for when a bundled dependency contains name a slash in it, because it is now `@apielements/apib-parser`. In this case, I needed to add logic to create the basepath (`@apielements`) if it is not created. The logic for adding a symbolic link to the original source in the project wide workspace needed to compute the correct location of it, instead of assuming `../../../node_modules`.

For more details on the package rename, see https://github.com/apiaryio/api-elements.js/issues/32