### PR TITLE
chore: bump dredd version to 14.0.0

### DIFF
--- a/packages/dredd-transactions/package.json
+++ b/packages/dredd-transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd-transactions",
-  "version": "9.2.2",
+  "version": "10.0.0",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from an API description document",
   "main": "index.js",
   "engines": {

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd",
-  "version": "13.2.0",
+  "version": "14.0.0",
   "description": "HTTP API Testing Framework",
   "main": "build/index.js",
   "bin": {
@@ -38,7 +38,7 @@
     "chai": "4.2.0",
     "clone": "2.1.2",
     "cross-spawn": "7.0.2",
-    "dredd-transactions": "^9.2.2",
+    "dredd-transactions": "^10.0.0",
     "gavel": "^9.1.1",
     "glob": "7.1.6",
     "html": "1.0.0",


### PR DESCRIPTION
- Removes NodeJS@8 support (EOL).
- Updates dependencies (incl. security issues fixes). 