### PR TITLE
Update OpenAPI 2/3 parsers and release

### DIFF
--- a/packages/dredd-transactions/compile/index.js
+++ b/packages/dredd-transactions/compile/index.js
@@ -46,7 +46,7 @@ function findRelevantTransactions(mediaType, apiElements) {
 
 function compileHeaders(httpHeadersElement) {
   if (!httpHeadersElement) { return []; }
-  return httpHeadersElement.toValue().map(({ key, value }) => ({ name: key, value }));
+  return httpHeadersElement.toValue().map(({ key, value }) => ({ name: key, value: value || '' }));
 }
 
 function compileOriginExampleName(mediaType, httpResponseElement, exampleNo) {

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -29,7 +29,7 @@
     "@apielements/apib-parser": "0.20.0",
     "@apielements/core": "^0.1.0",
     "@apielements/openapi2-parser": "0.32.1",
-    "@apielements/openapi3-parser": "0.13.0",
+    "@apielements/openapi3-parser": "0.13.1",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@apielements/apib-parser": "0.20.0",
     "@apielements/core": "^0.1.0",
-    "@apielements/openapi2-parser": "0.32.0",
+    "@apielements/openapi2-parser": "0.32.1",
     "@apielements/openapi3-parser": "0.13.0",
     "uri-template": "1.0.1"
   },

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -29,7 +29,7 @@
     "@apielements/apib-parser": "0.20.0",
     "@apielements/core": "^0.1.0",
     "@apielements/openapi2-parser": "0.32.1",
-    "@apielements/openapi3-parser": "0.13.1",
+    "@apielements/openapi3-parser": "0.14.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [

--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd-transactions",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from an API description document",
   "main": "index.js",
   "engines": {

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "HTTP API Testing Framework",
   "main": "build/index.js",
   "bin": {
@@ -38,7 +38,7 @@
     "chai": "4.2.0",
     "clone": "2.1.2",
     "cross-spawn": "7.0.2",
-    "dredd-transactions": "^9.2.1",
+    "dredd-transactions": "^9.2.2",
     "gavel": "^9.1.1",
     "glob": "7.1.6",
     "html": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     yaml-js "^0.2.3"
     z-schema "^4.1.0"
 
-"@apielements/openapi3-parser@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.13.1.tgz#63b95ce6382adfb767f8fd50d6d01d79bf3db260"
-  integrity sha512-hmlggYXmtt26VnvM2yIF02+otyejquDTWZJ4TMPw3vK9dcADpfV/00ryU0tYZGE1kpOnCxFfjmVDhKCicDDg0Q==
+"@apielements/openapi3-parser@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.14.0.tgz#65eab2be2db769870ad9317994ad377134f54f07"
+  integrity sha512-ujaVwxj+FdiwYB2YV2MeAraC7nx/qPH08ziRHUKL0uXJCw1CAHnWfv5S67k1ZKkhE1JACrrq/7QLT8nMzDRQaw==
   dependencies:
     content-type "^1.0.4"
     media-typer "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
     yaml-js "^0.2.3"
     z-schema "^4.1.0"
 
-"@apielements/openapi3-parser@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.13.0.tgz#63c600d0a22470c0d06d8c4ed434187fc0ca048f"
-  integrity sha512-X94ybR9Psqu1+Xlo0gbLJxUTk9AOccbFdI2UOlN0379cFq91J63Gjfvlh47i566Els7IeIjk8cdaTCU4DHbR6Q==
+"@apielements/openapi3-parser@0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@apielements/openapi3-parser/-/openapi3-parser-0.13.1.tgz#63b95ce6382adfb767f8fd50d6d01d79bf3db260"
+  integrity sha512-hmlggYXmtt26VnvM2yIF02+otyejquDTWZJ4TMPw3vK9dcADpfV/00ryU0tYZGE1kpOnCxFfjmVDhKCicDDg0Q==
   dependencies:
     content-type "^1.0.4"
     media-typer "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
   dependencies:
     api-elements "^0.2.4"
 
-"@apielements/openapi2-parser@0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@apielements/openapi2-parser/-/openapi2-parser-0.32.0.tgz#82e1d4100df67a6adcd07b481bb6c3ca8c5e1734"
-  integrity sha512-+/d5/kd6jS0WCk8qhIgEwGF2MldAfYfW30UaAayeFh5zf0kxs039TDXgqP5o9SOA1X959+7OWS+VpAwl1UXUpA==
+"@apielements/openapi2-parser@0.32.1":
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/@apielements/openapi2-parser/-/openapi2-parser-0.32.1.tgz#9934cebdc32ec9acddbe71ba1cea5e4e822ac204"
+  integrity sha512-nm/i6rTZp6d0+l3Uyvzb2jdbmoDex59QYUBDCWVdbwwT3/dbHtFvpKzuGpfb3yJ3HEUHIZ5bXWztOsnH37jwAw==
   dependencies:
     content-type "^1.0.4"
     js-yaml "^3.12.0"


### PR DESCRIPTION
#### :rocket: Why this change?

This brings fixes for the OpenAPI 2 and 3 parsers, namely a fix for https://github.com/apiaryio/dredd/issues/1686