### PR TITLE
chore(test): fix for too long messages with links

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
 };


### PR DESCRIPTION
#### :rocket: Why this change?

```
Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
✖   body's lines must not be longer than 100 characters [body-max-line-lengt
```

#### :memo: Related issues and Pull Requests

#1929 

