### PR TITLE
docs: fix broken link: hall-of-fame

### DIFF
--- a/docs/hooks/new-language.rst
+++ b/docs/hooks/new-language.rst
@@ -8,7 +8,7 @@ Dredd itself is written in JavaScript, so having :ref:`hooks in JavaScript <hook
 Several hooks handlers :ref:`already exist <supported-languages>`, either maintained by Dredd authors or external contributors. If you didn't find your favorite language among them, at this place you can learn how to create a new hooks handler.
 
 .. note::
-   `Deserve eternal praise <hall-of-fame>`__ and contribute hooks handler for **Java**! See :ghissue:`#875`
+   :ref:`Deserve eternal praise <hall-of-fame>` and contribute hooks handler for **Java**! See :ghissue:`#875`
 
 
 What is a hooks handler?


### PR DESCRIPTION
#### :rocket: Why this change?

```
Warning, treated as error:
/Users/abtris/Sites/apiaryio/dredd/docs/hooks/new-language.rst.rst:11:broken link: hall-of-fame ()
error Command failed with exit code 2.
```

#### :memo: Related issues and Pull Requests

#1883

#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
