### PR TITLE
docs: improve contributing steps with formatting clean up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ We are grateful for any contributions made by the community. Even seemingly smal
 - 📖 [Improving documentation](#improving-documentation)
 - 🛠 [Proposing changes to code](#proposing-changes-to-code)
 
-
 <a name="reporting-bugs"></a>
 
 ## 🐛 Reporting bugs
@@ -15,7 +14,6 @@ We are grateful for any contributions made by the community. Even seemingly smal
 Before reporting a bug, please try to first [search existing GitHub issues](https://github.com/apiaryio/dredd/issues?utf8=%E2%9C%93&q=is%3Aissue) to see whether your problem wasn't already discussed.
 
 To report a bug, [open a new GitHub issue](https://github.com/apiaryio/dredd/issues/new). To report privately, e.g. to alert the maintainers about a security problem, please [contact Apiary Support](https://apiary.io/support).
-
 
 <a name="asking-questions"></a>
 
@@ -29,7 +27,6 @@ You can always [contact Apiary Support](https://apiary.io/support), but we prefe
 - [Ask on StackOverflow](https://stackoverflow.com/questions/ask) with the [dredd tag](https://stackoverflow.com/questions/tagged/dredd)
 
 Also, we consider unclear or missing documentation to be a bug, so often your question can start a valuable improvement.
-
 
 <a name="improving-documentation"></a>
 
@@ -47,10 +44,10 @@ docs: add more OpenAPI examples
 
 You can learn more about Dredd's codebase in the [Internals](https://dredd.org/en/latest/internals.html) section of the documentation.
 
-
 <a name="proposing-changes-to-code"></a>
 
 ## 🛠 Proposing changes to code
+
 ### Before you start
 
 - Have [Node.js](https://nodejs.org/) installed
@@ -59,8 +56,10 @@ You can learn more about Dredd's codebase in the [Internals](https://dredd.org/e
 - Look at [easy to fix issues](https://github.com/apiaryio/dredd/labels/easy%20to%20fix)
 
 ### Improving Dredd
+
 1. [Fork and clone Dredd](https://guides.github.com/activities/forking/)
-1. Run `npm install`
+1. Run `yarn install`
+1. Build Dredd with `npm run build`
 1. [Write your code and tests](https://dredd.org/en/latest/internals.html#programming-language)
+1. Check your changes with `npm run lint && npm run test`
 1. Use the [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) format for the commit message
-1. Check your changes with `npm run lint`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![Dredd - HTTP API Testing Framework](docs/_static/images/dredd.png?raw=true)
 
 > **Dredd is a language-agnostic command-line tool for validating
-API description document against backend implementation of the API.**
+> API description document against backend implementation of the API.**
 
 - [Documentation][]
 - [Changelog][]
@@ -53,54 +53,51 @@ $ npm install -g dredd
 ## Quick Start
 
 1.  Create an [API Blueprint][] file called `api-description.apib`.
-    Follow [tutorial at API Blueprint website][API Blueprint tutorial]
-    or just take one of the [ready-made examples][API Blueprint examples].
+    Follow [tutorial at API Blueprint website][api blueprint tutorial]
+    or just take one of the [ready-made examples][api blueprint examples].
 2.  Run interactive configuration:
 
     ```shell
     $ dredd init
     ```
+
 3.  Run Dredd:
 
     ```shell
     $ dredd
     ```
-4.  To see how to use all Dredd's features, browse the
-    [full documentation][Documentation].
 
+4.  To see how to use all Dredd's features, browse the
+    [full documentation][documentation].
 
 ## Howtos, Tutorials, Blogposts (3rd party)
 
-- [Maintenir à jour sa documentation d'API avec Dredd!](https://blog.itnetwork.fr/blog-post/2019/05/06/dredd-partie-1-ecriture-documentation.html) *05/06/2019*
-- [Dredd - Language-agnostic HTTP API Testing Tool - Interview with Honza Javorek](https://survivejs.com/blog/dredd-interview/) *03/22/2019*
-- [Laravel OpenAPI 3 Documentation Verification Using Dredd](https://commandz.io/snippets/laravel/laravel-dredd-openapi-v3/) *02/24/2019*
-- [Testing your API with Dredd](https://medium.com/mop-developers/testing-your-api-with-dredd-c02e6ca151f2) *09/27/2018*
-- [Writing Testable API Documentation Using APIB and Dredd (Rails)](https://blog.rebased.pl/2018/06/29/testable-api-docs.html) *06/29/2018*
-- [Design-first API Specification Workflow Matures](https://philsturgeon.uk/api/2018/03/01/api-specification-workflow-matures/) *03/01/2018*
-- [Writing and testing API specifications with API Blueprint, Dredd and Apiary](https://hackernoon.com/writing-and-testing-api-specifications-with-api-blueprint-dreed-and-apiary-df138accce5a) *12/04/2017*
-- [Testing an API Against its Documentation](https://dev.to/albertofdzm/testing-an-api-against-documentation-6cl) *11/23/2017*
-- [Keeping Documentation Honest](https://blog.apisyouwonthate.com/keeping-documentation-honest-d9ab5351ddd4) *11/21/2017*
-- [Apiary designed APIs tested using Dredd](https://redthunder.blog/2017/09/20/apiary-designed-apis-tested-using-dredd/) *09/20/2017*
-- [Dredd + Swagger for REST API testing](https://codeburst.io/dredd-swagger-for-rest-api-testing-715d1af5e8c5) *01/24/2017*
-- [Testing Your API Documentation With Dredd](https://matthewdaly.co.uk/blog/2016/08/08/testing-your-api-documentation-with-dredd/) *08/08/2016*
-- [DREDD API Tester works with API Blueprints](http://www.finklabs.org/articles/api-blueprint-dredd.html) *07/05/2016*
-- [Documentation driven API Development using Laravel, Dredd and Apiary](https://medium.com/frianbiz/api-php-pilot%C3%A9e-par-la-doc-3c9eb4daa2aa) *06/21/2016*
-- [Dredd v1.1.0: A Bit Different](https://philsturgeon.uk/api/2016/06/20/dredd-v1-1-0-a-bit-different/) *06/20/2016*
-- [Dredd: Do Your HTTP API Justice](https://philsturgeon.uk/api/2015/01/28/dredd-api-testing-documentation/) *01/28/2015*
+- [Maintenir à jour sa documentation d'API avec Dredd!](https://blog.itnetwork.fr/blog-post/2019/05/06/dredd-partie-1-ecriture-documentation.html) _05/06/2019_
+- [Dredd - Language-agnostic HTTP API Testing Tool - Interview with Honza Javorek](https://survivejs.com/blog/dredd-interview/) _03/22/2019_
+- [Laravel OpenAPI 3 Documentation Verification Using Dredd](https://commandz.io/snippets/laravel/laravel-dredd-openapi-v3/) _02/24/2019_
+- [Testing your API with Dredd](https://medium.com/mop-developers/testing-your-api-with-dredd-c02e6ca151f2) _09/27/2018_
+- [Writing Testable API Documentation Using APIB and Dredd (Rails)](https://blog.rebased.pl/2018/06/29/testable-api-docs.html) _06/29/2018_
+- [Design-first API Specification Workflow Matures](https://philsturgeon.uk/api/2018/03/01/api-specification-workflow-matures/) _03/01/2018_
+- [Writing and testing API specifications with API Blueprint, Dredd and Apiary](https://hackernoon.com/writing-and-testing-api-specifications-with-api-blueprint-dreed-and-apiary-df138accce5a) _12/04/2017_
+- [Testing an API Against its Documentation](https://dev.to/albertofdzm/testing-an-api-against-documentation-6cl) _11/23/2017_
+- [Keeping Documentation Honest](https://blog.apisyouwonthate.com/keeping-documentation-honest-d9ab5351ddd4) _11/21/2017_
+- [Apiary designed APIs tested using Dredd](https://redthunder.blog/2017/09/20/apiary-designed-apis-tested-using-dredd/) _09/20/2017_
+- [Dredd + Swagger for REST API testing](https://codeburst.io/dredd-swagger-for-rest-api-testing-715d1af5e8c5) _01/24/2017_
+- [Testing Your API Documentation With Dredd](https://matthewdaly.co.uk/blog/2016/08/08/testing-your-api-documentation-with-dredd/) _08/08/2016_
+- [DREDD API Tester works with API Blueprints](http://www.finklabs.org/articles/api-blueprint-dredd.html) _07/05/2016_
+- [Documentation driven API Development using Laravel, Dredd and Apiary](https://medium.com/frianbiz/api-php-pilot%C3%A9e-par-la-doc-3c9eb4daa2aa) _06/21/2016_
+- [Dredd v1.1.0: A Bit Different](https://philsturgeon.uk/api/2016/06/20/dredd-v1-1-0-a-bit-different/) _06/20/2016_
+- [Dredd: Do Your HTTP API Justice](https://philsturgeon.uk/api/2015/01/28/dredd-api-testing-documentation/) _01/28/2015_
 
-
-
-[API Blueprint]: https://apiblueprint.org/
-[API Blueprint tutorial]: https://apiblueprint.org/documentation/tutorial.html
-[API Blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
-[OpenAPI 2]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
-[OpenAPI 3]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
-
-[Documentation]: https://dredd.org/en/latest/
-[Changelog]: https://github.com/apiaryio/dredd/releases
-[Contributor's Guidelines]: https://dredd.org/en/latest/contributing/
-
-[Travis CI]: https://travis-ci.org/
-[CircleCI]: https://circleci.com/
-[Jenkins]: https://jenkins.io/
-[AppVeyor]: https://www.appveyor.com/
+[api blueprint]: https://apiblueprint.org/
+[api blueprint tutorial]: https://apiblueprint.org/documentation/tutorial.html
+[api blueprint examples]: https://github.com/apiaryio/api-blueprint/tree/master/examples
+[openapi 2]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
+[openapi 3]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
+[documentation]: https://dredd.org/en/latest/
+[changelog]: https://github.com/apiaryio/dredd/releases
+[contributor's guidelines]: https://dredd.org/en/latest/contributing/
+[travis ci]: https://travis-ci.org/
+[circleci]: https://circleci.com/
+[jenkins]: https://jenkins.io/
+[appveyor]: https://www.appveyor.com/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@
 
 ```bash
 $ git checkout -b <user>/dredd-14.0.0
-$ npx lerna version --no-push --no-git-tag-version 
+$ npx lerna version --no-push --no-git-tag-version
 $ git add .
 $ git push -u origin <user>/dredd-14.0.0
 ```

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-module.exports = {  
+module.exports = {
   extends: ['@commitlint/config-conventional'],
   ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\./m.test(message)],
 };


### PR DESCRIPTION
#### :rocket: Why this change?

1. There was room for improvement in the Contributing guide for "Improving Dredd": additional steps to document along with a suggested change in ordering, and
2. local Markdown linting tools also suggested formatting improvements between the Contributing, Readme, and Release docs.

#### :memo: Related issues and Pull Requests

These changes were originally incorporated into PR #1965 for issue #1964.

#### :white_check_mark: What didn't I forget?

No unit tests added or modified as part of this change - documentation amendments only.

- [X] To write docs
- [X] To write tests
- [X] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
