### PR TITLE
feat: Adding the ability to output the decoded body, when specifying …

### DIFF
--- a/packages/dredd/lib/prettifyResponse.js
+++ b/packages/dredd/lib/prettifyResponse.js
@@ -17,7 +17,14 @@ export default function prettifyResponse(response) {
     return obj;
   }
 
-  function prettifyBody(body, contentKind) {
+  function prettifyBody(body, contentKind, bodyEncoding) {
+    switch (bodyEncoding) {
+      case 'base64':
+        body = Buffer.from(body, 'base64').toString()
+        break;
+      default:
+    }
+
     switch (contentKind) {
       case 'text/html':
         body = html.prettyPrint(body, { indent_size: 2 });
@@ -30,14 +37,14 @@ export default function prettifyResponse(response) {
 
   if (response && response.headers) {
     contentType =
-      response.headers['content-type'] || response.headers['Content-Type'];
+        response.headers['content-type'] || response.headers['Content-Type'];
   }
 
   let stringRepresentation = '';
   for (const key of Object.keys(response || {})) {
     let value = response[key];
     if (key === 'body') {
-      value = `\n${prettifyBody(value, contentType)}`;
+      value = `\n${prettifyBody(value, contentType, response.bodyEncoding)}`;
     } else if (key === 'schema') {
       value = `\n${stringify(value)}`;
     } else if (key === 'headers') {

--- a/packages/dredd/test/unit/prettifyResponse-test.js
+++ b/packages/dredd/test/unit/prettifyResponse-test.js
@@ -29,7 +29,7 @@ body: \n{
           'content-type': 'text/html',
         },
         body:
-          '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>',
+            '<div>before paragraph <p>in para <i>italics</i><br /><b>bold</b> afterwords</p></div>',
       });
 
       const expectedOutput = `\
@@ -65,9 +65,58 @@ body: \n<div>before paragraph
       assert.isArray(loggerStub.debug.firstCall.args);
       assert.lengthOf(loggerStub.debug.firstCall.args, 1);
       assert.equal(
-        loggerStub.debug.firstCall.args[0],
-        'Could not stringify: [object Object]',
+          loggerStub.debug.firstCall.args[0],
+          'Could not stringify: [object Object]',
       );
     });
   });
+
+  describe('with base64 body encoding', () => {
+    it("should've printed into debug with decode", () => {
+      const body = Buffer.from(JSON.stringify({a: 'b'})).toString('base64');
+
+      const output = prettifyResponse({
+        headers: {
+          'content-type': 'application/json',
+        },
+        bodyEncoding: 'base64',
+        body,
+      });
+
+      const expectedOutput = `\
+headers: \n    content-type: application/json\n
+bodyEncoding: base64
+body: \n{
+  "a": "b"
+}\n\
+`;
+      assert.equal(
+          output,
+          expectedOutput,
+      );
+    });
+  });
+
+  describe('without base64 body encoding', () => {
+    it("should've printed into debug without decode", () => {
+      const body = Buffer.from(JSON.stringify({a: 'b'})).toString('base64');
+
+      const output = prettifyResponse({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body,
+      });
+
+      const expectedOutput = `\
+headers: \n    content-type: application/json\n
+body: 
+eyJhIjoiYiJ9\n\
+`;
+      assert.equal(
+          output,
+          expectedOutput,
+      );
+    });
+  })
 });


### PR DESCRIPTION
…the bodyEncoding property of the transaction


#### :rocket: At the moment, if specify bodyEncoding=base64, the encoded body will be output to the console, which makes it difficult to debug and understand what was actually sent to the server.

- [ ] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
