### PR TITLE
fix: non-approved GH action

### DIFF
--- a/.github/workflows/run-docs-test.yml
+++ b/.github/workflows/run-docs-test.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2 
+      - run: yarn install          
+      - run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
 
   quality-checks:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ import urllib.request
 from sphinx.errors import SphinxError
 from pygments.lexers.data import YamlLexer
 
-
 ###########################################################################
 #                                                                         #
 #    Dredd documentation build configuration file                         #
@@ -150,5 +149,5 @@ def setup(app):
     app.add_css_file('css/dredd.css')
 
     # Adding lexers for rendering OpenAPI code blocks as YAML
-    app.add_lexer('openapi2', OpenAPI2Lexer())
-    app.add_lexer('openapi3', OpenAPI3Lexer())
+    app.add_lexer('openapi2', OpenAPI2Lexer)
+    app.add_lexer('openapi3', OpenAPI3Lexer)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,12 +3,14 @@
 
 
 # dependencies
-sphinx==3.5.4
-jinja2==3.0.1
+sphinx==4.3.0
+jinja2==3.0.3
 git+https://github.com/jhermann/pygments-markdown-lexer.git@e651a9a3f664285b01451eb39232b1ad9af65956#egg=pygments-markdown-lexer
 pygments-apiblueprint==0.2.0
-sphinx-tabs==3.1.0
+sphinx-tabs==3.2.0
+sphinx-panels==0.6.0
+myst-parser==0.15.2
 
 # dev dependencies
 sphinx-autobuild==2021.3.14
-sphinx-rtd-theme==0.5.2
+sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
#### :rocket: Why this change?

```
Error : .github#L1
wagoid/commitlint-github-action@v2 is not allowed to be used in apiaryio/dredd. Actions in this workflow must be: within a repository that belongs to your Enterprise account
```

#### :memo: Related issues and Pull Requests

Tests doesn't run.