### PR TITLE
fix: use axios instead of request

### DIFF
--- a/docs/data-structures.rst
+++ b/docs/data-structures.rst
@@ -46,14 +46,14 @@ Transaction object is passed as a first argument to :ref:`hook functions <hooks>
 
 -  expected (object) - the HTTP response Dredd expects to get from the tested server
 
-   -  statusCode: ``200`` (string)
+   -  status: ``200`` (string)
    -  headers (object) - keys are HTTP header names, values are HTTP header contents
    -  body (string)
    -  bodySchema (object) - JSON Schema of the response body
 
 -  real (object) - the HTTP response Dredd gets from the tested server (present only in ``after`` hooks)
 
-   -  statusCode: ``200`` (string)
+   -  status: ``200`` (string)
    -  headers (object) - keys are HTTP header names, values are HTTP header contents
    -  body (string)
    -  bodyEncoding (enum)
@@ -106,7 +106,7 @@ Transaction result equals to the result of the `Gavel <https://github.com/apiary
 -  fields (object)
    -  *uri* - :ref:`gavel-validation-result-field`
    -  *method* - :ref:`gavel-validation-result-field`
-   -  *statusCode* - :ref:`gavel-validation-result-field`
+   -  *status* - :ref:`gavel-validation-result-field`
    -  *headers* - :ref:`gavel-validation-result-field`
    -  *body* - :ref:`gavel-validation-result-field`
 

--- a/packages/dredd-transactions/compile/index.js
+++ b/packages/dredd-transactions/compile/index.js
@@ -57,7 +57,7 @@ function compileOriginExampleName(mediaType, httpResponseElement, exampleNo) {
       exampleName = `Example ${exampleNo}`;
     }
   } else {
-    const statusCode = (httpResponseElement.statusCode ? httpResponseElement.statusCode.toValue() : undefined) || '200';
+    const status = (httpResponseElement.status ? httpResponseElement.status.toValue() : undefined) || '200';
     const headers = compileHeaders(httpResponseElement.headers);
 
     const contentType = headers
@@ -65,7 +65,7 @@ function compileOriginExampleName(mediaType, httpResponseElement, exampleNo) {
       .map(header => header.value)[0];
 
     const segments = [];
-    if (statusCode) { segments.push(statusCode); }
+    if (status) { segments.push(status); }
     if (contentType) { segments.push(contentType); }
     exampleName = segments.join(' > ');
   }
@@ -132,7 +132,7 @@ function compileRequest(httpRequestElement) {
 }
 
 function compileResponse(httpResponseElement) {
-  const status = (httpResponseElement.statusCode ? httpResponseElement.statusCode.toValue() : undefined) || '200';
+  const status = (httpResponseElement.status ? httpResponseElement.status.toValue() : undefined) || '200';
   const headers = compileHeaders(httpResponseElement.headers);
   const response = { status, headers };
 

--- a/packages/dredd-transactions/test/integration/compileAPIB-test.js
+++ b/packages/dredd-transactions/test/integration/compileAPIB-test.js
@@ -59,9 +59,9 @@ describe('compile() · API Blueprint', () => {
     const compileResult = stubbedCompile(mediaType, apiElements);
 
     const expected = [
-      { exampleName: '', requestContentType: 'application/json', responseStatusCode: 200 },
-      { exampleName: 'Example 1', requestContentType: 'application/json', responseStatusCode: 200 },
-      { exampleName: 'Example 2', requestContentType: 'text/plain', responseStatusCode: 415 },
+      { exampleName: '', requestContentType: 'application/json', responsestatus: 200 },
+      { exampleName: 'Example 1', requestContentType: 'application/json', responsestatus: 200 },
+      { exampleName: 'Example 2', requestContentType: 'text/plain', responsestatus: 415 },
     ];
 
     it('calls the detection of transaction examples', () => {
@@ -73,7 +73,7 @@ describe('compile() · API Blueprint', () => {
       }));
     });
     Array.from(expected).map((expectations, i) => context(`transaction #${i + 1}`, () => {
-      const { exampleName, requestContentType, responseStatusCode } = expectations;
+      const { exampleName, requestContentType, responsestatus } = expectations;
 
       it(`is identified as part of ${JSON.stringify(exampleName)}`, () => {
         assert.equal(
@@ -88,10 +88,10 @@ describe('compile() · API Blueprint', () => {
           .map(header => header.value)[0];
         assert.equal(contentType, requestContentType);
       });
-      it(`has response with status code ${responseStatusCode}`, () => {
+      it(`has response with status code ${responsestatus}`, () => {
         assert.equal(
           compileResult.transactions[i].response.status,
-          responseStatusCode
+          responsestatus
         );
       });
     }));

--- a/packages/dredd-transactions/test/integration/compileOpenAPI2-test.js
+++ b/packages/dredd-transactions/test/integration/compileOpenAPI2-test.js
@@ -141,15 +141,15 @@ describe('compile() · OpenAPI 2', () => {
     const { mediaType, apiElements } = fixtures('multiple-responses').openapi2;
     const compileResult = stubbedCompile(mediaType, apiElements, filename);
 
-    const expectedStatusCodes = [200, 400, 500];
+    const expectedstatuss = [200, 400, 500];
 
     it('does not call the detection of transaction examples', () => {
       assert.isFalse(detectTransactionExampleNumbersStub.called);
     });
 
-    it(`produces ${expectedStatusCodes.length} transactions`, () => {
+    it(`produces ${expectedstatuss.length} transactions`, () => {
       assert.jsonSchema(compileResult, createCompileResultSchema({
-        transactions: expectedStatusCodes.length,
+        transactions: expectedstatuss.length,
       }));
     });
     it('skips non-JSON media types in \'produces\'', () => compileResult.transactions.forEach((transaction) => {
@@ -159,7 +159,7 @@ describe('compile() · OpenAPI 2', () => {
       assert.equal(contentType, 'application/json');
     }));
 
-    Array.from(expectedStatusCodes).map((statusCode, i) => context(`origin of transaction #${i + 1}`, () => {
+    Array.from(expectedstatuss).map((status, i) => context(`origin of transaction #${i + 1}`, () => {
       it('uses URI as resource name', () => {
         assert.equal(compileResult.transactions[i].origin.resourceName, '/honey');
       });
@@ -169,7 +169,7 @@ describe('compile() · OpenAPI 2', () => {
       it('uses status code and response\'s Content-Type as example name', () => {
         assert.equal(
           compileResult.transactions[i].origin.exampleName,
-          `${statusCode} > application/json`
+          `${status} > application/json`
         );
       });
     }));

--- a/packages/dredd/ApiaryReportingApi.apib
+++ b/packages/dredd/ApiaryReportingApi.apib
@@ -323,7 +323,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 
 + valid: true (boolean)
 + fields
-    + *statusCode*
+    + *status*
         + valid: true (boolean)
         + kind: text (enum, nullable)
             + text
@@ -349,7 +349,7 @@ with [Gavel](https://github.com/apiaryio/gavel.js).
 
 ### Actual HTTP Response
 
-+ statusCode: 200 (string)
++ status: 200 (string)
 + headers
     + *content-type*: application/json
 + body: `{\"message\": \"Hello World!\"}`

--- a/packages/dredd/lib/TransactionRunner.js
+++ b/packages/dredd/lib/TransactionRunner.js
@@ -326,7 +326,7 @@ class TransactionRunner {
       expected.body = response.body;
     }
     if (response.status) {
-      expected.statusCode = response.status;
+      expected.status = response.status;
     }
     if (response.schema) {
       expected.bodySchema = response.schema;
@@ -357,7 +357,7 @@ class TransactionRunner {
 
     const configuredTransaction = {
       name: transaction.name,
-      id: `${request.method} (${expected.statusCode}) ${request.uri}`,
+      id: `${request.method} (${expected.status}) ${request.uri}`,
       host: this.parsedUrl.hostname,
       port: this.parsedUrl.port,
       request,
@@ -717,17 +717,17 @@ Not performing HTTP request for '${transaction.name}'.\
 
     // Warn about empty responses
     // Expected is as string, actual is as integer :facepalm:
-    const isExpectedResponseStatusCodeEmpty = ['204', '205'].includes(
-      test.expected.statusCode
-        ? test.expected.statusCode.toString()
+    const isExpectedResponsestatusEmpty = ['204', '205'].includes(
+      test.expected.status
+        ? test.expected.status.toString()
         : undefined,
     );
-    const isActualResponseStatusCodeEmpty = ['204', '205'].includes(
-      test.actual.statusCode ? test.actual.statusCode.toString() : undefined,
+    const isActualResponsestatusEmpty = ['204', '205'].includes(
+      test.actual.status ? test.actual.status.toString() : undefined,
     );
     const hasBody = test.expected.body || test.actual.body;
     if (
-      (isExpectedResponseStatusCodeEmpty || isActualResponseStatusCodeEmpty) &&
+      (isExpectedResponsestatusEmpty || isActualResponsestatusEmpty) &&
       hasBody
     ) {
       logger.warn(`\
@@ -741,7 +741,7 @@ include a message body: https://tools.ietf.org/html/rfc7231#section-6.3\
 
     // Order-sensitive list of Gavel validation fields to output in the log
     // Note that Dredd asserts EXACTLY this order. Make sure to adjust tests upon change.
-    const loggedFields = ['headers', 'body', 'statusCode'].filter((fieldName) =>
+    const loggedFields = ['headers', 'body', 'status'].filter((fieldName) =>
       Object.prototype.hasOwnProperty.call(gavelResult.fields, fieldName),
     );
 

--- a/packages/dredd/lib/general.ts
+++ b/packages/dredd/lib/general.ts
@@ -33,13 +33,13 @@ export interface Transaction {
   fullPath: string;
   request: TransactionRequest;
   expected: {
-    statusCode: number;
+    status: number;
     headers: Record<string, string>;
     body: string;
     bodySchema: Record<string, any>;
   };
   real: {
-    statusCode: string;
+    status: string;
     headers: Record<string, string>;
     body: string;
     bodyEncoding: BodyEncoding;

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -1,4 +1,4 @@
-import defaultRequest from 'request';
+import axios from 'axios';
 import caseless from 'caseless';
 
 import defaultLogger from './logger';
@@ -22,7 +22,7 @@ function performRequest(uri, transactionReq, options, callback) {
     [options, callback] = [{}, options];
   }
   const logger = options.logger || defaultLogger;
-  const request = options.request || defaultRequest;
+  const request = options.request || axios;
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.proxy = false;

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -46,14 +46,13 @@ function performRequest(uri, transactionReq, options, callback) {
       `Performing ${protocol} request to the server under test: ` +
         `${httpOptions.method} ${httpOptions.uri}`,
     );
-
-    request(httpOptions, (error, response, responseBody) => {
+      //Reconfigure function to follow axios formatting
+    request(options).then((response) => {
       logger.debug(`Handling ${protocol} response from the server under test`);
-      if (error) {
-        callback(error);
-      } else {
-        callback(null, createTransactionResponse(response, responseBody));
-      }
+      callback(null, createTransactionResponse(response, response.data));
+
+    }).catch((error) => {
+      callback(error);
     });
   } catch (error) {
     process.nextTick(() => callback(error));

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -28,17 +28,17 @@ function performRequest(uri, transactionReq, options, callback) {
   httpOptions.proxy = false;
   httpOptions.followRedirect = false;
   httpOptions.encoding = null;
-  httpOptions.method = transactionReq.method;
+  httpOptions.method = transactionReq.method.toLowerCase();
   httpOptions.uri = uri;
 
   try {
-    httpOptions.body = getBodyAsBuffer(
+    httpOptions.data = getBodyAsBuffer(
       transactionReq.body,
       transactionReq.bodyEncoding,
     );
     httpOptions.headers = normalizeContentLengthHeader(
       transactionReq.headers,
-      httpOptions.body,
+      httpOptions.data,
     );
 
     const protocol = httpOptions.uri.split(':')[0].toUpperCase();
@@ -135,7 +135,7 @@ export function normalizeContentLengthHeader(headers, body, options = {}) {
  */
 export function createTransactionResponse(response, body) {
   const transactionRes = {
-    statusCode: response.statusCode,
+    statusCode: response.status,
     headers: Object.assign({}, response.headers),
   };
   if (Buffer.byteLength(body || '')) {

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -47,7 +47,7 @@ function performRequest(uri, transactionReq, options, callback) {
         `${httpOptions.method} ${httpOptions.uri}`,
     );
       // Reconfigure function to follow axios formatting
-    request(options).then((response) => {
+    request(httpOptions).then((response) => {
       logger.debug(`Handling ${protocol} response from the server under test`);
       callback(null, createTransactionResponse(response, response.data));
 

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -22,7 +22,7 @@ function performRequest(uri, transactionReq, options, callback) {
     [options, callback] = [{}, options];
   }
   const logger = options.logger || defaultLogger;
-  const request = options.request || axios;
+  const request = options.request || axios; // choose whether to use existing request information or use a new axios configuration
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.proxy = false;

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -44,7 +44,7 @@ function performRequest(uri, transactionReq, options, callback) {
     const protocol = httpOptions.uri.split(':')[0].toUpperCase();
     logger.debug(
       `Performing ${protocol} request to the server under test: ` +
-        `${httpOptions.method} ${httpOptions.uri}`,
+        `${httpOptions.method.toUpperCase()} ${httpOptions.uri}`,
     );
       // Reconfigure function to follow axios formatting
     request(httpOptions).then((response) => {

--- a/packages/dredd/lib/performRequest.js
+++ b/packages/dredd/lib/performRequest.js
@@ -46,7 +46,7 @@ function performRequest(uri, transactionReq, options, callback) {
       `Performing ${protocol} request to the server under test: ` +
         `${httpOptions.method} ${httpOptions.uri}`,
     );
-      //Reconfigure function to follow axios formatting
+      // Reconfigure function to follow axios formatting
     request(options).then((response) => {
       logger.debug(`Handling ${protocol} response from the server under test`);
       callback(null, createTransactionResponse(response, response.data));
@@ -135,7 +135,7 @@ export function normalizeContentLengthHeader(headers, body, options = {}) {
  */
 export function createTransactionResponse(response, body) {
   const transactionRes = {
-    statusCode: response.status,
+    status: response.status,
     headers: Object.assign({}, response.headers),
   };
   if (Buffer.byteLength(body || '')) {

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import defaultRequest from 'request';
+import axios from 'axios';
 
 import isURL from './isURL';
 
@@ -22,7 +23,7 @@ function readRemoteFile(uri, options, callback) {
   if (typeof options === 'function') {
     [options, callback] = [{}, options];
   }
-  const request = options.request || defaultRequest;
+  const request = options.request || axios;
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.uri = uri;

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -29,20 +29,20 @@ function readRemoteFile(uri, options, callback) {
   httpOptions.timeout = 5000; // ms, limits both connection time and server response time
 
   try {
-    request(httpOptions, (error, response, responseBody) => {
-      if (error) {
-        callback(error);
-      } else if (!response) {
+    //Reconfigure request to follow axios formatting
+    request(httpOptions).then((response) => {
+      if(!response){
         callback(new Error('Unexpected error'));
       } else if (
-        !responseBody ||
-        response.statusCode < 200 ||
-        response.statusCode >= 300
-      ) {
-        callback(getErrorFromResponse(response, !!responseBody));
+        !response.data || 
+        response.status < 200 || 
+        response.status >= 300) {
+          callback(getErrorFromResponse(response, !!response.data));
       } else {
-        callback(null, responseBody);
+        callback(null, response.data);
       }
+    }).catch((error) => {
+      callback(error);
     });
   } catch (error) {
     process.nextTick(() => callback(error));

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import defaultRequest from 'request';
 import axios from 'axios';
 
 import isURL from './isURL';
@@ -23,7 +22,7 @@ function readRemoteFile(uri, options, callback) {
   if (typeof options === 'function') {
     [options, callback] = [{}, options];
   }
-  const request = options.request || axios;
+  const request = options.request || axios; // choose whether to use existing request information or use a new axios configuration
 
   const httpOptions = Object.assign({}, options.http || {});
   httpOptions.uri = uri;

--- a/packages/dredd/lib/readLocation.js
+++ b/packages/dredd/lib/readLocation.js
@@ -10,11 +10,11 @@ function getErrorFromResponse(response, hasBody) {
       ? `'${contentType}' body`
       : 'body without Content-Type';
     return new Error(
-      `Dredd got HTTP ${response.statusCode} response with ${bodyDescription}`,
+      `Dredd got HTTP ${response.status} response with ${bodyDescription}`,
     );
   }
   return new Error(
-    `Dredd got HTTP ${response.statusCode} response without body`,
+    `Dredd got HTTP ${response.status} response without body`,
   );
 }
 
@@ -29,7 +29,7 @@ function readRemoteFile(uri, options, callback) {
   httpOptions.timeout = 5000; // ms, limits both connection time and server response time
 
   try {
-    //Reconfigure request to follow axios formatting
+    // Reconfigure request to follow axios formatting
     request(httpOptions).then((response) => {
       if(!response){
         callback(new Error('Unexpected error'));

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -279,20 +279,20 @@ to Apiary API: ${options.method} ${options.uri} \
       'Request details:',
       JSON.stringify({ options, data }, null, 2),
     );
-    //Reintegrating handleResponse function as component of axios request
+    // Reintegrating handleResponse function as component of axios request
     axios(options).then((res) => {
-      let resBody = res.data;
+      const resBody = res.data;
       let parsedBody;
       logger.debug('Handling HTTP response from Apiary API');
       try {
         parsedBody = JSON.parse(resBody);
       } catch (error) {
         this.serverError = true;
-        err = new Error(`
+        error = new Error(`
         Apiary reporter failed to parse Apiary API response body:
         ${error.message}\n${resBody}
         `);
-        return callback(err);
+        return callback(error);
       }
       const info = {
         headers: res.headers,

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -1,7 +1,7 @@
 import clone from 'clone';
 import { v4 as generateUuid } from 'uuid';
 import os from 'os';
-import request from 'request';
+import axios from 'axios';
 
 import logger from '../logger';
 import reporterOutputLogger from './reporterOutputLogger';
@@ -317,7 +317,8 @@ to Apiary API: ${options.method} ${options.uri} \
       'Request details:',
       JSON.stringify({ options, body }, null, 2),
     );
-    return request(options, handleRequest);
+    return axios(options, handleRequest);
+
   } catch (error) {
     this.serverError = true;
     logger.debug('Requesting Apiary API errored:', error);

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -317,7 +317,7 @@ to Apiary API: ${options.method} ${options.uri} \
       'Request details:',
       JSON.stringify({ options, body }, null, 2),
     );
-    return axios(options, handleRequest);
+    return axios(options, handleRequest); // replace request call with axios
 
   } catch (error) {
     this.serverError = true;

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -288,11 +288,11 @@ to Apiary API: ${options.method} ${options.uri} \
         parsedBody = JSON.parse(resBody);
       } catch (error) {
         this.serverError = true;
-        error = new Error(`
+        const err = new Error(`
         Apiary reporter failed to parse Apiary API response body:
         ${error.message}\n${resBody}
         `);
-        return callback(error);
+        return callback(err);
       }
       const info = {
         headers: res.headers,

--- a/packages/dredd/lib/reporters/ApiaryReporter.js
+++ b/packages/dredd/lib/reporters/ApiaryReporter.js
@@ -248,10 +248,10 @@ ApiaryReporter.prototype._createStep = function _createStep(test, callback) {
 ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(
   path,
   method,
-  reqBody,
+  reqData,
   callback,
 ) {
-  const body = reqBody ? JSON.stringify(reqBody) : '';
+  const data = reqData ? JSON.stringify(reqData) : '';
   const system = `${os.type()} ${os.release()}; ${os.arch()}`;
   const headers = {
     'User-Agent': `Dredd Apiary Reporter/${packageData.version} (${system})`,
@@ -260,9 +260,9 @@ ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(
 
   const options = clone(this.config.http || {});
   options.uri = this.configuration.apiUrl + path;
-  options.method = method;
+  options.method = method.toLowerCase();
   options.headers = headers;
-  options.body = body;
+  options.data = data;
 
   if (this.configuration.apiToken) {
     options.headers.Authentication = `Token ${this.configuration.apiToken}`;
@@ -273,11 +273,11 @@ ApiaryReporter.prototype._performRequestAsync = function _performRequestAsync(
     logger.debug(`
 About to perform an ${protocol} request from Apiary reporter
 to Apiary API: ${options.method} ${options.uri} \
-(${body ? 'with' : 'without'} body)
+(${data ? 'with' : 'without'} data)
 `);
     logger.debug(
       'Request details:',
-      JSON.stringify({ options, body }, null, 2),
+      JSON.stringify({ options, data }, null, 2),
     );
     //Reintegrating handleResponse function as component of axios request
     axios(options).then((res) => {
@@ -296,8 +296,8 @@ to Apiary API: ${options.method} ${options.uri} \
       }
       const info = {
         headers: res.headers,
-        statusCode: res.status,
-        body: parsedBody,
+        status: res.status,
+        data: parsedBody,
       };
   
       logger.debug('Apiary reporter response:', JSON.stringify(info, null, 2));

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -33,7 +33,8 @@
     "README.md"
   ],
   "dependencies": {
-    "async": "3.2.0",
+    "async": "3.2.4",
+    "axios":"1.3.6",
     "caseless": "0.12.0",
     "chai": "4.3.4",
     "clone": "2.1.2",
@@ -46,11 +47,10 @@
     "inquirer": "7.1.0",
     "js-yaml": "3.14.0",
     "make-dir": "3.1.0",
-    "markdown-it": "12.2.0",
+    "markdown-it": "13.0.1",
     "optimist": "0.6.1",
     "proxyquire": "2.1.3",
-    "ramda": "0.27.0",
-    "request": "2.88.2",
+    "ramda": "0.29.0",
     "spawn-args": "0.2.0",
     "untildify": "4.0.0",
     "uuid": "7.0.3",

--- a/packages/dredd/package.json
+++ b/packages/dredd/package.json
@@ -78,7 +78,7 @@
     "ps-node": "0.1.6",
     "sinon": "9.2.1",
     "ts-node": "8.10.2",
-    "typescript": "3.8.3"
+    "typescript": "5.0.4"
   },
   "keywords": [
     "api",

--- a/packages/dredd/test/integration/apiary-reporter-test.js
+++ b/packages/dredd/test/integration/apiary-reporter-test.js
@@ -175,7 +175,7 @@ describe('Apiary reporter', () => {
       );
       assert.nestedProperty(
         receivedRequest,
-        'results.validationResult.fields.statusCode.kind',
+        'results.validationResult.fields.status.kind',
       );
 
       it('prints out an error message', () => assert.notEqual(exitStatus, 0));
@@ -327,7 +327,7 @@ describe('Apiary reporter', () => {
         );
         assert.nestedProperty(
           receivedRequest,
-          'results.validationResult.fields.statusCode.kind',
+          'results.validationResult.fields.status.kind',
         );
       });
     });

--- a/packages/dredd/test/integration/cli/configuration-cli-test.js
+++ b/packages/dredd/test/integration/cli/configuration-cli-test.js
@@ -39,10 +39,10 @@ function execCommand(custom = {}, cb) {
   stderr = '';
   exitStatus = null;
   let finished = false;
-  const cli = new CLIStub({ custom }, (exitStatusCode) => {
+  const cli = new CLIStub({ custom }, (exitstatus) => {
     if (!finished) {
       finished = true;
-      exitStatus = exitStatusCode != null ? exitStatusCode : 0;
+      exitStatus = exitstatus != null ? exitstatus : 0;
       cb();
     }
   });

--- a/packages/dredd/test/integration/cli/reporters-cli-test.js
+++ b/packages/dredd/test/integration/cli/reporters-cli-test.js
@@ -123,7 +123,7 @@ describe('CLI - Reporters', () => {
         )
         assert.nestedProperty(
           stepRequest.body,
-          'results.validationResult.fields.statusCode'
+          'results.validationResult.fields.status'
         )
       })
     })

--- a/packages/dredd/test/integration/openapi2-test.js
+++ b/packages/dredd/test/integration/openapi2-test.js
@@ -80,7 +80,7 @@ describe('OpenAPI 2', () => {
               0: 'name',
               1: 'action',
               2: 'method',
-              3: 'statusCode',
+              3: 'status',
             };
             return match.reduce(
               (result, element, i) =>
@@ -95,13 +95,13 @@ describe('OpenAPI 2', () => {
 
     it('recognizes all 3 transactions', () => assert.equal(actual.length, 3));
     [
-      { action: 'skip', statusCode: '400' },
-      { action: 'skip', statusCode: '500' },
-      { action: 'fail', statusCode: '200' },
+      { action: 'skip', status: '400' },
+      { action: 'skip', status: '500' },
+      { action: 'fail', status: '200' },
     ].forEach((expected, i) =>
       context(`the transaction #${i + 1}`, () => {
-        it(`has status code ${expected.statusCode}`, () =>
-          assert.equal(expected.statusCode, actual[i].statusCode));
+        it(`has status code ${expected.status}`, () =>
+          assert.equal(expected.status, actual[i].status));
         it(`is ${
           expected.action === 'skip' ? '' : 'not '
         }skipped by default`, () =>
@@ -138,7 +138,7 @@ describe('OpenAPI 2', () => {
               0: 'name',
               1: 'action',
               2: 'method',
-              3: 'statusCode',
+              3: 'status',
             };
             return match.reduce(
               (result, element, i) =>
@@ -153,20 +153,20 @@ describe('OpenAPI 2', () => {
 
     it('recognizes all 3 transactions', () => assert.equal(actual.length, 3));
     [
-      { action: 'skip', statusCode: '400' },
-      { action: 'fail', statusCode: '200' },
-      { action: 'fail', statusCode: '500' }, // Unskipped in hooks
+      { action: 'skip', status: '400' },
+      { action: 'fail', status: '200' },
+      { action: 'fail', status: '500' }, // Unskipped in hooks
     ].forEach((expected, i) =>
       context(`the transaction #${i + 1}`, () => {
-        it(`has status code ${expected.statusCode}`, () =>
-          assert.equal(expected.statusCode, actual[i].statusCode));
+        it(`has status code ${expected.status}`, () =>
+          assert.equal(expected.status, actual[i].status));
 
         const defaultMessage = `is ${
           expected.action === 'skip' ? '' : 'not '
         }skipped by default`;
         const unskippedMessage = 'is unskipped in hooks';
         it(`${
-          expected.statusCode === '500' ? unskippedMessage : defaultMessage
+          expected.status === '500' ? unskippedMessage : defaultMessage
         }`, () => assert.equal(expected.action, actual[i].action));
       }),
     );

--- a/packages/dredd/test/integration/response-test.js
+++ b/packages/dredd/test/integration/response-test.js
@@ -278,7 +278,7 @@ files.forEach((apiDescription) =>
       it('prints four failures for each non-matching status code', () =>
         assert.equal(
           runtimeInfo.dredd.logging.match(
-            /fail: statusCode: Expected status code '\d+', but got '200'./g,
+            /fail: status: Expected status code '\d+', but got '200'./g,
           ).length,
           4,
         ));
@@ -317,14 +317,14 @@ files.forEach((apiDescription) =>
       it('prints two failures for each non-matching body (and status code)', () =>
         assert.equal(
           runtimeInfo.dredd.logging.match(
-            /fail: body: Actual and expected data do not match.\nstatusCode: Expected status code '\d+', but got '200'./g,
+            /fail: body: Actual and expected data do not match.\nstatus: Expected status code '\d+', but got '200'./g,
           ).length,
           2,
         ));
       it('prints two failures for each non-matching status code', () =>
         assert.equal(
           runtimeInfo.dredd.logging.match(
-            /fail: statusCode: Expected status code '\d+', but got '200'./g,
+            /fail: status: Expected status code '\d+', but got '200'./g,
           ).length,
           2,
         ));

--- a/packages/dredd/test/integration/sanitation-test.js
+++ b/packages/dredd/test/integration/sanitation-test.js
@@ -627,7 +627,7 @@ describe('Sanitation of Reported Data', () => {
       assert.containsAllKeys(events[2].test, ['errors']);
       assert.hasAllKeys(events[2].test.results, ['valid', 'fields']);
       assert.hasAllKeys(events[2].test.results.fields, [
-        'statusCode',
+        'status',
         'headers',
         'body',
       ]);

--- a/packages/dredd/test/unit/performRequest/createTransactionResponse-test.js
+++ b/packages/dredd/test/unit/performRequest/createTransactionResponse-test.js
@@ -3,34 +3,34 @@ import { assert } from 'chai'
 import { createTransactionResponse } from '../../../lib/performRequest'
 
 describe('performRequest._createTransactionResponse()', () => {
-  const res = { statusCode: 200, headers: {} }
+  const res = { status: 200, headers: {} }
 
   it('sets the status code', () =>
     assert.deepEqual(createTransactionResponse(res), {
-      statusCode: 200,
+      status: 200,
       headers: {}
     }))
   it('copies the headers', () => {
     const headers = { 'Content-Type': 'application/json' }
     const transactionRes = createTransactionResponse({
-      statusCode: 200,
+      status: 200,
       headers
     })
     headers['X-Header'] = 'abcd'
 
     assert.deepEqual(transactionRes, {
-      statusCode: 200,
+      status: 200,
       headers: { 'Content-Type': 'application/json' }
     })
   })
   it('does not set empty body', () =>
     assert.deepEqual(createTransactionResponse(res, Buffer.from([])), {
-      statusCode: 200,
+      status: 200,
       headers: {}
     }))
   it('sets textual body as a string with UTF-8 encoding', () =>
     assert.deepEqual(createTransactionResponse(res, Buffer.from('řeřicha')), {
-      statusCode: 200,
+      status: 200,
       headers: {},
       body: 'řeřicha',
       bodyEncoding: 'utf-8'
@@ -39,7 +39,7 @@ describe('performRequest._createTransactionResponse()', () => {
     assert.deepEqual(
       createTransactionResponse(res, Buffer.from([0xff, 0xbe])),
       {
-        statusCode: 200,
+        status: 200,
         headers: {},
         body: Buffer.from([0xff, 0xbe]).toString('base64'),
         bodyEncoding: 'base64'

--- a/packages/dredd/test/unit/performRequest/performRequest-test.js
+++ b/packages/dredd/test/unit/performRequest/performRequest-test.js
@@ -7,7 +7,7 @@ describe('performRequest()', () => {
   const uri = 'http://example.com/42'
   const uriS = 'https://example.com/42'
   const transactionReq = {
-    method: 'POST',
+    method: 'post',
     headers: { 'Content-Type': 'text/plain' },
     body: 'Hello'
   }
@@ -65,7 +65,7 @@ describe('performRequest()', () => {
   })
   it('propagates the HTTP request body as a Buffer', (done) => {
     performRequest(uri, transactionReq, { request }, () => {
-      assert.deepEqual(request.firstCall.args[0].body, Buffer.from('Hello'))
+      assert.deepEqual(request.firstCall.args[0].data, Buffer.from('Hello'))
       done()
     })
   })

--- a/packages/dredd/test/unit/performRequest/performRequest-test.js
+++ b/packages/dredd/test/unit/performRequest/performRequest-test.js
@@ -136,7 +136,7 @@ describe('performRequest()', () => {
       assert.deepEqual(real, {
         status: 200,
         headers: { 'Content-Type': 'text/plain' },
-        body: 'Bye',
+        data: 'Bye',
         bodyEncoding: 'utf-8'
       })
       done()

--- a/packages/dredd/test/unit/performRequest/performRequest-test.js
+++ b/packages/dredd/test/unit/performRequest/performRequest-test.js
@@ -11,7 +11,7 @@ describe('performRequest()', () => {
     headers: { 'Content-Type': 'text/plain' },
     body: 'Hello'
   }
-  const res = { statusCode: 200, headers: { 'Content-Type': 'text/plain' } }
+  const res = { status: 200, headers: { 'Content-Type': 'text/plain' } }
   const request = sinon
     .stub()
     .callsArgWithAsync(1, null, res, Buffer.from('Bye'))
@@ -134,7 +134,7 @@ describe('performRequest()', () => {
   it('provides the real HTTP response object', (done) => {
     performRequest(uri, transactionReq, { request }, (err, real) => {
       assert.deepEqual(real, {
-        statusCode: 200,
+        status: 200,
         headers: { 'Content-Type': 'text/plain' },
         body: 'Bye',
         bodyEncoding: 'utf-8'

--- a/packages/dredd/test/unit/reporters/ApiaryReporter-test.js
+++ b/packages/dredd/test/unit/reporters/ApiaryReporter-test.js
@@ -48,7 +48,7 @@ describe('ApiaryReporter', () => {
         status: 'fail',
         title: 'POST /machines',
         message:
-          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
+          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatus: Real and expected data does not match.\n",
 
         startedAt: 1234567890 * 1000, // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
 
@@ -62,7 +62,7 @@ describe('ApiaryReporter', () => {
         },
 
         actual: {
-          statusCode: 400,
+          status: 400,
           headers: {
             'content-type': 'text/plain'
           },
@@ -135,7 +135,7 @@ describe('ApiaryReporter', () => {
             rawData: null
           },
 
-          statusCode: {
+          status: {
             realType: 'text/vnd.apiary.status-code',
             expectedType: 'text/vnd.apiary.status-code',
             validator: 'TextDiff',
@@ -935,12 +935,12 @@ describe('ApiaryReporter', () => {
         status: 'fail',
         title: 'POST /machines',
         message:
-          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatusCode: Real and expected data does not match.\n",
+          "headers: Value of the ‘content-type’ must be application/json.\nbody: No validator found for real data media type 'text/plain' and expected data media type 'application/json'.\nstatus: Real and expected data does not match.\n",
 
         startedAt: 1234567890 * 1000, // JavaScript Date.now() timestamp (UNIX-like timestamp * 1000 precision)
 
         actual: {
-          statusCode: 400,
+          status: 400,
           headers: {
             'content-type': 'text/plain'
           },
@@ -1013,7 +1013,7 @@ describe('ApiaryReporter', () => {
             rawData: null
           },
 
-          statusCode: {
+          status: {
             realType: 'text/vnd.apiary.status-code',
             expectedType: 'text/vnd.apiary.status-code',
             validator: 'TextDiff',

--- a/packages/dredd/test/unit/transactionRunner-test.js
+++ b/packages/dredd/test/unit/transactionRunner-test.js
@@ -800,7 +800,7 @@ describe('TransactionRunner', () => {
 
       it('should not follow the redirect', (done) =>
         runner.executeTransaction(transaction, () => {
-          assert.equal(transaction.real.statusCode, 303);
+          assert.equal(transaction.real.status, 303);
           assert.notOk(server.isDone());
           done();
         }));
@@ -823,7 +823,7 @@ describe('TransactionRunner', () => {
 
       it('should not follow the redirect', (done) =>
         runner.executeTransaction(transaction, () => {
-          assert.equal(transaction.real.statusCode, 303);
+          assert.equal(transaction.real.status, 303);
           assert.notOk(server.isDone());
           done();
         }));
@@ -882,7 +882,7 @@ describe('TransactionRunner', () => {
             headers: { 'content-type': 'application/json' },
             body:
               '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-            statusCode: '202',
+            status: '202',
           },
           origin: {
             resourceGroupName: 'Group Machine',
@@ -935,13 +935,13 @@ describe('TransactionRunner', () => {
 
       serverNock1 = nock('http://127.0.0.1:3000')
         .post('/machines1', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode, transaction.expected.body, {
+        .reply(transaction.expected.status, transaction.expected.body, {
           'Content-Type': 'application/json',
         });
 
       serverNock2 = nock('http://127.0.0.1:3000')
         .post('/machines2', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode, transaction.expected.body, {
+        .reply(transaction.expected.status, transaction.expected.body, {
           'Content-Type': 'application/json',
         });
     });
@@ -1520,7 +1520,7 @@ describe('TransactionRunner', () => {
           headers: { 'content-type': 'application/json' },
           body:
             '{\n  "type": "bulldozer",\n "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-          statusCode: '202',
+          status: '202',
         },
         origin: {
           resourceGroupName: 'Group Machine',
@@ -1534,7 +1534,7 @@ describe('TransactionRunner', () => {
 
       server = nock('http://127.0.0.1:3000')
         .post('/machines', { type: 'bulldozer', name: 'willy' })
-        .reply(transaction.expected.statusCode, transaction.expected.body, {
+        .reply(transaction.expected.status, transaction.expected.body, {
           'Content-Type': 'application/json',
         });
 
@@ -1731,7 +1731,7 @@ describe('TransactionRunner', () => {
             headers: { 'content-type': 'application/json' },
             body:
               '{\n  "type": "bulldozer",\n  "name": "willy",\n  "id": "5229c6e8e4b0bd7dbb07e29c"\n}\n',
-            statusCode: '202',
+            status: '202',
           },
           origin: {
             resourceGroupName: 'Group Machine',
@@ -1761,7 +1761,7 @@ describe('TransactionRunner', () => {
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
             .reply(
-              transactionsForExecution[0].expected.statusCode,
+              transactionsForExecution[0].expected.status,
               transactionsForExecution[0].expected.body,
               { 'Content-Type': 'application/json' },
             );
@@ -1799,7 +1799,7 @@ describe('TransactionRunner', () => {
       describe('with a ‘beforeEachValidation’ hook', () => {
         // eslint-disable-next-line
         const hook = function(transaction, callback) {
-          transaction.real.statusCode = '403';
+          transaction.real.status = '403';
           callback();
         };
 
@@ -1810,7 +1810,7 @@ describe('TransactionRunner', () => {
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
             .reply(
-              transactionsForExecution[0].expected.statusCode,
+              transactionsForExecution[0].expected.status,
               transactionsForExecution[0].expected.body,
               { 'Content-Type': 'application/json' },
             );
@@ -1832,7 +1832,7 @@ describe('TransactionRunner', () => {
 
         it('should run before gavel', (done) => {
           transaction = clone(transactionsForExecution[0]);
-          transaction.expected.statusCode = '403';
+          transaction.expected.status = '403';
           runner.executeAllTransactions([transaction], runner.hooks, () => {
             assert.equal(transaction.test.status, 'pass');
             done();
@@ -1864,7 +1864,7 @@ describe('TransactionRunner', () => {
           server = nock('http://127.0.0.1:3000')
             .post('/machines', { type: 'bulldozer', name: 'willy' })
             .reply(
-              transactionsForExecution[0].expected.statusCode,
+              transactionsForExecution[0].expected.status,
               transactionsForExecution[0].expected.body,
               { 'Content-Type': 'application/json' },
             );
@@ -2384,7 +2384,7 @@ describe('TransactionRunner', () => {
         let modifiedTransaction = {};
         beforeEach(() => {
           modifiedTransaction = clone(transaction);
-          modifiedTransaction.expected.statusCode = '303';
+          modifiedTransaction.expected.status = '303';
 
           runner.hooks.afterHooks = {
             'Group Machine > Machine > Delete Message > Bogus example name': [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+async@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 async@~1.0.0:
   version "1.0.0"
@@ -1516,6 +1516,15 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.6.tgz#1ace9a9fb994314b5f6327960918406fa92c6646"
+  integrity sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1976,7 +1985,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2647,10 +2656,10 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 env-paths@^1.0.0:
   version "1.0.0"
@@ -3215,6 +3224,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3229,6 +3243,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4430,10 +4453,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -4679,14 +4702,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.2.0.tgz#091f720fd5db206f80de7a8d1f1a7035fd0d38db"
-  integrity sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==
+markdown-it@13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
   dependencies:
     argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
@@ -5846,6 +5869,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 proxyquire@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
@@ -5941,6 +5969,11 @@ ramda@0.27.0, ramda@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
   integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+
+ramda@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
+  integrity sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==
 
 randexp@^0.5.3:
   version "0.5.3"
@@ -6189,7 +6222,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.88.2, request@^2.87.0:
+request@^2.87.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
#### :rocket: Why this change?
Request is deprecated, and Axios provides all of the same requirements. To complete this upgraded, other dependencies needed to be udpated.
#### :memo: Related issues and Pull Requests
#2177 
#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
