### PR TITLE
docs(installation): fix link to npmjs' https-proxy config

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -89,7 +89,7 @@ Installing Node.js and npm
       - Node.js needs to be at least version 8
 
 .. note::
-   If your internet connection is restricted (VPN, firewall, proxy), you need to `configure npm <https://docs.npmjs.com/misc/config#https-proxy>`__:
+   If your internet connection is restricted (VPN, firewall, proxy), you need to `configure npm <https://docs.npmjs.com/cli/v6/using-npm/config#https-proxy>`__:
 
    .. code-block:: text
 


### PR DESCRIPTION
#### :rocket: Why this change?

Fixes failing quality checks because of documentation link of npmjs configuration was changed.

#### :memo: Related issues and Pull Requests

`tests` automation will be unblocked in almost all PRs thanks to this little change.

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
