### PR TITLE
fix(deps): update uuid deprecated

### DIFF
--- a/packages/dredd/lib/HooksWorkerClient.js
+++ b/packages/dredd/lib/HooksWorkerClient.js
@@ -1,4 +1,4 @@
-import generateUuid from 'uuid/v4';
+import { v4 as generateUuid } from 'uuid';
 import net from 'net';
 import path from 'path';
 import spawnArgs from 'spawn-args';

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -1,5 +1,5 @@
 import clone from 'clone';
-import generateUuid from 'uuid/v4';
+import { v4 as generateUuid } from 'uuid';
 import os from 'os';
 import request from 'request';
 


### PR DESCRIPTION
when i run `dredd` command , my terminal show 


```
(node:11604) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.
```

this PR just update uuid deprecated