### PR TITLE
fix: issue #2173 OpenApi3.0.0

### DIFF
--- a/packages/dredd-transactions/compile/compileURI/validateParams.js
+++ b/packages/dredd-transactions/compile/compileURI/validateParams.js
@@ -5,32 +5,46 @@ module.exports = function validateParams(params) {
     let text;
     const param = params[paramName];
 
+    
     if (param.required && !(typeof param.example !== 'undefined' && param.example !== '') && !(typeof param.default !== 'undefined' && param.default !== '')) {
       text = `Required URI parameter '${paramName}' has no example or default value.`;
       result.errors.push(text);
     }
 
-    switch (param.type) {
-      case 'number':
-        if (Number.isNaN(parseFloat(param.example))) {
-          text = `URI parameter '${paramName}' is declared as 'number' but it is a string.`;
-          result.errors.push(text);
-        }
-        break;
-      case 'boolean':
-        if ((param.example !== 'true') && (param.example !== 'false')) {
-          text = `URI parameter '${paramName}' is declared as 'boolean' but it is not.`;
-          result.errors.push(text);
-        }
-        break;
-      default:
-        break;
+    if (param.schema && param.schema.example  && typeof param.example === 'string'){
+      const example = param.schema.example;
+      if(!example || example.length){
+        text = `URI parameter '${paramName}' example value is an empty string.`;
+        result.warnings.push(text); 
+      } 
+      else if(param.example !== example){
+        text = `URI parameter '${paramName}' example value does not match schema's example value`
+        result.warnings.push(text);
+      }
     }
-
-    if (param.values.length > 0) {
-      if (!(param.values.indexOf(param.example) > -1)) {
-        text = `URI parameter '${paramName}' example value is not one of enum values.`;
-        result.errors.push(text);
+    else{
+      switch (param.type) {
+        case 'number':
+          if (Number.isNaN(parseFloat(param.example))) {
+            text = `URI parameter '${paramName}' is declared as 'number' but it is a string.`;
+            result.errors.push(text);
+          }
+          break;
+        case 'boolean':
+          if ((param.example !== 'true') && (param.example !== 'false')) {
+            text = `URI parameter '${paramName}' is declared as 'boolean' but it is not.`;
+            result.errors.push(text);
+          }
+          break;
+        default:
+          break;
+      }
+  
+      if (param.values.length > 0) {
+        if (!(param.values.indexOf(param.example) > -1)) {
+          text = `URI parameter '${paramName}' example value is not one of enum values.`;
+          result.errors.push(text);
+        }
       }
     }
   });


### PR DESCRIPTION
#### :rocket: Why this change?
JSON parsing (validateParams) doesn't support the new OpenApiV3.0.0 JSON formatting
#### :memo: Related issues and Pull Requests
Issue #2173 
#### :white_check_mark: What didn't I forget?

<!--
Place an `x` between the square brackets on the lines below for every satisfied prerequisite.
-->

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.org/en/latest/internals.html#sem-rel) prefixes in front of all my commits and run `npm run lint`
