### PR TITLE
chore: bump dredd version to 13.2.0

### DIFF
--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "13.1.2",
+  "version": "13.2.0",
   "description": "HTTP API Testing Framework",
   "main": "build/index.js",
   "bin": {


### PR DESCRIPTION
#### :rocket: Why this change?

- updated request 2.88.0 to 2.88.2
- updated node-fetch 2.6.0 to 2.6.1
- updated @types/ramda 0.27.4 to 0.27.32
- updated js-yaml 3.13.1 to 3.14.0.