### PR TITLE
Support skipping non-200 responses with OpenAPI3

### DIFF
--- a/packages/dredd/lib/TransactionRunner.js
+++ b/packages/dredd/lib/TransactionRunner.js
@@ -347,6 +347,7 @@ class TransactionRunner {
     if (
       transaction.apiDescription &&
       transaction.apiDescription.mediaType.includes('swagger')
+      || transaction.apiDescription.mediaType.includes('openapi')
     ) {
       const status = parseInt(response.status, 10);
       if (status < 200 || status >= 300) {


### PR DESCRIPTION
#### :rocket: Why this change?

When running OAS3 specs with non-200 response codes, they incorrectly fail. Here's a start on a PR.

#### :memo: Related issues and Pull Requests

https://github.com/apiaryio/dredd/issues/1257

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [ ] To write docs
- [ ] To write tests
- [ ] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
