### PR TITLE
fix: replacing request with axios

### DIFF
--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -1,4 +1,4 @@
-import defaultRequest from 'request';
+import axios from 'axios';
 import caseless from 'caseless';
 
 import defaultLogger from './logger';
@@ -22,7 +22,7 @@ function performRequest(uri, transactionReq, options, callback) {
     [options, callback] = [{}, options];
   }
   const logger = options.logger || defaultLogger;
-  const request = options.request || defaultRequest;
+  const request = options.request || axios;
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.proxy = false;

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -22,7 +22,7 @@ function performRequest(uri, transactionReq, options, callback) {
     [options, callback] = [{}, options];
   }
   const logger = options.logger || defaultLogger;
-  const request = options.request || axios;
+  const request = options.request || axios; // choose whether to use existing request information or use a new axios configuration
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.proxy = false;

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import defaultRequest from 'request';
+import axios from 'axios';
 
 import isURL from './isURL';
 
@@ -22,7 +23,7 @@ function readRemoteFile(uri, options, callback) {
   if (typeof options === 'function') {
     [options, callback] = [{}, options];
   }
-  const request = options.request || defaultRequest;
+  const request = options.request || axios;
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.uri = uri;

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import defaultRequest from 'request';
 import axios from 'axios';
 
 import isURL from './isURL';
@@ -23,7 +22,7 @@ function readRemoteFile(uri, options, callback) {
   if (typeof options === 'function') {
     [options, callback] = [{}, options];
   }
-  const request = options.request || axios;
+  const request = options.request || axios; // choose whether to use existing request information or use a new axios configuration
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.uri = uri;

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -1,7 +1,7 @@
 import clone from 'clone';
 import { v4 as generateUuid } from 'uuid';
 import os from 'os';
-import request from 'request';
+import axios from 'axios';
 
 import logger from '../logger';
 import reporterOutputLogger from './reporterOutputLogger';
@@ -317,7 +317,8 @@ to Apiary API: ${options.method} ${options.uri} \
       'Request details:',
       JSON.stringify({ options, body }, null, 2),
     );
-    return request(options, handleRequest);
+    return axios(options, handleRequest);
+
   } catch (error) {
     this.serverError = true;
     logger.debug('Requesting Apiary API errored:', error);

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -317,7 +317,7 @@ to Apiary API: ${options.method} ${options.uri} \
       'Request details:',
       JSON.stringify({ options, body }, null, 2),
     );
-    return axios(options, handleRequest);
+    return axios(options, handleRequest); // replace request call with axios
 
   } catch (error) {
     this.serverError = true;

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -33,7 +33,8 @@
     "README.md"
   ],
   "dependencies": {
-    "async": "3.2.0",
+    "async": "3.2.4",
+    "axios":"1.3.6",
     "caseless": "0.12.0",
     "chai": "4.3.4",
     "clone": "2.1.2",
@@ -46,11 +47,10 @@
     "inquirer": "7.1.0",
     "js-yaml": "3.14.0",
     "make-dir": "3.1.0",
-    "markdown-it": "12.2.0",
+    "markdown-it": "13.0.1",
     "optimist": "0.6.1",
     "proxyquire": "2.1.3",
-    "ramda": "0.27.0",
-    "request": "2.88.2",
+    "ramda": "0.29.0",
     "spawn-args": "0.2.0",
     "untildify": "4.0.0",
     "uuid": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+async@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 async@~1.0.0:
   version "1.0.0"
@@ -1516,6 +1516,15 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.6.tgz#1ace9a9fb994314b5f6327960918406fa92c6646"
+  integrity sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1976,7 +1985,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2647,10 +2656,10 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 env-paths@^1.0.0:
   version "1.0.0"
@@ -3215,6 +3224,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3229,6 +3243,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4430,10 +4453,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -4679,14 +4702,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.2.0.tgz#091f720fd5db206f80de7a8d1f1a7035fd0d38db"
-  integrity sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==
+markdown-it@13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
   dependencies:
     argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
@@ -5846,6 +5869,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 proxyquire@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
@@ -5941,6 +5969,11 @@ ramda@0.27.0, ramda@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
   integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+
+ramda@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
+  integrity sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==
 
 randexp@^0.5.3:
   version "0.5.3"
@@ -6189,7 +6222,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.88.2, request@^2.87.0:
+request@^2.87.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
#### :rocket: Why this change?
Request has been deprecated since 2020 due to changes within the JavaScript framework. Because Axios is still being maintained, I thought it would be a good fit to replace Request. In addition, snyk found some security violations within the current dependencies so those are updated as well.
#### :memo: Related issues and Pull Requests
#2177 
#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x ] To write docs
- [ x] To write tests
- [ x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
